### PR TITLE
GH-5236: fix(autopilot): platform-outage breaker is blind to the outage's actual shape — CI timeouts and missing checks never feed correlation

### DIFF
--- a/.agent/tasks/gh-5236.md
+++ b/.agent/tasks/gh-5236.md
@@ -1,0 +1,55 @@
+# GH-5236
+
+**Created:** 2026-08-26
+
+## Problem
+
+GitHub Issue GH-5236: fix(autopilot): platform-outage breaker is blind to the outage's actual shape — CI timeouts and missing checks never feed correlation
+
+## Context
+
+GitHub Actions went into a **major outage** on 2026-08-26 at 15:11:58Z. The platform-outage breaker is enabled in production and is exactly the mechanism meant to protect the fleet during such an event. It never tripped.
+
+The reason is a gap in what feeds it. `platformBreaker.Observe` is called from the CI-**failure** handling path, so it correlates failures that carry a failure class across distinct PRs. But an Actions outage most often does not produce CI failures at all — it produces work that never runs:
+
+- PR#5231's run completed with conclusion `failure` while all eight of its jobs sat `queued` and never started. Autopilot waited out its 30-minute `waiting_ci` budget with `last_status=pending`, then set `StageFailed` directly. That path never calls `Observe`.
+- A sibling repo's PR received **zero check runs** for over an hour while other PRs opened minutes later got a full set.
+- Another branch recorded a `startup_failure`.
+
+None of these reach the correlation signal, so the breaker stayed closed through a confirmed platform-wide outage and destructive CI-failure actions stayed armed.
+
+This is the same root as the sibling issue about a PR whose CI never ran resolving to success: an outage has two shapes, and the fleet is unprotected against both. Either checks never appear, and the run is treated as green and merged; or they appear and time out, and the PR is failed as though the code were at fault. The breaker was built for exactly this and sees neither.
+
+## Task
+
+Feed the outage-shaped signals into the same cross-PR correlation the breaker already performs.
+
+A CI wait that expires with the checks still pending, and a SHA that never produces checks on a repository that normally does, are both evidence about the platform rather than about the code. Record them as such before the stage transition, so a burst of them across distinct PRs opens the breaker the same way a burst of infra-class failures does.
+
+Once the breaker is open, the existing suppression should cover these paths too: a timeout during an open breaker must not drive a PR to failed, spawn a fix issue, or close anything. Hold and re-drive when the breaker closes, which is the machinery that already exists.
+
+Consider also consulting the platform's own published status as a corroborating input rather than the sole trigger. Correlation across PRs is the more reliable signal and should stay primary; an external status check is a useful accelerant so the breaker opens on the first timeout rather than the third.
+
+Keep the existing behaviour for a genuine single-PR timeout when no correlation exists — one slow PR is not an outage.
+
+## Acceptance
+
+- A CI wait that expires with checks still pending records a platform observation before the stage transition.
+- A SHA producing no checks, on a repository with prior observed check runs, records the same kind of observation.
+- A burst of either across distinct PRs within the correlation window opens the breaker.
+- While the breaker is open, neither shape drives a PR to failed, spawns a fix issue, or closes a PR; both are held and re-driven when it closes.
+- A single isolated timeout with no correlation behaves exactly as it does today.
+- The breaker's open and close transitions continue to alert as they do now.
+- Table-driven tests cover: correlated timeouts opening the breaker, correlated missing-checks opening it, an isolated timeout not opening it, and suppression plus re-drive of both shapes while open.
+
+## Implementation
+
+- `internal/autopilot/platform_breaker.go`
+- `internal/autopilot/platform_breaker_probe.go`
+- `internal/autopilot/controller.go` — the CI-timeout and check-discovery paths
+- the corresponding test files
+
+Do not decompose — this is a standalone task, single PR.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3112,8 +3112,57 @@ func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState, ghPR
 			c.parkForBaseMismatch(ctx, prState, prState.TargetBranch, defaultBranch)
 			return nil
 		}
+
+		// GH-5236: a CI wait that expires with checks still pending, or a
+		// SHA that never produced a single check-run despite this repo
+		// having produced them before (ci_monitor.go's
+		// checkAutoDiscoveredRuns holds THAT shape at CIPending forever
+		// rather than resolving CISuccess — GH-5233 — so it also reaches
+		// this same deadline-expired branch, distinguishable here by
+		// prState.DiscoveredChecks staying empty for the whole wait), is
+		// evidence about the platform, not the code: nothing failed, the
+		// run simply never completed or never started. Record it for the
+		// same cross-PR correlation handleCIFailed already feeds
+		// (platform_breaker.go) BEFORE the stage transition below, so a
+		// burst of these across distinct PRs opens the breaker exactly like
+		// a burst of infra/unknown-class CI failures does. 2026-08-26
+		// GitHub Actions outage: PR#5231 sat with all eight jobs `queued`
+		// and never started, exhausted this exact 30-minute wait with
+		// last_status pending, and hit StageFailed directly — this path
+		// never called Observe, so the breaker never saw it.
+		missingChecks := len(prState.DiscoveredChecks) == 0
+		corroborated := false
+		if c.platformBreaker != nil && !c.platformBreaker.IsOpen() {
+			// Only pay the githubstatus.com round-trip when the breaker is
+			// actually wired up (feature enabled) and not already open —
+			// a nil breaker means this PR's ObserveTimeout call below is a
+			// pure no-op anyway, and once already open there's nothing left
+			// to accelerate. Never gates the correlation-only path —
+			// ObserveTimeout still opens on minDistinctPRs distinct PRs with
+			// corroborated=false.
+			corroborated = ProbeGitHubStatus(c.log) == PlatformProbeCorroborating
+		}
+		platformBreakerResult := c.platformBreaker.ObserveTimeout(prState.PRNumber, c.repoKey(), corroborated)
+		c.metrics.SetPlatformBreakerOpen(platformBreakerResult.Open)
+		c.alertPlatformBreakerTransition(platformBreakerResult)
+
+		if platformBreakerResult.Open {
+			// GH-5236: mirrors handleCIFailed's own breaker-open suppression
+			// (controller.go ~3471) — hold via BreakerHoldActive instead of
+			// confirming a terminal timeout, spawning a fix issue, or
+			// closing anything. ReDriveBreakerHeldPRs re-enters this PR into
+			// StageWaitingCI with a fresh wait clock once the breaker
+			// closes.
+			c.metrics.RecordPlatformBreakerTrip()
+			c.log.Warn("platform-outage breaker open — holding PR instead of confirming CI timeout",
+				"pr", prState.PRNumber, "waited", waited, "last_status", status, "missing_checks", missingChecks)
+			prState.BreakerHoldActive = true
+			prState.Stage = StageFailed
+			return nil
+		}
+
 		c.log.Warn("CI timeout confirmed by same-tick poll",
-			"pr", prState.PRNumber, "waited", waited, "last_status", status)
+			"pr", prState.PRNumber, "waited", waited, "last_status", status, "missing_checks", missingChecks)
 		prState.Stage = StageFailed
 		prState.Error = fmt.Sprintf("CI timeout after %v (last confirmed status: %s)", ciTimeout, status)
 		// GH-4851: without a TerminalLabel here, a later external close of

--- a/internal/autopilot/controller_gh5236_platform_timeout_test.go
+++ b/internal/autopilot/controller_gh5236_platform_timeout_test.go
@@ -1,0 +1,463 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-5236 (2026-08-26 GitHub Actions outage) regression tests.
+//
+// During the outage, PR#5231 sat with all 8 jobs `queued` and never
+// started, exhausted the 30-minute CI-wait deadline with last_status
+// pending, and hit StageFailed directly via handleWaitingCI's
+// deadlineExceeded branch — a path that never called
+// PlatformBreaker.Observe. A sibling repo PR got zero check-runs for over
+// an hour (the "missing checks" shape, which GH-5233 already folds into
+// the same CIPending-forever/deadline-exceeded branch since it holds a SHA
+// at CIPending forever once the repo has previously produced check-runs).
+// Neither shape ever reached the breaker's cross-PR correlation, so the
+// breaker never opened during a real platform-wide outage.
+//
+// These tests cover the four acceptance-criteria table rows: correlated
+// timeouts open the breaker, correlated missing-checks open the breaker,
+// an isolated timeout does not open it, and suppression + re-drive of both
+// shapes while the breaker is open — exercised through handleWaitingCI via
+// ProcessPR, mirroring gh4851_ci_wait_confirm_poll_test.go's pattern.
+
+// gh5236PendingCheckRunHandler reports a single in-progress (never
+// resolving) check run for sha — the "timeout" shape: checks exist and
+// were discovered, but never complete.
+func gh5236PendingCheckRunHandler(sha string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/commits/"+sha+"/check-runs" {
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: github.CheckRunInProgress}},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}
+}
+
+// gh5236MultiPendingCheckRunHandler is the multi-SHA counterpart, reporting
+// a single in-progress check run for any of the given SHAs.
+func gh5236MultiPendingCheckRunHandler(shas []string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		for _, sha := range shas {
+			if r.URL.Path == "/repos/owner/repo/commits/"+sha+"/check-runs" {
+				resp := github.CheckRunsResponse{
+					TotalCount: 1,
+					CheckRuns:  []github.CheckRun{{Name: "ci", Status: github.CheckRunInProgress}},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}
+}
+
+// gh5236NoCheckRunsHandler reports zero check-runs for every SHA — the
+// "missing checks" shape: a SHA never produces a single check-run.
+func gh5236NoCheckRunsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/check-runs") {
+			resp := github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}
+}
+
+func gh5236SeedWaitingPR(c *Controller, prNum int, sha string) *PRState {
+	prState := &PRState{
+		PRNumber:        prNum,
+		IssueNumber:     prNum,
+		HeadSHA:         sha,
+		Stage:           StageWaitingCI,
+		CIStatus:        CIPending,
+		TargetBranch:    "main",
+		CIWaitStartedAt: time.Now().Add(-45 * time.Minute),
+	}
+	c.mu.Lock()
+	c.activePRs[prNum] = prState
+	c.mu.Unlock()
+	return prState
+}
+
+// TestHandleWaitingCI_CorrelatedTimeouts_OpenBreaker covers acceptance row
+// 1: a burst of CI-wait timeouts (checks discovered but never resolving)
+// across distinct PRs must open the shared platform breaker, exactly like
+// a burst of infra-classified CI failures does via handleCIFailed.
+func TestHandleWaitingCI_CorrelatedTimeouts_OpenBreaker(t *testing.T) {
+	stubPlatformStatusHTTPGet(t, func(url string) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, "")
+	})
+
+	shas := []string{"gh5236to1", "gh5236to2", "gh5236to3"}
+	server := httptest.NewServer(gh5236MultiPendingCheckRunHandler(shas))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	breaker := NewPlatformBreaker(3, 15*time.Minute, 20*time.Minute, nil)
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithPlatformBreaker(breaker))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prNums := []int{5301, 5302, 5303}
+	for i, prNum := range prNums {
+		prState := gh5236SeedWaitingPR(c, prNum, shas[i])
+		ghPR := &github.PullRequest{Number: prNum, Head: github.PRRef{SHA: shas[i]}, Base: github.PRRef{Ref: "main"}}
+		if err := c.ProcessPR(context.Background(), prNum, ghPR); err != nil {
+			t.Fatalf("ProcessPR(%d) returned unexpected error: %v", prNum, err)
+		}
+		if i < 2 {
+			if breaker.IsOpen() {
+				t.Fatalf("breaker opened too early, after only %d distinct-PR timeouts", i+1)
+			}
+			if prState.Stage != StageFailed {
+				t.Errorf("PR %d Stage = %s, want %s (confirmed timeout, breaker not yet open)", prNum, prState.Stage, StageFailed)
+			}
+			if prState.BreakerHoldActive {
+				t.Errorf("PR %d should not be breaker-held before the breaker opens", prNum)
+			}
+		}
+	}
+
+	if !breaker.IsOpen() {
+		t.Fatal("breaker should be open after 3 distinct-PR CI-wait timeouts")
+	}
+
+	// The 3rd PR's own tick is the one that crossed the threshold — it must
+	// be held, not confirmed as a terminal timeout.
+	thirdPR, ok := c.GetPRState(5303)
+	if !ok {
+		t.Fatal("PR 5303 no longer tracked")
+	}
+	if thirdPR.Stage != StageFailed || !thirdPR.BreakerHoldActive {
+		t.Errorf("PR 5303 Stage=%s BreakerHoldActive=%v, want StageFailed+BreakerHoldActive=true (held, not confirmed-timeout)", thirdPR.Stage, thirdPR.BreakerHoldActive)
+	}
+
+	if len(sink.events) != 1 || sink.events[0].Type != alerts.EventType("platform_breaker_open") {
+		t.Fatalf("expected exactly 1 platform_breaker_open alert, got %+v", sink.events)
+	}
+}
+
+// TestHandleWaitingCI_CorrelatedMissingChecks_OpenBreaker covers acceptance
+// row 2: a burst of SHAs that never produce a single check-run across
+// distinct PRs must open the breaker via the same deadline-exceeded path.
+func TestHandleWaitingCI_CorrelatedMissingChecks_OpenBreaker(t *testing.T) {
+	stubPlatformStatusHTTPGet(t, func(url string) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, "")
+	})
+
+	server := httptest.NewServer(gh5236NoCheckRunsHandler())
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	breaker := NewPlatformBreaker(3, 15*time.Minute, 20*time.Minute, nil)
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithPlatformBreaker(breaker))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prNums := []int{5311, 5312, 5313}
+	for i, prNum := range prNums {
+		sha := fmt.Sprintf("gh5236mc%d", i)
+		gh5236SeedWaitingPR(c, prNum, sha)
+		ghPR := &github.PullRequest{Number: prNum, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+		if err := c.ProcessPR(context.Background(), prNum, ghPR); err != nil {
+			t.Fatalf("ProcessPR(%d) returned unexpected error: %v", prNum, err)
+		}
+		if i < 2 && breaker.IsOpen() {
+			t.Fatalf("breaker opened too early, after only %d distinct-PR missing-checks observations", i+1)
+		}
+	}
+
+	if !breaker.IsOpen() {
+		t.Fatal("breaker should be open after 3 distinct-PR missing-checks timeouts")
+	}
+
+	thirdPR, ok := c.GetPRState(5313)
+	if !ok {
+		t.Fatal("PR 5313 no longer tracked")
+	}
+	if thirdPR.Stage != StageFailed || !thirdPR.BreakerHoldActive {
+		t.Errorf("PR 5313 Stage=%s BreakerHoldActive=%v, want StageFailed+BreakerHoldActive=true", thirdPR.Stage, thirdPR.BreakerHoldActive)
+	}
+	if len(thirdPR.DiscoveredChecks) != 0 {
+		t.Errorf("PR 5313 DiscoveredChecks = %v, want empty (missing-checks shape)", thirdPR.DiscoveredChecks)
+	}
+}
+
+// TestHandleWaitingCI_IsolatedTimeout_DoesNotOpenBreaker covers acceptance
+// row 3: a single, uncorrelated CI-wait timeout — with the breaker wired up
+// but no other distinct-PR observations feeding it — must behave exactly
+// as an isolated timeout does today: a normal confirmed-timeout terminal
+// failure, no breaker hold, no suppression.
+func TestHandleWaitingCI_IsolatedTimeout_DoesNotOpenBreaker(t *testing.T) {
+	stubPlatformStatusHTTPGet(t, func(url string) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, `{"components":[{"name":"Actions","status":"operational"}],"incidents":[]}`)
+	})
+
+	const sha = "gh5236iso1"
+	server := httptest.NewServer(gh5236PendingCheckRunHandler(sha))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	breaker := NewPlatformBreaker(3, 15*time.Minute, 20*time.Minute, nil)
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithPlatformBreaker(breaker))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := gh5236SeedWaitingPR(c, 5321, sha)
+	ghPR := &github.PullRequest{Number: 5321, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+	if err := c.ProcessPR(context.Background(), 5321, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	if breaker.IsOpen() {
+		t.Error("breaker should not open on a single isolated timeout with a green githubstatus.com probe")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s (isolated confirmed timeout)", prState.Stage, StageFailed)
+	}
+	if prState.BreakerHoldActive {
+		t.Error("BreakerHoldActive should be false — this is a normal terminal timeout, not a breaker hold")
+	}
+	if prState.TerminalLabel != github.LabelFailed {
+		t.Errorf("TerminalLabel = %q, want %q", prState.TerminalLabel, github.LabelFailed)
+	}
+	if !strings.Contains(prState.Error, "CI timeout") {
+		t.Errorf("Error = %q, want it to mention CI timeout", prState.Error)
+	}
+	if len(sink.events) != 0 {
+		t.Errorf("expected no platform-breaker alert for an isolated timeout, got %+v", sink.events)
+	}
+}
+
+// TestHandleWaitingCI_IsolatedTimeout_NilBreaker_UnchangedBehavior is the
+// disabled-by-config control: with no WithPlatformBreaker option (nil, the
+// default — the pre-GH-5236 configuration), an isolated timeout must behave
+// byte-identically to before, including never making an outbound
+// githubstatus.com call (the probe is gated on the breaker being wired up
+// and not yet open).
+func TestHandleWaitingCI_IsolatedTimeout_NilBreaker_UnchangedBehavior(t *testing.T) {
+	probeCalled := false
+	stubPlatformStatusHTTPGet(t, func(url string) (*http.Response, error) {
+		probeCalled = true
+		return jsonResponse(http.StatusOK, `{"components":[],"incidents":[]}`)
+	})
+
+	const sha = "gh5236nilbreaker1"
+	server := httptest.NewServer(gh5236PendingCheckRunHandler(sha))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := gh5236SeedWaitingPR(c, 5325, sha)
+	ghPR := &github.PullRequest{Number: 5325, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+	if err := c.ProcessPR(context.Background(), 5325, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+	}
+	if prState.BreakerHoldActive {
+		t.Error("BreakerHoldActive should be false with no breaker wired")
+	}
+	if probeCalled {
+		t.Error("githubstatus.com probe should not be called when no platform breaker is wired up")
+	}
+}
+
+// TestHandleWaitingCI_CorroboratedProbe_OpensOnFirstTimeout covers the
+// accelerant: when githubstatus.com corroborates an Actions incident, a
+// single CI-wait timeout is enough to open the breaker — never required to
+// wait for minDistinctPRs distinct timeouts to each expire in turn.
+func TestHandleWaitingCI_CorroboratedProbe_OpensOnFirstTimeout(t *testing.T) {
+	stubPlatformStatusHTTPGet(t, func(url string) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, `{"components":[{"name":"Actions","status":"major_outage"}],"incidents":[]}`)
+	})
+
+	const sha = "gh5236corrob1"
+	server := httptest.NewServer(gh5236PendingCheckRunHandler(sha))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	breaker := NewPlatformBreaker(3, 15*time.Minute, 20*time.Minute, nil)
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithPlatformBreaker(breaker))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := gh5236SeedWaitingPR(c, 5331, sha)
+	ghPR := &github.PullRequest{Number: 5331, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+	if err := c.ProcessPR(context.Background(), 5331, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	if !breaker.IsOpen() {
+		t.Error("breaker should open on the very first timeout when githubstatus.com corroborates an Actions outage")
+	}
+	if prState.Stage != StageFailed || !prState.BreakerHoldActive {
+		t.Errorf("Stage=%s BreakerHoldActive=%v, want StageFailed+BreakerHoldActive=true (held, breaker open)", prState.Stage, prState.BreakerHoldActive)
+	}
+}
+
+// TestHandleWaitingCI_BreakerOpen_SuppressesAndReDrives covers acceptance
+// row 4 for the timeout shape: while the breaker is already open (opened by
+// unrelated PRs), a PR whose own CI wait expires must be held
+// (BreakerHoldActive), not confirmed as a terminal timeout — and once the
+// breaker closes, ReDriveBreakerHeldPRs must revive it back into
+// StageWaitingCI with a fresh wait clock.
+func TestHandleWaitingCI_BreakerOpen_SuppressesAndReDrives(t *testing.T) {
+	stubPlatformStatusHTTPGet(t, func(url string) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, "")
+	})
+
+	const sha = "gh5236held1"
+	server := httptest.NewServer(gh5236PendingCheckRunHandler(sha))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+
+	breaker := NewPlatformBreaker(3, 15*time.Minute, 20*time.Minute, nil)
+	// Pre-correlate three OTHER, unrelated PRs directly so the breaker is
+	// already open going into this PR's own timeout, independent of this
+	// PR's own shape.
+	breaker.Observe(9001, "owner/repo", FailureClassInfra)
+	breaker.Observe(9002, "owner/repo", FailureClassInfra)
+	breaker.Observe(9003, "owner/repo", FailureClassInfra)
+	if !breaker.IsOpen() {
+		t.Fatal("test setup: breaker should already be open")
+	}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithPlatformBreaker(breaker))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := gh5236SeedWaitingPR(c, 5341, sha)
+	ghPR := &github.PullRequest{Number: 5341, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+	if err := c.ProcessPR(context.Background(), 5341, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	if prState.Stage != StageFailed || !prState.BreakerHoldActive {
+		t.Fatalf("Stage=%s BreakerHoldActive=%v, want StageFailed+BreakerHoldActive=true while breaker is open", prState.Stage, prState.BreakerHoldActive)
+	}
+	if strings.Contains(prState.Error, "CI timeout") {
+		t.Errorf("Error = %q should not be set on a breaker-held PR (not a confirmed timeout)", prState.Error)
+	}
+	// No new alert: the open transition happened via the pre-seeded direct
+	// Observe calls, not through this PR's own ObserveTimeout call.
+	if len(sink.events) != 0 {
+		t.Errorf("expected no new alert (breaker was already open), got %+v", sink.events)
+	}
+
+	// The breaker itself need not be closed for ReDriveBreakerHeldPRs to run
+	// — it acts purely on each PR's own Stage/BreakerHoldActive flags (see
+	// redriveBreakerHeldPRLocked), mirroring the periodic monitor calling it
+	// once the breaker's own JustClosed transition fires.
+	c.ReDriveBreakerHeldPRs(context.Background())
+
+	revived, ok := c.GetPRState(5341)
+	if !ok {
+		t.Fatal("PR 5341 no longer tracked")
+	}
+	if revived.Stage != StageWaitingCI {
+		t.Errorf("Stage = %s, want %s after re-drive", revived.Stage, StageWaitingCI)
+	}
+	if revived.BreakerHoldActive {
+		t.Error("BreakerHoldActive should be cleared after re-drive")
+	}
+	if revived.BreakerReadoptCount != 1 {
+		t.Errorf("BreakerReadoptCount = %d, want 1", revived.BreakerReadoptCount)
+	}
+	if revived.CIWaitStartedAt.Before(time.Now().Add(-time.Minute)) {
+		t.Error("CIWaitStartedAt should be reset to a fresh clock on re-drive")
+	}
+}
+
+// TestHandleWaitingCI_MissingChecks_BreakerOpen_SuppressesAndReDrives is the
+// missing-checks-shape counterpart of the above: same suppression and
+// re-drive guarantee, but for a SHA that never produced a single
+// check-run rather than one that produced checks which never resolved.
+func TestHandleWaitingCI_MissingChecks_BreakerOpen_SuppressesAndReDrives(t *testing.T) {
+	stubPlatformStatusHTTPGet(t, func(url string) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, "")
+	})
+
+	server := httptest.NewServer(gh5236NoCheckRunsHandler())
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+
+	breaker := NewPlatformBreaker(3, 15*time.Minute, 20*time.Minute, nil)
+	breaker.Observe(9011, "owner/repo", FailureClassInfra)
+	breaker.Observe(9012, "owner/repo", FailureClassInfra)
+	breaker.Observe(9013, "owner/repo", FailureClassInfra)
+	if !breaker.IsOpen() {
+		t.Fatal("test setup: breaker should already be open")
+	}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithPlatformBreaker(breaker))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	const sha = "gh5236heldmc1"
+	prState := gh5236SeedWaitingPR(c, 5351, sha)
+	ghPR := &github.PullRequest{Number: 5351, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+	if err := c.ProcessPR(context.Background(), 5351, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	if prState.Stage != StageFailed || !prState.BreakerHoldActive {
+		t.Fatalf("Stage=%s BreakerHoldActive=%v, want StageFailed+BreakerHoldActive=true while breaker is open", prState.Stage, prState.BreakerHoldActive)
+	}
+	if len(sink.events) != 0 {
+		t.Errorf("expected no new alert (breaker was already open), got %+v", sink.events)
+	}
+
+	c.ReDriveBreakerHeldPRs(context.Background())
+
+	revived, ok := c.GetPRState(5351)
+	if !ok {
+		t.Fatal("PR 5351 no longer tracked")
+	}
+	if revived.Stage != StageWaitingCI {
+		t.Errorf("Stage = %s, want %s after re-drive", revived.Stage, StageWaitingCI)
+	}
+	if revived.BreakerHoldActive {
+		t.Error("BreakerHoldActive should be cleared after re-drive")
+	}
+	if revived.BreakerReadoptCount != 1 {
+		t.Errorf("BreakerReadoptCount = %d, want 1", revived.BreakerReadoptCount)
+	}
+}

--- a/internal/autopilot/platform_breaker.go
+++ b/internal/autopilot/platform_breaker.go
@@ -18,8 +18,21 @@ import (
 // independent regressions. PlatformBreaker adds that signal.
 //
 // Part 1 scope: correlation + suppression of destructive actions only. Part
-// 2 (deferred) adds the external githubstatus.com probe, admission pause,
-// and held-PR re-drive on close.
+// 2 (TASK-458 part 2, GH-4792) added the external githubstatus.com probe
+// (advisory alert enrichment), admission pause, and held-PR re-drive on
+// close.
+//
+// GH-5236 (2026-08-26 outage): correlation was fed exclusively from the
+// CI-failure path (handleCIFailed's Observe call below). An Actions outage
+// most often does not produce a CI failure at all — a wait simply expires
+// with checks still pending, or a SHA never produces a single check-run.
+// Neither shape reached this breaker. ObserveTimeout adds that signal to
+// the SAME correlation store, and lets the githubstatus.com probe act as a
+// genuine (positive-only) accelerant for that shape specifically: when the
+// probe corroborates, a single timeout observation opens the breaker
+// instead of waiting for minDistinctPRs independent ~30-minute waits to
+// each expire in turn. Observe's own correlation-only behavior (and the
+// probe's role there, purely alert enrichment) is unchanged.
 
 // DefaultPlatformBreakerMinCorrelatedPRs, DefaultPlatformBreakerCorrelationWindow,
 // and DefaultPlatformBreakerQuietPeriod are GH-4791's part-1 defaults, used
@@ -144,7 +157,49 @@ func (b *PlatformBreaker) Observe(pr int, repo string, class FailureClass) Platf
 	if b == nil {
 		return PlatformBreakerResult{}
 	}
+	relevant := class.IsInfra() || class == FailureClassUnknown
+	return b.record(pr, repo, relevant, false)
+}
 
+// ObserveTimeout records one CI-wait-timeout or missing-checks observation
+// (GH-5236) — platform evidence that carries no FailureClass at all,
+// because nothing failed: a CI wait simply expired with checks still
+// pending, or a SHA never produced a single check-run despite this
+// repository having produced them before (ci_monitor.go's
+// checkAutoDiscoveredRuns holds that shape at CIPending forever rather than
+// resolving CISuccess/CIFailure — GH-5233 — so it surfaces to the caller as
+// an expired wait too). Feeds the SAME correlation store as Observe: a
+// distinct-PR count that mixes timeouts and infra/unknown-class failures is
+// exactly right, since the 2026-08-26 outage produced both shapes across
+// the fleet at once.
+//
+// corroborated is the caller's own up-to-date read of ProbeGitHubStatus
+// (platform_breaker_probe.go), taken OUTSIDE this call so no network I/O
+// ever runs under this breaker's mutex. When true and the breaker is not
+// yet open, this single observation alone is enough to open it — an
+// accelerant so the fleet isn't left unprotected while minDistinctPRs
+// independent ~30-minute waits each expire in turn before anyone notices.
+// corroborated=false (no probe run, or it came back green/unknown) opens
+// the breaker exactly as Observe does: on minDistinctPRs distinct
+// observations within the window. This only ever lowers the bar to open —
+// it can never keep the breaker open longer or veto an already-correlated
+// signal, matching ProbeGitHubStatus's own doc: status pages lag reality.
+//
+// A nil receiver always reports closed (Open: false, no transition).
+func (b *PlatformBreaker) ObserveTimeout(pr int, repo string, corroborated bool) PlatformBreakerResult {
+	if b == nil {
+		return PlatformBreakerResult{}
+	}
+	return b.record(pr, repo, true, corroborated)
+}
+
+// record is the shared implementation behind Observe and ObserveTimeout.
+// relevant reports whether this observation feeds correlation at all
+// (Observe: class.IsInfra()||Unknown; ObserveTimeout: always true).
+// corroborated (only ever non-false from ObserveTimeout) lowers the
+// distinct-PR threshold required to open to a single observation — see
+// ObserveTimeout's doc.
+func (b *PlatformBreaker) record(pr int, repo string, relevant, corroborated bool) PlatformBreakerResult {
 	now := time.Now
 	if b.now != nil {
 		now = b.now
@@ -161,7 +216,7 @@ func (b *PlatformBreaker) Observe(pr int, repo string, class FailureClass) Platf
 	// open a brand-new episode below in the same call.
 	result := b.closeIfQuietLocked(t)
 
-	if relevant := class.IsInfra() || class == FailureClassUnknown; relevant {
+	if relevant {
 		key := platformBreakerKey(repo, pr)
 		b.lastInfraAt = t
 		b.observations = append(b.observations, platformFailureObservation{key: key, at: t})
@@ -174,14 +229,20 @@ func (b *PlatformBreaker) Observe(pr int, repo string, class FailureClass) Platf
 			b.correlated[key] = true
 		} else {
 			distinct := b.distinctKeysLocked()
-			if len(distinct) >= b.minDistinctPRs {
+			threshold := b.minDistinctPRs
+			if corroborated && threshold > 1 {
+				threshold = 1
+			}
+			if len(distinct) >= threshold {
 				b.open = true
 				b.correlated = distinct
 				result.JustOpened = true
 				result.CorrelatedPRs = sortedKeys(distinct)
-				b.log.Warn("platform-outage breaker opened — correlated infra/unknown-class CI failures across distinct PRs, suspected platform outage",
+				b.log.Warn("platform-outage breaker opened — correlated infra/unknown-class CI failures and/or CI timeouts across distinct PRs, suspected platform outage",
 					"distinct_prs", len(distinct),
 					"min_distinct_prs", b.minDistinctPRs,
+					"threshold_used", threshold,
+					"probe_corroborated", corroborated,
 					"correlation_window", b.correlationWindow,
 					"correlated_prs", result.CorrelatedPRs,
 				)

--- a/internal/autopilot/platform_breaker_probe.go
+++ b/internal/autopilot/platform_breaker_probe.go
@@ -8,13 +8,21 @@ import (
 )
 
 // GH-4792 (TASK-458 part 2): advisory corroboration probe against GitHub's
-// own official Statuspage API. This NEVER gates PlatformBreaker's
-// open/close decision — that is driven exclusively by cross-PR CI-failure
-// correlation (platform_breaker.go). The probe only enriches the
+// own official Statuspage API. This NEVER VETOES PlatformBreaker's
+// open/close decision — that stays driven exclusively by cross-PR
+// correlation (platform_breaker.go), which is always sufficient on its own.
+// Called from alertPlatformBreakerTransition, the probe only enriches the
 // operator-facing open/close alert with independent evidence, and a green
 // result must never veto an already-correlated signal: status pages lag
 // reality, confirmed during the 2026-08-06 outage this whole feature exists
 // to catch.
+//
+// GH-5236 (2026-08-26 outage): also consulted from the CI-wait-timeout path
+// (controller.go's handleWaitingCI, via PlatformBreaker.ObserveTimeout) as
+// a one-directional ACCELERANT — a corroborating verdict there can only
+// lower the distinct-PR threshold required to open (down to a single
+// timeout), never raise it or block opening. A green/unknown verdict never
+// prevents correlation-only opening; it just means no shortcut was taken.
 //
 // Endpoint choice: component-scoped, not the coarse page-level
 // status.json. componentsURL finds the "Actions" component's own status;

--- a/internal/autopilot/platform_breaker_test.go
+++ b/internal/autopilot/platform_breaker_test.go
@@ -182,6 +182,93 @@ func TestPlatformBreaker_DistinctRepos(t *testing.T) {
 	}
 }
 
+// TestPlatformBreaker_ObserveTimeout_CorrelatesLikeObserve (GH-5236) verifies
+// ObserveTimeout feeds the SAME correlation store as Observe: minDistinctPRs
+// distinct timeout/missing-check observations (corroborated=false, the
+// uncorroborated/common case) open the breaker exactly like a burst of
+// infra/unknown-class CI failures does — neither more nor less eagerly.
+func TestPlatformBreaker_ObserveTimeout_CorrelatesLikeObserve(t *testing.T) {
+	b, _ := newTestPlatformBreaker(3, 15*time.Minute, 20*time.Minute)
+
+	r1 := b.ObserveTimeout(1, "owner/repo", false)
+	if r1.Open || r1.JustOpened {
+		t.Fatalf("after 1 distinct PR timeout: Open=%v JustOpened=%v, want both false", r1.Open, r1.JustOpened)
+	}
+	r2 := b.ObserveTimeout(2, "owner/repo", false)
+	if r2.Open || r2.JustOpened {
+		t.Fatalf("after 2 distinct PR timeouts: Open=%v JustOpened=%v, want both false", r2.Open, r2.JustOpened)
+	}
+	r3 := b.ObserveTimeout(3, "owner/repo", false)
+	if !r3.Open || !r3.JustOpened {
+		t.Fatalf("after 3 distinct PR timeouts: Open=%v JustOpened=%v, want both true", r3.Open, r3.JustOpened)
+	}
+	wantPRs := []string{"owner/repo#1", "owner/repo#2", "owner/repo#3"}
+	if !equalStringSlices(r3.CorrelatedPRs, wantPRs) {
+		t.Errorf("CorrelatedPRs = %v, want %v", r3.CorrelatedPRs, wantPRs)
+	}
+}
+
+// TestPlatformBreaker_ObserveTimeout_MixesWithObserve (GH-5236) verifies a
+// timeout observation and a CI-failure observation on distinct PRs count
+// toward the SAME correlation threshold — the 2026-08-26 outage produced
+// both shapes across the fleet at once, and neither alone should have to
+// independently reach minDistinctPRs.
+func TestPlatformBreaker_ObserveTimeout_MixesWithObserve(t *testing.T) {
+	b, _ := newTestPlatformBreaker(3, 15*time.Minute, 20*time.Minute)
+
+	b.Observe(1, "owner/repo", FailureClassInfra)
+	b.ObserveTimeout(2, "owner/repo", false)
+	r3 := b.ObserveTimeout(3, "owner/repo", false)
+
+	if !r3.Open || !r3.JustOpened {
+		t.Fatalf("mixed CI-failure + timeout observations: Open=%v JustOpened=%v, want both true", r3.Open, r3.JustOpened)
+	}
+}
+
+// TestPlatformBreaker_ObserveTimeout_CorroboratedOpensOnFirstObservation
+// (GH-5236) verifies the probe-corroboration accelerant: when the caller
+// passes corroborated=true, a SINGLE timeout observation is enough to open
+// the breaker, rather than waiting for minDistinctPRs independent
+// ~30-minute waits to each expire in turn.
+func TestPlatformBreaker_ObserveTimeout_CorroboratedOpensOnFirstObservation(t *testing.T) {
+	b, _ := newTestPlatformBreaker(3, 15*time.Minute, 20*time.Minute)
+
+	r := b.ObserveTimeout(1, "owner/repo", true)
+	if !r.Open || !r.JustOpened {
+		t.Fatalf("single corroborated timeout: Open=%v JustOpened=%v, want both true", r.Open, r.JustOpened)
+	}
+	if !equalStringSlices(r.CorrelatedPRs, []string{"owner/repo#1"}) {
+		t.Errorf("CorrelatedPRs = %v, want [owner/repo#1]", r.CorrelatedPRs)
+	}
+}
+
+// TestPlatformBreaker_ObserveTimeout_CorroboratedNeverVetoesOrReopensAlreadyOpen
+// (GH-5236) verifies corroboration only ever lowers the bar to OPEN — it
+// must never affect an already-open breaker's state, and a
+// corroborated=false single observation must NOT open (no accidental
+// always-on accelerant).
+func TestPlatformBreaker_ObserveTimeout_CorroboratedNeverVetoesOrReopensAlreadyOpen(t *testing.T) {
+	b, _ := newTestPlatformBreaker(3, 15*time.Minute, 20*time.Minute)
+
+	uncorroborated := b.ObserveTimeout(1, "owner/repo", false)
+	if uncorroborated.Open {
+		t.Fatalf("single uncorroborated timeout: Open=%v, want false (no accelerant applied)", uncorroborated.Open)
+	}
+
+	b.ObserveTimeout(2, "owner/repo", false)
+	opened := b.ObserveTimeout(3, "owner/repo", false)
+	if !opened.Open {
+		t.Fatal("test setup: breaker should open on the 3rd correlation-only observation")
+	}
+
+	// A further corroborated call while already open must not re-fire
+	// JustOpened or otherwise disturb the existing episode.
+	again := b.ObserveTimeout(4, "owner/repo", true)
+	if !again.Open || again.JustOpened {
+		t.Errorf("corroborated observation on an already-open breaker: Open=%v JustOpened=%v, want Open=true JustOpened=false", again.Open, again.JustOpened)
+	}
+}
+
 // TestPlatformBreaker_NilReceiverIsNoOp verifies the disabled-by-config path
 // is a byte-identical no-op: a nil *PlatformBreaker always reports closed
 // with no transition, regardless of how many observations are fed in.
@@ -192,6 +279,15 @@ func TestPlatformBreaker_NilReceiverIsNoOp(t *testing.T) {
 		r := b.Observe(pr, "owner/repo", FailureClassInfra)
 		if r.Open || r.JustOpened || r.JustClosed || r.CorrelatedPRs != nil {
 			t.Fatalf("nil breaker Observe(%d) = %+v, want zero value", pr, r)
+		}
+	}
+	// GH-5236: ObserveTimeout must be equally nil-safe, including with the
+	// corroborated=true accelerant — a nil breaker (disabled by config) must
+	// never open regardless.
+	for pr := 1; pr <= 10; pr++ {
+		r := b.ObserveTimeout(pr, "owner/repo", true)
+		if r.Open || r.JustOpened || r.JustClosed || r.CorrelatedPRs != nil {
+			t.Fatalf("nil breaker ObserveTimeout(%d) = %+v, want zero value", pr, r)
 		}
 	}
 	if b.IsOpen() {

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -301,8 +301,10 @@ type PlatformBreakerConfig struct {
 	// re-evaluates the time-based close condition. Also the trigger interval
 	// for the advisory corroboration probe fired just before the breaker
 	// opens. Zero/unset falls back to DefaultPlatformBreakerProbeInterval
-	// (5m). The probe result is advisory only — see ProbeGitHubStatus's doc
-	// comment — it never gates open/close.
+	// (5m). The probe result never vetoes correlation and never gates
+	// close — see ProbeGitHubStatus's doc comment. GH-5236: on the
+	// CI-wait-timeout path specifically, a corroborating probe result CAN
+	// accelerate open (fewer distinct PRs required), one direction only.
 	ProbeInterval time.Duration `yaml:"probe_interval"`
 	// PauseAdmission controls whether new executor dispatch is paused while
 	// the breaker is open (GH-4792): stops burning executor spend on work


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5236.

Closes #5236

## Changes

GitHub Issue GH-5236: fix(autopilot): platform-outage breaker is blind to the outage's actual shape — CI timeouts and missing checks never feed correlation

## Context

GitHub Actions went into a **major outage** on 2026-08-26 at 15:11:58Z. The platform-outage breaker is enabled in production and is exactly the mechanism meant to protect the fleet during such an event. It never tripped.

The reason is a gap in what feeds it. `platformBreaker.Observe` is called from the CI-**failure** handling path, so it correlates failures that carry a failure class across distinct PRs. But an Actions outage most often does not produce CI failures at all — it produces work that never runs:

- PR#5231's run completed with conclusion `failure` while all eight of its jobs sat `queued` and never started. Autopilot waited out its 30-minute `waiting_ci` budget with `last_status=pending`, then set `StageFailed` directly. That path never calls `Observe`.
- A sibling repo's PR received **zero check runs** for over an hour while other PRs opened minutes later got a full set.
- Another branch recorded a `startup_failure`.

None of these reach the correlation signal, so the breaker stayed closed through a confirmed platform-wide outage and destructive CI-failure actions stayed armed.

This is the same root as the sibling issue about a PR whose CI never ran resolving to success: an outage has two shapes, and the fleet is unprotected against both. Either checks never appear, and the run is treated as green and merged; or they appear and time out, and the PR is failed as though the code were at fault. The breaker was built for exactly this and sees neither.

## Task

Feed the outage-shaped signals into the same cross-PR correlation the breaker already performs.

A CI wait that expires with the checks still pending, and a SHA that never produces checks on a repository that normally does, are both evidence about the platform rather than about the code. Record them as such before the stage transition, so a burst of them across distinct PRs opens the breaker the same way a burst of infra-class failures does.

Once the breaker is open, the existing suppression should cover these paths too: a timeout during an open breaker must not drive a PR to failed, spawn a fix issue, or close anything. Hold and re-drive when the breaker closes, which is the machinery that already exists.

Consider also consulting the platform's own published status as a corroborating input rather than the sole trigger. Correlation across PRs is the more reliable signal and should stay primary; an external status check is a useful accelerant so the breaker opens on the first timeout rather than the third.

Keep the existing behaviour for a genuine single-PR timeout when no correlation exists — one slow PR is not an outage.

## Acceptance

- A CI wait that expires with checks still pending records a platform observation before the stage transition.
- A SHA producing no checks, on a repository with prior observed check runs, records the same kind of observation.
- A burst of either across distinct PRs within the correlation window opens the breaker.
- While the breaker is open, neither shape drives a PR to failed, spawns a fix issue, or closes a PR; both are held and re-driven when it closes.
- A single isolated timeout with no correlation behaves exactly as it does today.
- The breaker's open and close transitions continue to alert as they do now.
- Table-driven tests cover: correlated timeouts opening the breaker, correlated missing-checks opening it, an isolated timeout not opening it, and suppression plus re-drive of both shapes while open.

## Implementation

- `internal/autopilot/platform_breaker.go`
- `internal/autopilot/platform_breaker_probe.go`
- `internal/autopilot/controller.go` — the CI-timeout and check-discovery paths
- the corresponding test files

Do not decompose — this is a standalone task, single PR.