### PR TITLE
GH-5233: fix(autopilot): a PR whose CI never ran resolves to CISuccess and auto-merges — treat missing checks on a CI-bearing repo as an anomaly

### DIFF
--- a/.agent/tasks/gh-5233.md
+++ b/.agent/tasks/gh-5233.md
@@ -1,0 +1,56 @@
+# GH-5233
+
+**Created:** 2026-08-26
+
+## Problem
+
+GitHub Issue GH-5233: fix(autopilot): a PR whose CI never ran resolves to CISuccess and auto-merges — treat missing checks on a CI-bearing repo as an anomaly
+
+## Context
+
+A pull request whose CI never ran is currently indistinguishable, to autopilot, from a repository that has no CI configured — and both outcomes mean "merge".
+
+Observed live on 2026-08-26: `qf-studio/pilot-console` PR#221 sat for over an hour with **zero check runs** and no workflow run of any kind on its branch, while sibling PRs opened minutes later each had three. The repository does have a CI workflow, triggered on every pull request with no path filter, so this was a trigger failure rather than an absence of CI. A sibling branch in the same window recorded a `startup_failure`, so something was genuinely wrong with Actions on that repo at that time.
+
+That PR was **red underneath**: it adds a migration, and an existing test rolls back exactly one migration step on the assumption that the step is the previous one, so the down-migration assertion fails. Had it merged on a false green, a broken migration test would have reached main.
+
+The path through the code:
+
+- `checkAutoDiscoveredRuns` finds zero check runs and waits out the discovery grace period.
+- The grace period expires, and it falls back to the combined-status API, which for a GitHub Actions repository legitimately reports nothing, since Actions writes check-runs rather than commit statuses.
+- `mapCombinedStatus` maps a zero total count to success.
+- If the combined-status lookup itself errors, the code explicitly returns success with the comment "treating as no CI".
+
+So the terminal state for "no checks appeared" is success, and the PR is eligible for auto-merge.
+
+For a repository that genuinely has no CI — the dev-mode case — that behavior is intended and should stay. The gap is that a repository which *does* have CI, and has been producing check runs on other branches all day, gets the same verdict when its checks simply fail to appear.
+
+## Task
+
+Distinguish "this repository has no CI" from "this repository has CI and it did not report", and refuse to treat the latter as success.
+
+The cheapest reliable signal is the repository's own recent history: if check runs have been observed for other SHAs on this repository, then zero check runs for the current SHA is an anomaly, not an absence of configuration. Prefer that over inspecting workflow files, which is more brittle.
+
+On detecting the anomaly, do not conclude success. Hold the PR in a non-merging state, surface it clearly — the operator needs to know CI did not run, since that is usually a platform problem rather than a code problem — and let the existing wait-and-timeout machinery handle it from there.
+
+Preserve today's behavior for a repository that has never produced a check run, so genuinely CI-less repositories are unaffected.
+
+Also reconsider the error branch: a failed combined-status lookup currently returns success. An API error is not evidence that CI passed, and it should not be the one path that unblocks a merge.
+
+## Acceptance
+
+- A repository with prior observed check runs, whose current SHA has none after the grace period, does not resolve to success and does not auto-merge.
+- A repository that has never produced a check run continues to resolve exactly as it does today.
+- A failed combined-status lookup no longer resolves to success on its own.
+- The anomalous case is logged at warn and surfaced to the operator, naming the SHA and the fact that CI did not report.
+- Table-driven tests cover: no-CI repository unchanged, CI-bearing repository with missing checks held, combined-status error held, and normal green and red paths unchanged.
+
+## Implementation
+
+- `internal/autopilot/ci_monitor.go`
+- `internal/autopilot/ci_monitor_test.go`
+
+Do not decompose — this is a standalone task, single PR.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -53,6 +53,18 @@ type CIMonitor struct {
 	discoveredChecks map[string][]string  // sha -> check names
 	discoveryStart   map[string]time.Time // sha -> when discovery started
 	mu               sync.RWMutex
+
+	// everSeenCheckRuns records whether this repository has produced ANY
+	// check-run, for ANY SHA, during this monitor's lifetime (GH-5233). It's
+	// the cheap, reliable signal checkAutoDiscoveredRuns uses to tell "this
+	// repo genuinely has no CI" (the flag never flips true; the existing
+	// combined-status fallback stays load-bearing) apart from "this repo has
+	// CI and it simply didn't report for this SHA" (the flag is already
+	// true, so zero check-runs here is an anomaly, not a config). Recording
+	// it per-monitor (one CIMonitor per owner/repo) rather than per-SHA is
+	// deliberate: the whole point is comparing THIS sha's silence against
+	// what OTHER shas on the same repo have done.
+	everSeenCheckRuns bool
 }
 
 // NewCIMonitor creates a CI monitor with configuration from Config.
@@ -258,6 +270,16 @@ func (m *CIMonitor) checkStatus(ctx context.Context, sha string, skipGrace bool)
 
 	// Store discovered check names for later retrieval (filtered by exclusions in auto mode)
 	if len(checkRuns.CheckRuns) > 0 {
+		// GH-5233: record, independent of required-checks/exclude scoping,
+		// that this repo has produced a check-run at all. This is the raw
+		// "does this repo's CI infrastructure exist" signal
+		// checkAutoDiscoveredRuns needs — deliberately not gated on the same
+		// filters as discoveredChecks below, since even an excluded/
+		// non-required check run still proves Actions is wired up here.
+		m.mu.Lock()
+		m.everSeenCheckRuns = true
+		m.mu.Unlock()
+
 		m.mu.RLock()
 		_, hasDiscovered := m.discoveredChecks[sha]
 		m.mu.RUnlock()
@@ -523,16 +545,45 @@ func (m *CIMonitor) checkAutoDiscoveredRuns(ctx context.Context, sha string, che
 			m.mu.Unlock()
 		}
 
+		// GH-5233: this repo has produced at least one check-run for SOME sha
+		// during this monitor's lifetime, so its CI is demonstrably wired up
+		// (an Actions workflow exists and has fired before). Zero check-runs
+		// for THIS sha after the grace period is therefore not "no CI
+		// configured" — the combined-status fallback below exists for that
+		// case, and legitimately returns empty for every Actions-only repo —
+		// it's a trigger/platform anomaly (workflow didn't fire, Actions
+		// outage, etc). Observed live 2026-08-26: qf-studio/pilot-console
+		// PR#221 sat with zero check-runs of any kind while sibling PRs
+		// opened minutes later each had three; the combined-status fallback
+		// mapped its silence to CISuccess and it was eligible to auto-merge
+		// a red down-migration test on a false green. Hold as CIPending —
+		// never consult combined-status, which would just rubber-stamp the
+		// same wrong answer — and let WaitForCI's existing timeout surface
+		// the anomaly instead of merging on it.
+		if m.hasEverSeenCheckRuns() {
+			m.log.Warn("CI checks never reported for this SHA on a repository with prior observed check runs on other SHAs — holding rather than treating as no-CI success",
+				"sha", ShortSHA(sha),
+				"owner", m.owner,
+				"repo", m.repo,
+			)
+			return CIPending, nil
+		}
+
 		// Grace period expired (or skipped) with no check runs — query commit-status
 		// API before concluding that no CI is configured. Providers like CircleCI,
 		// Jenkins, Travis, and Buildkite report exclusively via the statuses API.
 		combined, err := m.ghClient.GetCombinedStatus(ctx, m.owner, m.repo, sha)
 		if err != nil {
-			m.log.Warn("grace period expired; combined-status lookup failed, treating as no CI",
+			// GH-5233: an API error is not evidence CI passed — it's evidence
+			// we don't know. This used to return CISuccess ("treating as no
+			// CI"), making a transient GitHub API failure the one path that
+			// could unblock a merge without CI ever actually reporting. Hold
+			// instead; WaitForCI's timeout still applies on top of this.
+			m.log.Warn("grace period expired; combined-status lookup failed, holding rather than treating as no CI",
 				"sha", ShortSHA(sha),
 				"error", err,
 			)
-			return CISuccess, nil
+			return CIPending, nil
 		}
 		status := m.mapCombinedStatus(combined)
 		m.log.Info("grace period expired with no check runs; using commit-status API",
@@ -573,6 +624,15 @@ func (m *CIMonitor) checkAutoDiscoveredRuns(ctx context.Context, sha string, che
 		return CIPending, nil
 	}
 	return CISuccess, nil
+}
+
+// hasEverSeenCheckRuns reports whether this repository has produced any
+// check-run, for any SHA, during this monitor's lifetime (GH-5233) — see
+// everSeenCheckRuns.
+func (m *CIMonitor) hasEverSeenCheckRuns() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.everSeenCheckRuns
 }
 
 // mapCombinedStatus converts a GitHub combined commit-status response into CIStatus.

--- a/internal/autopilot/ci_monitor_test.go
+++ b/internal/autopilot/ci_monitor_test.go
@@ -1615,7 +1615,10 @@ func TestCIMonitor_CommitStatusFallback(t *testing.T) {
 }
 
 func TestCIMonitor_CommitStatusFallback_APIError(t *testing.T) {
-	// When GetCombinedStatus fails, treat as no CI configured (success).
+	// GH-5233: a failed combined-status lookup is not evidence CI passed —
+	// it must hold (CIPending), not resolve to CISuccess. Before this fix, an
+	// API error was the one path that could unblock a merge without CI ever
+	// actually reporting.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/repos/owner/repo/commits/abc1234/check-runs":
@@ -1643,13 +1646,125 @@ func TestCIMonitor_CommitStatusFallback_APIError(t *testing.T) {
 	_, _ = monitor.CheckCI(context.Background(), "abc1234")
 	time.Sleep(30 * time.Millisecond)
 
-	// After grace period, status API fails → treat as no CI (success)
+	// After grace period, status API fails → hold, do not resolve to success.
+	status, err := monitor.CheckCI(context.Background(), "abc1234")
+	if err != nil {
+		t.Fatalf("CheckCI() error = %v", err)
+	}
+	if status != CIPending {
+		t.Errorf("CheckCI() on status API error = %s, want %s (must not resolve to success on an API error)", status, CIPending)
+	}
+}
+
+// TestCIMonitor_NoCIRepo_StillResolvesSuccess is the "unaffected" control for
+// GH-5233: a repository that has never produced a check-run for ANY sha
+// during the monitor's lifetime must keep resolving a checkless SHA to
+// CISuccess after the grace period, exactly as it did before this fix.
+func TestCIMonitor_NoCIRepo_StillResolvesSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/abc1234/check-runs":
+			resp := github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/commits/abc1234/status":
+			resp := github.CombinedStatus{State: github.StatusPending, TotalCount: 0, Statuses: []github.CommitStatus{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 1 * time.Second
+	cfg.RequiredChecks = nil
+	cfg.CIChecks = &CIChecksConfig{
+		Mode:                 "auto",
+		DiscoveryGracePeriod: 20 * time.Millisecond,
+	}
+	monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+	_, _ = monitor.CheckCI(context.Background(), "abc1234")
+	time.Sleep(30 * time.Millisecond)
+
 	status, err := monitor.CheckCI(context.Background(), "abc1234")
 	if err != nil {
 		t.Fatalf("CheckCI() error = %v", err)
 	}
 	if status != CISuccess {
-		t.Errorf("CheckCI() on status API error = %s, want %s (degrade gracefully)", status, CISuccess)
+		t.Errorf("CheckCI() for a repo that never produced a check-run = %s, want %s (no-CI behavior must be unaffected)", status, CISuccess)
+	}
+}
+
+// TestCIMonitor_CIBearingRepo_MissingChecksHeld is the GH-5233 regression
+// test: once this repo has produced check-runs for SOME sha, a DIFFERENT sha
+// that reports zero check-runs after the grace period must be held
+// (CIPending), never resolved to CISuccess via the combined-status fallback —
+// reproducing qf-studio/pilot-console PR#221 (2026-08-26), where a CI trigger
+// failure on a CI-bearing repo let a red PR look green.
+func TestCIMonitor_CIBearingRepo_MissingChecksHeld(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/withchecks/check-runs":
+			resp := github.CheckRunsResponse{TotalCount: 1, CheckRuns: []github.CheckRun{
+				{ID: 1, Name: "test", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+			}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/commits/nochecks/check-runs":
+			resp := github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/commits/nochecks/status":
+			// Actions-only repo: combined-status legitimately reports empty.
+			resp := github.CombinedStatus{State: github.StatusPending, TotalCount: 0, Statuses: []github.CommitStatus{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 1 * time.Second
+	cfg.RequiredChecks = nil
+	cfg.CIChecks = &CIChecksConfig{
+		Mode:                 "auto",
+		DiscoveryGracePeriod: 20 * time.Millisecond,
+	}
+	monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+	// A sibling SHA on this repo has produced check-runs — this is the
+	// repo's own recent-history signal that CI is wired up here.
+	status, err := monitor.CheckCI(context.Background(), "withchecks")
+	if err != nil {
+		t.Fatalf("CheckCI(withchecks) error = %v", err)
+	}
+	if status != CISuccess {
+		t.Fatalf("CheckCI(withchecks) = %s, want %s", status, CISuccess)
+	}
+
+	// Now a different SHA on the same repo reports zero check-runs. Start
+	// the grace period and let it expire.
+	status, _ = monitor.CheckCI(context.Background(), "nochecks")
+	if status != CIPending {
+		t.Fatalf("first CheckCI(nochecks) = %s, want %s", status, CIPending)
+	}
+	time.Sleep(30 * time.Millisecond)
+
+	status, err = monitor.CheckCI(context.Background(), "nochecks")
+	if err != nil {
+		t.Fatalf("CheckCI(nochecks) error = %v", err)
+	}
+	if status != CIPending {
+		t.Errorf("CheckCI(nochecks) after grace period on a CI-bearing repo = %s, want %s (must hold, not resolve to success)", status, CIPending)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5233.

Closes #5233

## Changes

GitHub Issue GH-5233: fix(autopilot): a PR whose CI never ran resolves to CISuccess and auto-merges — treat missing checks on a CI-bearing repo as an anomaly

## Context

A pull request whose CI never ran is currently indistinguishable, to autopilot, from a repository that has no CI configured — and both outcomes mean "merge".

Observed live on 2026-08-26: `qf-studio/pilot-console` PR#221 sat for over an hour with **zero check runs** and no workflow run of any kind on its branch, while sibling PRs opened minutes later each had three. The repository does have a CI workflow, triggered on every pull request with no path filter, so this was a trigger failure rather than an absence of CI. A sibling branch in the same window recorded a `startup_failure`, so something was genuinely wrong with Actions on that repo at that time.

That PR was **red underneath**: it adds a migration, and an existing test rolls back exactly one migration step on the assumption that the step is the previous one, so the down-migration assertion fails. Had it merged on a false green, a broken migration test would have reached main.

The path through the code:

- `checkAutoDiscoveredRuns` finds zero check runs and waits out the discovery grace period.
- The grace period expires, and it falls back to the combined-status API, which for a GitHub Actions repository legitimately reports nothing, since Actions writes check-runs rather than commit statuses.
- `mapCombinedStatus` maps a zero total count to success.
- If the combined-status lookup itself errors, the code explicitly returns success with the comment "treating as no CI".

So the terminal state for "no checks appeared" is success, and the PR is eligible for auto-merge.

For a repository that genuinely has no CI — the dev-mode case — that behavior is intended and should stay. The gap is that a repository which *does* have CI, and has been producing check runs on other branches all day, gets the same verdict when its checks simply fail to appear.

## Task

Distinguish "this repository has no CI" from "this repository has CI and it did not report", and refuse to treat the latter as success.

The cheapest reliable signal is the repository's own recent history: if check runs have been observed for other SHAs on this repository, then zero check runs for the current SHA is an anomaly, not an absence of configuration. Prefer that over inspecting workflow files, which is more brittle.

On detecting the anomaly, do not conclude success. Hold the PR in a non-merging state, surface it clearly — the operator needs to know CI did not run, since that is usually a platform problem rather than a code problem — and let the existing wait-and-timeout machinery handle it from there.

Preserve today's behavior for a repository that has never produced a check run, so genuinely CI-less repositories are unaffected.

Also reconsider the error branch: a failed combined-status lookup currently returns success. An API error is not evidence that CI passed, and it should not be the one path that unblocks a merge.

## Acceptance

- A repository with prior observed check runs, whose current SHA has none after the grace period, does not resolve to success and does not auto-merge.
- A repository that has never produced a check run continues to resolve exactly as it does today.
- A failed combined-status lookup no longer resolves to success on its own.
- The anomalous case is logged at warn and surfaced to the operator, naming the SHA and the fact that CI did not report.
- Table-driven tests cover: no-CI repository unchanged, CI-bearing repository with missing checks held, combined-status error held, and normal green and red paths unchanged.

## Implementation

- `internal/autopilot/ci_monitor.go`
- `internal/autopilot/ci_monitor_test.go`

Do not decompose — this is a standalone task, single PR.