### PR TITLE
fix(autopilot): post-merge CI treated absent signal as success and never fed the breaker

### DIFF
--- a/.agent/tasks/gh-5238.md
+++ b/.agent/tasks/gh-5238.md
@@ -1,0 +1,46 @@
+# GH-5238
+
+**Created:** 2026-08-26
+
+## Problem
+
+GitHub Issue GH-5238: fix(autopilot): post-merge CI treats absent signal as success and never feeds the breaker — ships a release on no evidence
+
+## Context
+
+Two fail-open holes in the CI decision path were found and fixed today: a pre-merge SHA with no check runs resolving to success, and the platform-outage breaker being blind to CI timeouts. A follow-up audit found the **same class surviving in the post-merge stage**, where neither fix reaches — and this one gates tagging, releasing and deploying rather than merging.
+
+**Absence is still treated as a pass.** `handlePostMergeCI` probes with a short no-workflow grace window and, if `HasAnyCIConfigured` reports nothing for the merged SHA, sets the status to success directly and proceeds to the releasing stage. Unlike the pre-merge path, that probe is a raw single-SHA look with **no cross-SHA history guard** — the very protection the pre-merge fix added. During a platform outage a freshly merged main-branch SHA legitimately shows zero check runs inside that grace window, so this fires and a release artifact ships on no evidence at all. It never reaches the failure or alerting branch, so it ships silently.
+
+**The post-merge stage also never feeds the breaker.** Its own timeout branch sets the failed stage, re-queues the scope release and can spawn a fix issue, with no breaker observation of any kind. The breaker's only call sites are in the CI-failure path, the merging path and release backfill — none in post-merge handling. So a burst of post-merge outage symptoms neither opens the breaker nor is held by it, and each carrier independently misdiagnoses a platform problem as either "no CI configured" or "CI failed" — including filing fix issues for an outage.
+
+Worth stating plainly as context for whoever picks this up: **there is no revert path anywhere in the autopilot package.** If post-merge CI later fails for real, the merged commit is never touched — the carrier spawns a fix issue or re-queues. That makes a false green at this stage strictly worse than one before merge, because nothing downstream can undo it.
+
+## Task
+
+Bring the post-merge stage to the same standard the pre-merge path now meets.
+
+**Absence must not mean success.** Route the no-workflow probe through the same history-aware check the pre-merge discovery path uses: if this repository has produced check runs before, then zero check runs for this SHA is an anomaly, not an absence of configuration, and the stage should hold rather than pass. Preserve today's behaviour for a repository that genuinely has no CI, so nothing regresses for those.
+
+**Feed the breaker.** Add a timeout observation on the post-merge timeout branch, mirroring how the pre-merge wait now reports one, so post-merge outage symptoms contribute to correlation and are suppressed while the breaker is open. While it is open, a post-merge timeout must not spawn a fix issue or drive the carrier to failed — hold and re-drive, using the machinery that already exists.
+
+## Acceptance
+
+- A repository with prior observed check runs, whose merged SHA has none within the grace window, does not resolve to success and does not proceed to releasing.
+- A repository that has never produced a check run continues to behave exactly as it does today.
+- The post-merge timeout branch records a breaker observation before its stage transition.
+- While the breaker is open, a post-merge timeout neither spawns a fix issue nor drives the PR to failed; it is held and re-driven on close.
+- A genuine post-merge failure is handled exactly as it is today.
+- Table-driven tests cover: no-CI repo unchanged, CI-bearing repo with missing checks held, correlated post-merge timeouts opening the breaker, and suppression plus re-drive while open.
+
+## Implementation
+
+- `internal/autopilot/controller.go` — the post-merge CI handler
+- `internal/autopilot/ci_monitor.go` — the has-any-CI-configured probe needs the history-aware guard
+- `internal/autopilot/platform_breaker.go` if the timeout observation needs a new entry point
+- the corresponding test files
+
+Do not decompose — this is a standalone task, single PR.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -811,6 +811,23 @@ func (m *CIMonitor) HasAnyCIConfigured(ctx context.Context, sha string) (bool, e
 	if checkRuns.TotalCount > 0 {
 		return true, nil
 	}
+	// GH-5238: zero check-runs for THIS sha is not evidence this repo has no
+	// CI when it has produced check-runs before, for some OTHER sha, during
+	// this monitor's lifetime (m.everSeenCheckRuns — the same cross-SHA
+	// history guard GH-5233 added to checkAutoDiscoveredRuns for the
+	// pre-merge discovery path). It's an anomaly instead — a platform
+	// outage, a workflow that hasn't triggered yet, etc — and the
+	// combined-status fallback below would just rubber-stamp the same wrong
+	// answer, since Actions-only repos legitimately report empty statuses
+	// too. Report CI as configured so handlePostMergeCI's no-workflow probe
+	// falls through to its normal timeout+poll wait (which itself now holds
+	// this shape at CIPending via checkAutoDiscoveredRuns) instead of
+	// short-circuiting straight to CISuccess. A repo that has never produced
+	// a check-run at all is unaffected — it still falls through to the
+	// combined-status check below, exactly as before.
+	if m.hasEverSeenCheckRuns() {
+		return true, nil
+	}
 	combined, err := m.ghClient.GetCombinedStatus(ctx, m.owner, m.repo, sha)
 	if err != nil {
 		return false, err

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -5472,7 +5472,47 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 			ciTimeout = envCITimeout
 		}
 		if time.Since(prState.PostMergeCIStartedAt) > ciTimeout {
-			c.log.Warn("post-merge CI timeout", "pr", prState.PRNumber, "waited", time.Since(prState.PostMergeCIStartedAt))
+			waited := time.Since(prState.PostMergeCIStartedAt)
+			c.log.Warn("post-merge CI timeout", "pr", prState.PRNumber, "waited", waited)
+
+			// GH-5238: mirror handleWaitingCI's GH-5236 breaker feed — a
+			// post-merge CI wait that times out (checks stuck pending, or a
+			// SHA that never produced one despite this repo's history — the
+			// same shape checkAutoDiscoveredRuns/HasAnyCIConfigured now hold
+			// rather than resolve, per the GH-5238 fix above) is platform
+			// evidence exactly like its pre-merge counterpart. Before this,
+			// the post-merge rung never called Observe/ObserveTimeout at
+			// all, despite gating tagging/releasing/deploy rather than mere
+			// merging — and there is no revert path anywhere in this
+			// package, so a false confirmation here is strictly worse than
+			// one before merge.
+			corroborated := false
+			if c.platformBreaker != nil && !c.platformBreaker.IsOpen() {
+				// Same gating as handleWaitingCI: only pay the
+				// githubstatus.com round-trip when the breaker is wired up
+				// and not already open.
+				corroborated = ProbeGitHubStatus(c.log) == PlatformProbeCorroborating
+			}
+			platformBreakerResult := c.platformBreaker.ObserveTimeout(prState.PRNumber, c.repoKey(), corroborated)
+			c.metrics.SetPlatformBreakerOpen(platformBreakerResult.Open)
+			c.alertPlatformBreakerTransition(platformBreakerResult)
+
+			if platformBreakerResult.Open {
+				// Hold rather than confirm: while the breaker is open, a
+				// post-merge timeout must not re-queue the scope release,
+				// mark it failed/parked, or spawn a fix issue — none of
+				// that machinery has any evidence to act on during a
+				// platform outage. redriveBreakerHeldPRLocked re-enters this
+				// PR at StagePostMergeCI with a fresh timer once the breaker
+				// closes (mirrors ReDriveBreakerHeldPRs' pre-merge revival).
+				c.metrics.RecordPlatformBreakerTrip()
+				c.log.Warn("platform-outage breaker open — holding post-merge PR instead of confirming CI timeout",
+					"pr", prState.PRNumber, "waited", waited)
+				prState.BreakerHoldActive = true
+				prState.Stage = StageFailed
+				return nil
+			}
+
 			if prState.ScopeKey != "" {
 				// GH-3990: re-queue the scope for a fresh carrier attempt instead of
 				// leaving this one wedged at StageFailed forever — drain it now so the
@@ -7346,8 +7386,22 @@ func (c *Controller) redriveBreakerHeldPRLocked(ctx context.Context, prState *PR
 
 	prState.BreakerReadoptCount++
 	prState.BreakerHoldActive = false
-	prState.Stage = StageWaitingCI
-	prState.CIWaitStartedAt = time.Now()
+
+	// GH-5238: a PR held from a POST-merge CI timeout must re-enter
+	// StagePostMergeCI, not StageWaitingCI — it is already merged, so a
+	// pre-merge CI wait has nothing to poll (its head branch is typically
+	// gone) and would never resolve. PostMergeSHA is only ever set once, on
+	// first entry to handlePostMergeCI (controller.go's mainSHA capture),
+	// so its presence reliably distinguishes a post-merge hold from a
+	// pre-merge one at this point in the PR's lifecycle: a PR held from a
+	// pre-merge timeout can never have reached post-merge yet.
+	if prState.PostMergeSHA != "" {
+		prState.Stage = StagePostMergeCI
+		prState.PostMergeCIStartedAt = time.Now()
+	} else {
+		prState.Stage = StageWaitingCI
+		prState.CIWaitStartedAt = time.Now()
+	}
 	prState.Error = ""
 
 	c.log.Info("ReDriveBreakerHeldPRs: platform-outage breaker closed, re-entering pipeline",

--- a/internal/autopilot/gh5238_test.go
+++ b/internal/autopilot/gh5238_test.go
@@ -1,0 +1,325 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-5238 regression tests.
+//
+// Two fail-open holes were found in the post-merge stage, the same class
+// GH-5233 (pre-merge discovery) and GH-5236 (platform-breaker feed) already
+// fixed pre-merge:
+//
+//  1. handlePostMergeCI's no-workflow probe (HasAnyCIConfigured) was a raw
+//     single-SHA look with no cross-SHA history guard, so a repo with prior
+//     observed check runs whose merged SHA legitimately shows zero checks
+//     during a platform outage resolved straight to CISuccess and proceeded
+//     to StageReleasing — shipping a release on no evidence, with no revert
+//     path anywhere in this package.
+//  2. The post-merge timeout branch never called PlatformBreaker.Observe/
+//     ObserveTimeout at all, so a burst of post-merge outage symptoms never
+//     opened the breaker and was never suppressed by it.
+//
+// These tests cover the four acceptance-criteria rows: no-CI repo unchanged,
+// CI-bearing repo with missing checks held, correlated post-merge timeouts
+// opening the breaker, and suppression + re-drive while open.
+
+// TestHandlePostMergeCI_GH5238_NoCIRepo_Unchanged is acceptance row 1: a
+// repository that has never produced a check run for any SHA must continue
+// to treat a checkless merge SHA as satisfied CI and proceed to releasing,
+// exactly as it did before this fix (GH-4643's original behavior).
+func TestHandlePostMergeCI_GH5238_NoCIRepo_Unchanged(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/gh5238nocisha/check-runs":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}})
+		case "/repos/owner/repo/commits/gh5238nocisha/status":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CombinedStatus{TotalCount: 0})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 5 * time.Second
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:     92380,
+		ScopeKey:     "epic:5238-a",
+		IssueNumber:  92380,
+		Stage:        StagePostMergeCI,
+		PostMergeSHA: "gh5238nocisha",
+		// Past the 90s no-workflow grace period but not the 5s CIWaitTimeout's
+		// relative order — proves the probe path resolves this, not a timeout.
+		PostMergeCIStartedAt: time.Now().Add(-2 * time.Minute),
+	}
+	c.mu.Lock()
+	c.activePRs[prState.PRNumber] = prState
+	c.mu.Unlock()
+
+	if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+		t.Fatalf("handlePostMergeCI() error = %v", err)
+	}
+
+	if prState.Stage != StageReleasing {
+		t.Errorf("Stage = %v, want StageReleasing (no-CI repo behavior must be unaffected)", prState.Stage)
+	}
+	if prState.Error != "" {
+		t.Errorf("Error = %q, want empty", prState.Error)
+	}
+}
+
+// TestHandlePostMergeCI_GH5238_CIBearingRepo_MissingChecksHeld is acceptance
+// row 2: once this repo's CI monitor has observed check runs before (on a
+// different SHA), a merged SHA that reports zero check runs within the grace
+// window must be held — never resolved to CISuccess, never StageReleasing.
+func TestHandlePostMergeCI_GH5238_CIBearingRepo_MissingChecksHeld(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/gh5238priorsha/check-runs":
+			resp := github.CheckRunsResponse{TotalCount: 1, CheckRuns: []github.CheckRun{
+				{ID: 1, Name: "test", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+			}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/commits/gh5238mainsha/check-runs":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}})
+		case "/repos/owner/repo/commits/gh5238mainsha/status":
+			// Actions-only repo: combined-status legitimately reports empty
+			// too — this must not be consulted once history is present.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CombinedStatus{TotalCount: 0})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 5 * time.Minute
+	cfg.RequiredChecks = nil
+	cfg.CIChecks = &CIChecksConfig{Mode: "auto", DiscoveryGracePeriod: 10 * time.Millisecond}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Seed this monitor's cross-SHA history: the repo HAS produced a
+	// check-run before, just on a different SHA.
+	if _, err := c.ciMonitor.CheckCI(context.Background(), "gh5238priorsha"); err != nil {
+		t.Fatalf("seed CheckCI(gh5238priorsha) error = %v", err)
+	}
+
+	prState := &PRState{
+		PRNumber:             92381,
+		IssueNumber:          92381,
+		Stage:                StagePostMergeCI,
+		PostMergeSHA:         "gh5238mainsha",
+		PostMergeCIStartedAt: time.Now().Add(-2 * time.Minute), // past the 90s no-workflow grace
+	}
+	c.mu.Lock()
+	c.activePRs[prState.PRNumber] = prState
+	c.mu.Unlock()
+
+	if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+		t.Fatalf("handlePostMergeCI() (1st) error = %v", err)
+	}
+	// Let the per-SHA discovery grace period elapse so the second call
+	// exercises checkAutoDiscoveredRuns' post-grace anomaly-hold branch,
+	// not just "grace not yet expired".
+	time.Sleep(30 * time.Millisecond)
+	if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+		t.Fatalf("handlePostMergeCI() (2nd) error = %v", err)
+	}
+
+	if prState.Stage == StageReleasing {
+		t.Error("Stage = StageReleasing, want held — a CI-bearing repo's missing checks must not resolve to success")
+	}
+	if prState.CIStatus == CISuccess {
+		t.Errorf("CIStatus = %v, want anything but CISuccess", prState.CIStatus)
+	}
+	if prState.Stage != StagePostMergeCI {
+		t.Errorf("Stage = %v, want StagePostMergeCI (still holding, not failed/timed out yet)", prState.Stage)
+	}
+}
+
+// TestHandlePostMergeCI_GH5238_CorrelatedTimeouts_OpenBreaker is acceptance
+// row 3: a burst of post-merge CI timeouts across distinct PRs must open the
+// shared platform breaker via the post-merge rung's own ObserveTimeout call
+// — before this fix, post-merge handling never called Observe/ObserveTimeout
+// at all, so this burst would have gone completely unnoticed by the breaker.
+func TestHandlePostMergeCI_GH5238_CorrelatedTimeouts_OpenBreaker(t *testing.T) {
+	stubPlatformStatusHTTPGet(t, func(url string) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, "")
+	})
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://127.0.0.1:0")
+	cfg := DefaultConfig()
+	cfg.CIWaitTimeout = 50 * time.Millisecond
+	breaker := NewPlatformBreaker(3, 15*time.Minute, 20*time.Minute, nil)
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithPlatformBreaker(breaker))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prNums := []int{92391, 92392, 92393}
+	var lastState *PRState
+	for i, prNum := range prNums {
+		prState := &PRState{
+			PRNumber:    prNum,
+			IssueNumber: prNum,
+			Stage:       StagePostMergeCI,
+			// Distinct SHA per PR; irrelevant here since the timeout check
+			// fires before any CheckCI call (started-at already exceeds the
+			// timeout, but not yet the 90s no-workflow grace period).
+			PostMergeSHA:         fmt.Sprintf("gh5238to%d", i),
+			PostMergeCIStartedAt: time.Now().Add(-200 * time.Millisecond),
+		}
+		c.mu.Lock()
+		c.activePRs[prNum] = prState
+		c.mu.Unlock()
+
+		if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+			t.Fatalf("handlePostMergeCI(%d) error = %v", prNum, err)
+		}
+
+		if i < 2 {
+			if breaker.IsOpen() {
+				t.Fatalf("breaker opened too early, after only %d distinct-PR post-merge timeouts", i+1)
+			}
+			if prState.Stage != StageFailed || prState.BreakerHoldActive {
+				t.Errorf("PR %d Stage=%s BreakerHoldActive=%v, want StageFailed+BreakerHoldActive=false (confirmed timeout, breaker not yet open)",
+					prNum, prState.Stage, prState.BreakerHoldActive)
+			}
+		}
+		lastState = prState
+	}
+
+	if !breaker.IsOpen() {
+		t.Fatal("breaker should be open after 3 distinct-PR post-merge CI timeouts")
+	}
+	if lastState.Stage != StageFailed || !lastState.BreakerHoldActive {
+		t.Errorf("3rd PR Stage=%s BreakerHoldActive=%v, want StageFailed+BreakerHoldActive=true (held, not confirmed-timeout)",
+			lastState.Stage, lastState.BreakerHoldActive)
+	}
+}
+
+// TestHandlePostMergeCI_GH5238_BreakerOpen_SuppressesAndReDrives is
+// acceptance row 4: while the breaker is already open (opened by unrelated
+// PRs), a post-merge timeout must not re-queue/fail the scope release or
+// spawn a fix issue — it must be held (BreakerHoldActive), and once the
+// breaker closes, ReDriveBreakerHeldPRs must revive it back into
+// StagePostMergeCI (not StageWaitingCI — this PR is already merged) with a
+// fresh timer.
+func TestHandlePostMergeCI_GH5238_BreakerOpen_SuppressesAndReDrives(t *testing.T) {
+	stubPlatformStatusHTTPGet(t, func(url string) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, "")
+	})
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://127.0.0.1:0")
+	cfg := DefaultConfig()
+	cfg.CIWaitTimeout = 50 * time.Millisecond
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"}
+
+	breaker := NewPlatformBreaker(3, 15*time.Minute, 20*time.Minute, nil)
+	// Pre-correlate three OTHER, unrelated PRs directly so the breaker is
+	// already open going into this PR's own post-merge timeout.
+	breaker.Observe(9001, "owner/repo", FailureClassInfra)
+	breaker.Observe(9002, "owner/repo", FailureClassInfra)
+	breaker.Observe(9003, "owner/repo", FailureClassInfra)
+	if !breaker.IsOpen() {
+		t.Fatal("test setup: breaker should already be open")
+	}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithPlatformBreaker(breaker))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	stateStore := newTestStateStore(t)
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:5238-held", "epic", []int{92401}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	c.SetStateStore(stateStore)
+
+	prState := &PRState{
+		PRNumber:             92401,
+		ScopeKey:             "epic:5238-held",
+		IssueNumber:          92401,
+		Stage:                StagePostMergeCI,
+		PostMergeSHA:         "gh5238held",
+		PostMergeCIStartedAt: time.Now().Add(-200 * time.Millisecond),
+	}
+	c.mu.Lock()
+	c.activePRs[prState.PRNumber] = prState
+	c.mu.Unlock()
+
+	if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+		t.Fatalf("handlePostMergeCI() error = %v", err)
+	}
+
+	if prState.Stage != StageFailed || !prState.BreakerHoldActive {
+		t.Fatalf("Stage=%s BreakerHoldActive=%v, want StageFailed+BreakerHoldActive=true while breaker is open",
+			prState.Stage, prState.BreakerHoldActive)
+	}
+
+	// The scope-release row must be untouched — handleScopeReleaseFailure
+	// must never have been called while the breaker holds this PR.
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:5238-held")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "pending" || row.Attempts != 0 {
+		t.Errorf("scope release row = state=%q attempts=%d, want state=pending attempts=0 (untouched — no scope failure recorded while held)",
+			row.State, row.Attempts)
+	}
+	// No new alert: the open transition happened via the pre-seeded direct
+	// Observe calls, not through this PR's own ObserveTimeout call.
+	if len(sink.events) != 0 {
+		t.Errorf("expected no new alert (breaker was already open), got %+v", sink.events)
+	}
+
+	// The PR must still be tracked (not drained via removePR) so it can be
+	// re-driven once the breaker closes.
+	if _, ok := c.GetPRState(92401); !ok {
+		t.Fatal("PR 92401 should still be tracked while breaker-held")
+	}
+
+	c.ReDriveBreakerHeldPRs(context.Background())
+
+	revived, ok := c.GetPRState(92401)
+	if !ok {
+		t.Fatal("PR 92401 no longer tracked")
+	}
+	if revived.Stage != StagePostMergeCI {
+		t.Errorf("Stage = %s, want %s after re-drive (already merged — must not re-enter pre-merge CI wait)", revived.Stage, StagePostMergeCI)
+	}
+	if revived.BreakerHoldActive {
+		t.Error("BreakerHoldActive should be cleared after re-drive")
+	}
+	if revived.BreakerReadoptCount != 1 {
+		t.Errorf("BreakerReadoptCount = %d, want 1", revived.BreakerReadoptCount)
+	}
+	if revived.PostMergeCIStartedAt.Before(time.Now().Add(-time.Minute)) {
+		t.Error("PostMergeCIStartedAt should be reset to a fresh clock on re-drive")
+	}
+}


### PR DESCRIPTION
## Summary

Two fail-open holes fixed pre-merge today (GH-5233, GH-5236) survived in the post-merge stage, which neither fix reaches — and this one gates tagging/releasing/deploy rather than merging, with no revert path anywhere in the `autopilot` package once it ships wrong.

- **Absence no longer means success.** `HasAnyCIConfigured` (`ci_monitor.go`) was a raw single-SHA look with no cross-SHA history guard. It now consults the same `everSeenCheckRuns` history `CIMonitor` already tracks (GH-5233): if this repo has ever produced a check-run, zero on the merge SHA is an anomaly, not "no CI configured" — `handlePostMergeCI` falls through to its normal timeout+poll wait (which itself already holds this shape at `CIPending`) instead of short-circuiting to `CISuccess`/`StageReleasing`. A repo that has never produced a check-run is unaffected.
- **The post-merge timeout branch now feeds the breaker.** It calls `PlatformBreaker.ObserveTimeout` before its stage transition, mirroring `handleWaitingCI`'s GH-5236 feed. While the breaker is open, a post-merge timeout holds (`BreakerHoldActive`) instead of re-queueing the scope release, marking it failed/parked, or spawning a fix issue. `redriveBreakerHeldPRLocked` now re-enters a held PR into `StagePostMergeCI` (not `StageWaitingCI`) when `PostMergeSHA` is already set, since a merged PR has nothing to poll pre-merge.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (full package, including new table-driven tests)
- [x] `go test ./...` (full repo)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...`
- [x] New tests in `internal/autopilot/gh5238_test.go` cover all four acceptance rows: no-CI repo unchanged, CI-bearing repo with missing checks held, correlated post-merge timeouts opening the breaker, and suppression + re-drive while open