### PR TITLE
GH-5230: fix(dispatch): repick-backoff skip is logged as "completed execution exists" — misleading operator diagnosis

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -4235,6 +4235,15 @@ func (s storeTaskChecker) IsTaskQueued(taskID string) bool {
 // constructor (including every pre-GH-5139 test) falls back byte-for-byte to
 // the old "canceled is permanent" behavior — see the nil-ghClient branch in
 // HasCompletedExecution.
+//
+// GH-5230: "looks identical to the poller" above is deliberate and stays
+// that way — dispatch behavior (this function still returns true, still
+// gates the same tasks) is unchanged. What changed is the OPERATOR-facing
+// side: the backoff branch now also emits its own unconditional INFO log
+// line naming the real reason (cooldown, not completion) before returning,
+// so the SDK's "completed execution exists" message is never the only
+// explanation on offer. See the backoff branch below for the log line
+// itself.
 type terminalCompletionChecker struct {
 	store *memory.Store
 
@@ -4251,6 +4260,35 @@ func (c terminalCompletionChecker) HasCompletedExecution(taskID, projectPath str
 			logging.WithComponent("dispatch").Debug("task in repick backoff window, skipping poller candidacy entirely",
 				slog.String("task_id", taskID))
 		}
+		// GH-5230: returning true here makes the vendored SDK poller log
+		// "Skipping re-dispatch — completed execution exists" on THIS tick
+		// and every tick until the window expires — that message is false;
+		// there is no completed execution row, only a cooldown. The debug
+		// line above fires once per window and never says how long the gate
+		// lasts, so an operator reading only the poller's log sees a
+		// misleading "completed" verdict repeated with nothing to correct
+		// it (confirmed on pilot-cloud-infra GH-33: three ledger rows —
+		// stalled, failed, stalled — no commit, no PR, no completed status,
+		// yet the misleading message was the only thing in the log). Emit
+		// an unconditional INFO line, every gated tick, naming the real
+		// reason plus the remaining cooldown and drop counts, so the truth
+		// always precedes the SDK's misleading message rather than being
+		// buried in a once-per-window DEBUG line.
+		remaining, consecutiveDrops, claimLostDrops, ok := repickBackoff.gateDetail(key)
+		attrs := []any{
+			slog.String("task_id", taskID),
+			slog.String("project_path", projectPath),
+		}
+		if ok {
+			attrs = append(attrs,
+				slog.Duration("backoff_remaining", remaining),
+				slog.Int("consecutive_drops", consecutiveDrops),
+				slog.Int("claim_lost_drops", claimLostDrops),
+			)
+		}
+		logging.WithComponent("dispatch").Info(
+			"skip reason: repick-backoff cooldown, NOT a completed execution — the SDK poller's next log line (\"completed execution exists\") is misleading for this task",
+			attrs...)
 		return true, nil
 	}
 

--- a/cmd/pilot/main_test.go
+++ b/cmd/pilot/main_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -12,6 +13,7 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/teams"
 )
@@ -1193,5 +1195,117 @@ func TestTerminalCompletionChecker_RecognizesNoOp(t *testing.T) {
 	}
 	if rawCompleted {
 		t.Error("expected raw Store.HasCompletedExecution to stay strict (no_op has no deliverable) — if this now passes, the invariant this test pins has changed")
+	}
+}
+
+// TestHasCompletedExecution_SkipReasonDiffersByCause is the GH-5230
+// regression: HasCompletedExecution returns true (bool) for two very
+// different underlying reasons — a genuine completed/no_op execution row,
+// and a task merely cooling down in the repick-backoff window — and the
+// vendored SDK poller logs the SAME "completed execution exists" message for
+// both. Diagnosing a stalled task cost real operator time (pilot-cloud-infra
+// GH-33: ledger showed stalled/failed/stalled, no commit, no PR, no
+// completed status, yet the log insisted a completed execution existed)
+// because the two cases were indistinguishable in the logs. This pins that
+// the backoff-gated branch now emits its own INFO line naming the real
+// reason plus the remaining cooldown and drop counts, and that a genuine
+// completion does NOT emit that line — so the two causes are distinguishable
+// by grepping the log, without changing what HasCompletedExecution returns.
+func TestHasCompletedExecution_SkipReasonDiffersByCause(t *testing.T) {
+	tests := []struct {
+		name string
+		// setup seeds whatever state makes HasCompletedExecution return true
+		// for this case's reason.
+		setup func(t *testing.T, store *memory.Store, taskID, projectPath, key string)
+		// wantReasonSubstr must appear in the log emitted for this case; ""
+		// means this case must NOT emit the backoff reason line at all (see
+		// backoffReasonSubstr check below).
+		wantReasonSubstr string
+	}{
+		{
+			name: "backoff-gated skip: not a completed execution",
+			setup: func(t *testing.T, _ *memory.Store, _, _, key string) {
+				t.Helper()
+				repickBackoff.recordDrop(key)
+				t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+			},
+			wantReasonSubstr: "repick-backoff cooldown, NOT a completed execution",
+		},
+		{
+			name: "genuine terminal completion",
+			setup: func(t *testing.T, store *memory.Store, taskID, projectPath, _ string) {
+				t.Helper()
+				if err := store.SaveExecution(&memory.Execution{
+					ID:          "exec-" + taskID,
+					TaskID:      taskID,
+					ProjectPath: projectPath,
+					Status:      "completed",
+					PRUrl:       "https://github.com/qf-studio/pilot/pull/1",
+				}); err != nil {
+					t.Fatalf("SaveExecution: %v", err)
+				}
+			},
+			wantReasonSubstr: "", // genuine completion emits no GH-5230 reason line at all
+		},
+	}
+
+	const backoffReasonSubstr = "repick-backoff cooldown, NOT a completed execution"
+	logs := make(map[string]string, len(tests))
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			store, err := memory.NewStore(tmpDir)
+			if err != nil {
+				t.Fatalf("memory.NewStore: %v", err)
+			}
+			t.Cleanup(func() { _ = store.Close() })
+
+			taskID := "GH-5230-" + strings.ReplaceAll(tc.name, " ", "-")
+			projectPath := "/tmp/pilot-gh-5230-skip-reason-test-does-not-exist"
+			key := repickBackoffKey(projectPath, taskID)
+
+			tc.setup(t, store, taskID, projectPath, key)
+
+			logPath := filepath.Join(tmpDir, "skip-reason.log")
+			if err := logging.Init(&logging.Config{Level: "info", Format: "json", Output: logPath}); err != nil {
+				t.Fatalf("logging.Init: %v", err)
+			}
+			t.Cleanup(func() { _ = logging.Init(logging.DefaultConfig()) })
+
+			checker := terminalCompletionChecker{store: store}
+			done, err := checker.HasCompletedExecution(taskID, projectPath)
+			if err != nil {
+				t.Fatalf("HasCompletedExecution: %v", err)
+			}
+			if !done {
+				t.Fatalf("expected HasCompletedExecution to return true for %q", tc.name)
+			}
+
+			data, readErr := os.ReadFile(logPath)
+			if readErr != nil && !os.IsNotExist(readErr) {
+				t.Fatalf("ReadFile: %v", readErr)
+			}
+			got := string(data)
+			logs[tc.name] = got
+
+			if tc.wantReasonSubstr != "" && !strings.Contains(got, tc.wantReasonSubstr) {
+				t.Errorf("expected log to contain %q, got:\n%s", tc.wantReasonSubstr, got)
+			}
+			if tc.wantReasonSubstr == "" && strings.Contains(got, backoffReasonSubstr) {
+				t.Errorf("genuine completion must NOT emit the backoff skip-reason line, got:\n%s", got)
+			}
+		})
+	}
+
+	// The core GH-5230 assertion: the two causes must produce genuinely
+	// different logs, not the same message twice.
+	gatedLog := logs["backoff-gated skip: not a completed execution"]
+	genuineLog := logs["genuine terminal completion"]
+	if gatedLog == genuineLog {
+		t.Fatalf("expected backoff-gated and genuine-completion logs to differ, both were:\n%s", gatedLog)
+	}
+	if !strings.Contains(gatedLog, "backoff_remaining") || !strings.Contains(gatedLog, "consecutive_drops") {
+		t.Errorf("expected backoff-gated log to include remaining cooldown and drop count, got:\n%s", gatedLog)
 	}
 }

--- a/cmd/pilot/repick_backoff.go
+++ b/cmd/pilot/repick_backoff.go
@@ -170,6 +170,28 @@ func (t *repickBackoffTracker) gateStatus(key string) (gated bool, shouldLog boo
 	return false, false
 }
 
+// gateDetail returns the diagnostic detail behind a gated key — how long the
+// cooldown has left and the drop counters that grew it — for callers that
+// need to explain WHY a backoff-gated skip happened, not just that it did
+// (GH-5230). It is a pure read: it does not touch gateLogged or persist
+// state, so it is safe to call every time gateStatus reports gated, on every
+// poll tick, without disturbing gateStatus's own once-per-window bookkeeping.
+// ok is false if key has no in-memory entry (already expired/cleared, or
+// never armed) — callers should treat that as "nothing to report".
+func (t *repickBackoffTracker) gateDetail(key string) (remaining time.Duration, consecutiveDrops int, claimLostDrops int, ok bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	e, found := t.entries[key]
+	if !found {
+		return 0, 0, 0, false
+	}
+	remaining = time.Until(e.nextAllowedAt)
+	if remaining < 0 {
+		remaining = 0
+	}
+	return remaining, e.consecutiveDrops, e.claimLostDrops, true
+}
+
 // recordDrop registers a dropped pickup for key, extending its backoff window
 // exponentially (capped), and returns the new consecutive-drop count so the
 // caller can decide whether to escalate its log level / fire a metric.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5230.

Closes #5230

## Changes

GitHub Issue GH-5230: fix(dispatch): repick-backoff skip is logged as "completed execution exists" — misleading operator diagnosis

## Context

Diagnosing a stalled task on 2026-08-26 (pilot-cloud-infra GH-33) cost significant operator time because the poller reported a reason that was not true.

Every poll tick logged:

`Skipping re-dispatch — completed execution exists  component=github-sdk-poller  repo=qf-studio/pilot-cloud-infra  number=33  task_id=GH-33`

The ledger showed no such thing: that task/project had exactly three rows — stalled, failed, stalled — with no commit, no PR, and no completed status. The message sent the investigation toward a cross-project task-id collision (the GH-4276 class) that did not exist.

The actual cause is by design. In `terminalCompletionChecker.HasCompletedExecution` (`cmd/pilot/main.go`), the first branch checks the repick-backoff window and returns `true` when the task is gated. Returning `true` is what the SDK poller renders as "completed execution exists" — the function's own doc comment states the intent, that a backoff-gated task should "look identical to an already-completed one to the poller". The behavior is correct; the operator-facing explanation is not. Two very different states — this task already succeeded, and this task is cooling down after repeated drops — are indistinguishable in the log.

## Task

Make the backoff-gated skip distinguishable from a genuine terminal completion in the logs and metrics, without changing dispatch behavior.

The simplest fix is pilot-side only: before returning `true` from the backoff branch, emit an explicit log line at info level naming the real reason and the window's remaining time, so the misleading SDK message is always preceded by the truth. The existing debug-level line in that branch is not enough — it is debug, and it does not say how long the gate lasts.

If a cleaner contract is preferred, a distinct skip reason plumbed through the SDK's poller message would be better, but that is a cross-repo change and should be a separate task. Do the pilot-side fix here.

## Acceptance

- A task skipped because of the repick-backoff window produces a log line, at info level, that names the backoff as the reason and includes the remaining cooldown and the drop count.
- A task skipped because of a genuine terminal completion remains distinguishable from the above in the logs.
- Dispatch behavior is unchanged: the backoff branch still returns the same value and still gates the same tasks.
- The metric recorded for the backoff case remains as it is today, or gains a distinct reason label — do not silently change existing metric semantics.
- Table-driven test covering both branches and asserting the emitted reason differs.

## Implementation

- `cmd/pilot/main.go`
- `cmd/pilot/main_test.go`

Do not decompose — this is a standalone task, single PR.