### PR TITLE
GH-5242: feat(autopilot): thread execution mode and mode-gate iteration-limit PR closes

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -67,9 +67,12 @@ var (
 var quietMode bool
 
 // executionMode mirrors the execution-mode enum the (now-deleted, GH-4191)
-// in-tree github.Poller used to expose. Kept locally since it now only drives
-// the startup "sequential mode" display decision below — GitHub polling is
-// SDK-only and the SDK adapter runs ExecutionModeAuto unconditionally.
+// in-tree github.Poller used to expose. Kept locally since it still drives
+// the startup "sequential mode" display decision below. GitHub polling is
+// SDK-only, but as of PR #5207 orchestrator.execution.mode IS wired through
+// to the SDK poller (see poller_github.go's pollerDeps.ExecutionMode) — the
+// mode is no longer dropped on the floor; only an empty/unset mode falls
+// back to the SDK's own default (auto).
 type executionMode string
 
 const (
@@ -930,6 +933,15 @@ Examples:
 								if proj.Approval != nil {
 									gwBoardOpts = append(gwBoardOpts, autopilot.WithApprovalOverride(proj.Approval))
 								}
+							}
+							// GH-5242/TASK-486: thread the execution mode through so the
+							// iteration-limit close-vs-hold branch in controller.go can see
+							// it — cfg.Orchestrator.Autopilot is a *Config pointer shared by
+							// every controller this process constructs, so this assignment
+							// is visible to all of them, but it's set at each call site to
+							// keep the wiring obvious at each construction point.
+							if cfg.Orchestrator.Execution != nil {
+								cfg.Orchestrator.Autopilot.ExecutionMode = cfg.Orchestrator.Execution.Mode
 							}
 							gwAutopilotController = autopilot.NewController(
 								cfg.Orchestrator.Autopilot,
@@ -2369,6 +2381,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 							ctrlOpts = append(ctrlOpts, autopilot.WithApprovalOverride(proj.Approval))
 						}
 					}
+					// GH-5242/TASK-486: thread the execution mode through so the
+					// iteration-limit close-vs-hold branch in controller.go can see it.
+					if cfg.Orchestrator.Execution != nil {
+						cfg.Orchestrator.Autopilot.ExecutionMode = cfg.Orchestrator.Execution.Mode
+					}
 					controller := autopilot.NewController(
 						cfg.Orchestrator.Autopilot,
 						apGHClient,
@@ -2434,6 +2451,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				// gate and ApprovalSource channel).
 				if proj.Approval != nil {
 					ctrlOpts = append(ctrlOpts, autopilot.WithApprovalOverride(proj.Approval))
+				}
+				// GH-5242/TASK-486: thread the execution mode through so the
+				// iteration-limit close-vs-hold branch in controller.go can see it.
+				if cfg.Orchestrator.Execution != nil {
+					cfg.Orchestrator.Autopilot.ExecutionMode = cfg.Orchestrator.Execution.Mode
 				}
 				controller := autopilot.NewController(
 					cfg.Orchestrator.Autopilot,

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3586,36 +3586,51 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 				"issue", prState.IssueNumber,
 				"iteration", iteration,
 				"max", c.config.MaxCIFixIterations,
+				"execution_mode", c.config.ExecutionMode,
 			)
 
-			// Close the failed PR so the sequential poller can unblock
-			if err := c.ghClient.ClosePullRequest(ctx, c.owner, c.repo, prState.PRNumber); err != nil {
-				c.log.Warn("failed to close failed PR", "pr", prState.PRNumber, "error", err)
-			}
-
-			// GH-3260: Sync board card to "Blocked/Failed" column on execution failure (iteration limit).
-			if c.boardSync != nil && prState.IssueNodeID != "" && c.failStatus != "" {
-				if err := c.boardSync.UpdateProjectItemStatus(ctx, prState.IssueNodeID, c.failStatus); err != nil {
-					c.log.Warn("board sync on exec failure (iteration limit) failed", "pr", prState.PRNumber, "error", err)
-					c.alertBoardSyncScopeFailureOnce(err)
-				}
-			}
-
-			// GH-3806: name the reason and terminal outcome so notifyExternalClose
-			// (which fires on the next poll once it sees this PR closed) can post a
-			// PR/issue comment and correct the issue's labels instead of silently
-			// leaving a stale pilot-in-progress/pilot-done on discarded work.
 			reason := fmt.Sprintf("CI fix iteration limit reached (%d/%d): stopping cascade to prevent infinite loop", iteration, c.config.MaxCIFixIterations)
 			if len(failedChecks) > 0 {
 				reason = fmt.Sprintf("%s (failing checks: %s)", reason, strings.Join(failedChecks, ", "))
 			}
-			prState.Stage = StageFailed
-			prState.Error = reason
-			prState.TerminalLabel = github.LabelFailed
+
+			if c.config.ExecutionMode == executionModeSequential {
+				// Close the failed PR so the sequential poller can unblock
+				if err := c.ghClient.ClosePullRequest(ctx, c.owner, c.repo, prState.PRNumber); err != nil {
+					c.log.Warn("failed to close failed PR", "pr", prState.PRNumber, "error", err)
+				}
+
+				// GH-3260: Sync board card to "Blocked/Failed" column on execution failure (iteration limit).
+				if c.boardSync != nil && prState.IssueNodeID != "" && c.failStatus != "" {
+					if err := c.boardSync.UpdateProjectItemStatus(ctx, prState.IssueNodeID, c.failStatus); err != nil {
+						c.log.Warn("board sync on exec failure (iteration limit) failed", "pr", prState.PRNumber, "error", err)
+						c.alertBoardSyncScopeFailureOnce(err)
+					}
+				}
+
+				// GH-3806: name the reason and terminal outcome so notifyExternalClose
+				// (which fires on the next poll once it sees this PR closed) can post a
+				// PR/issue comment and correct the issue's labels instead of silently
+				// leaving a stale pilot-in-progress/pilot-done on discarded work.
+				prState.Stage = StageFailed
+				prState.Error = reason
+				prState.TerminalLabel = github.LabelFailed
+				c.metrics.RecordIssueProcessed("failed")
+			} else {
+				// GH-5227/TASK-486: under any non-sequential mode (including
+				// empty/unset, which defaults to auto) nothing is blocked
+				// waiting on this PR to close — the SDK poller dispatches
+				// independently — so closing here would discard the branch
+				// and any salvageable work for no benefit. Hold for a human
+				// instead, mirroring the other escalateAndHold branches in
+				// this function; notifyExternalClose only fires on an
+				// actual close, so the comment is posted inline here.
+				comment := fmt.Sprintf("%s No further automated CI-fix attempts will be made.", reason)
+				c.escalateAndHold(ctx, prState, reason, []string{labelNeedsHuman}, comment)
+			}
 			c.metrics.RecordPRFailed()
 			c.metrics.RecordPRFailedClass(failureClass)
 			c.recordCIFailVerdict(failureClass)
-			c.metrics.RecordIssueProcessed("failed")
 			return nil
 		}
 	}
@@ -4041,18 +4056,30 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 				"pr", prState.PRNumber,
 				"iteration", iteration,
 				"max", c.config.ReviewFeedback.MaxIterations,
+				"execution_mode", c.config.ExecutionMode,
 			)
 
-			if err := c.ghClient.ClosePullRequest(ctx, c.owner, c.repo, prState.PRNumber); err != nil {
-				c.log.Warn("failed to close PR", "pr", prState.PRNumber, "error", err)
-			}
+			reason := fmt.Sprintf("review feedback iteration limit reached (%d/%d)", iteration, c.config.ReviewFeedback.MaxIterations)
 
 			// GH-3806: see the matching comment on handleCIFailed's iteration-limit branch.
-			prState.Stage = StageFailed
-			prState.Error = fmt.Sprintf("review feedback iteration limit reached (%d/%d)", iteration, c.config.ReviewFeedback.MaxIterations)
-			prState.TerminalLabel = github.LabelFailed
+			if c.config.ExecutionMode == executionModeSequential {
+				if err := c.ghClient.ClosePullRequest(ctx, c.owner, c.repo, prState.PRNumber); err != nil {
+					c.log.Warn("failed to close PR", "pr", prState.PRNumber, "error", err)
+				}
+
+				prState.Stage = StageFailed
+				prState.Error = reason
+				prState.TerminalLabel = github.LabelFailed
+				c.metrics.RecordIssueProcessed("failed")
+			} else {
+				// GH-5227/TASK-486: see the matching comment on handleCIFailed's
+				// iteration-limit branch — nothing is blocked waiting on this PR
+				// to close under non-sequential dispatch, so hold for a human
+				// instead of discarding the branch.
+				comment := fmt.Sprintf("%s No further automated revision attempts will be made.", reason)
+				c.escalateAndHold(ctx, prState, reason, []string{labelNeedsHuman}, comment)
+			}
 			c.metrics.RecordPRFailed()
-			c.metrics.RecordIssueProcessed("failed")
 			return nil
 		}
 	}

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -4563,6 +4563,10 @@ func TestController_CIFixCascadeLimit(t *testing.T) {
 	cfg.CIPollInterval = 10 * time.Millisecond
 	cfg.CIWaitTimeout = 1 * time.Second
 	cfg.MaxCIFixIterations = 3
+	// GH-5242/TASK-486: this test exercises the sequential close-at-limit
+	// behavior; non-sequential modes hold instead (see
+	// TestHandleCIFailed_IterationLimit_ExecutionModeGate).
+	cfg.ExecutionMode = "sequential"
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
 	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc1234", "pilot/GH-10", "")
@@ -4693,6 +4697,10 @@ func TestController_CIFailedClose_PostsCommentsAndCorrectsLabels(t *testing.T) {
 	cfg.CIPollInterval = 10 * time.Millisecond
 	cfg.CIWaitTimeout = 1 * time.Second
 	cfg.MaxCIFixIterations = 3
+	// GH-5242/TASK-486: this test targets the sequential close + notifyExternalClose
+	// audit trail; non-sequential modes hold instead (see
+	// TestHandleCIFailed_IterationLimit_ExecutionModeGate).
+	cfg.ExecutionMode = "sequential"
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
 	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc1234", "pilot/GH-10", "")
@@ -6620,6 +6628,104 @@ func TestController_HandleReviewRequested_IterationLimit(t *testing.T) {
 	}
 	if !strings.Contains(pr.Error, "iteration limit") {
 		t.Errorf("error should mention iteration limit: %s", pr.Error)
+	}
+}
+
+// TestHandleReviewRequested_IterationLimit_ExecutionModeGate is GH-5242/
+// TASK-486: mirrors TestHandleCIFailed_IterationLimit_ExecutionModeGate for
+// the review-feedback iteration-limit branch — "sequential" closes the PR,
+// every other mode (including empty/unset, which defaults to auto) holds it
+// for a human instead, and no continuation revision issue is ever spawned
+// once the limit is hit.
+func TestHandleReviewRequested_IterationLimit_ExecutionModeGate(t *testing.T) {
+	tests := []struct {
+		name          string
+		executionMode string
+		wantClose     bool
+		wantLabel     string
+	}{
+		{name: "sequential closes and labels failed", executionMode: "sequential", wantClose: true, wantLabel: github.LabelFailed},
+		{name: "auto holds, no close", executionMode: "auto", wantClose: false, wantLabel: ""},
+		{name: "parallel holds, no close", executionMode: "parallel", wantClose: false, wantLabel: ""},
+		{name: "unset (empty) holds, no close", executionMode: "", wantClose: false, wantLabel: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var closeCalled bool
+			var revisionIssueSpawned bool
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/repos/owner/repo/pulls/42/reviews":
+					resp := []*github.PullRequestReview{
+						{ID: 1, User: github.User{Login: "alice"}, Body: "Still broken", State: "CHANGES_REQUESTED"},
+					}
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(mustJSON(t, resp))
+				case r.URL.Path == "/repos/owner/repo/pulls/42/comments":
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+				case r.URL.Path == "/repos/owner/repo/issues/10" && r.Method == http.MethodGet:
+					// Return issue with iteration=3 metadata (at limit)
+					resp := github.Issue{
+						Number: 10,
+						Body:   "some body\n<!-- autopilot-meta branch:pilot/GH-10 pr:42 iteration:3 -->",
+					}
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(mustJSON(t, resp))
+				case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == http.MethodPatch:
+					closeCalled = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(mustJSON(t, github.PullRequest{Number: 42, State: "closed"}))
+				case r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues":
+					revisionIssueSpawned = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"number":99}`))
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.ReviewFeedback = &ReviewFeedbackConfig{Enabled: true, MaxIterations: 3}
+			cfg.ExecutionMode = tt.executionMode
+
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+			c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", "")
+
+			c.mu.Lock()
+			c.activePRs[42].Stage = StageReviewRequested
+			c.mu.Unlock()
+
+			err := c.ProcessPR(context.Background(), 42, nil)
+			if err != nil {
+				t.Fatalf("ProcessPR error: %v", err)
+			}
+
+			pr, ok := c.GetPRState(42)
+			if !ok {
+				t.Fatal("PR should still be tracked")
+			}
+			if pr.Stage != StageFailed {
+				t.Errorf("stage = %s, want %s", pr.Stage, StageFailed)
+			}
+			if !strings.Contains(pr.Error, "review feedback iteration limit reached") {
+				t.Errorf("error should mention the review feedback iteration limit: %s", pr.Error)
+			}
+			if pr.TerminalLabel != tt.wantLabel {
+				t.Errorf("TerminalLabel = %q, want %q", pr.TerminalLabel, tt.wantLabel)
+			}
+			if closeCalled != tt.wantClose {
+				t.Errorf("ClosePullRequest called = %v, want %v", closeCalled, tt.wantClose)
+			}
+			if revisionIssueSpawned {
+				t.Error("no continuation revision issue should be spawned when the review-feedback iteration limit is hit")
+			}
+		})
 	}
 }
 
@@ -10508,6 +10614,11 @@ func TestController_IssuesProcessed_TerminalFailure(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
 	cfg.MaxCIFixIterations = 3
+	// GH-5242/TASK-486: RecordIssueProcessed("failed") only fires on the
+	// sequential close path today, matching the sibling escalateAndHold
+	// branches in handleCIFailed (zero-evidence, size guard, preflight
+	// declined), none of which record it either.
+	cfg.ExecutionMode = "sequential"
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
 	c.OnPRCreated(55, "https://github.com/owner/repo/pull/55", 20, "failsha1", "pilot/GH-20", "")
 	pr, _ := c.GetPRState(55)
@@ -11437,6 +11548,10 @@ func TestController_handleCIFailed_BoardSync_IterationLimit(t *testing.T) {
 			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			cfg := DefaultConfig()
 			cfg.MaxCIFixIterations = 3 // iteration = 3 >= MaxCIFixIterations = 3 → limit hit
+			// GH-5242/TASK-486: the close + board-sync behavior this test
+			// exercises only happens under execution_mode "sequential" —
+			// other modes hold instead (see TestHandleCIFailed_IterationLimit_ExecutionModeGate).
+			cfg.ExecutionMode = "sequential"
 
 			opt := withBoardSyncerForTest(mock, "Done", tt.failStatus, "In Review", "")
 			c := NewController(cfg, ghClient, nil, "owner", "repo", opt)
@@ -11468,6 +11583,98 @@ func TestController_handleCIFailed_BoardSync_IterationLimit(t *testing.T) {
 				if got.statusName != tt.failStatus {
 					t.Errorf("statusName = %q, want %q", got.statusName, tt.failStatus)
 				}
+			}
+		})
+	}
+}
+
+// TestHandleCIFailed_IterationLimit_ExecutionModeGate is GH-5242/TASK-486:
+// under execution_mode "sequential" the CI-fix iteration-limit branch closes
+// the PR (unblocking the sequential poller's per-PR MergeWaiter, which would
+// otherwise wait on a PR that will never merge). Under any other mode —
+// "auto", "parallel", or empty/unset (which defaults to auto) — nothing is
+// blocked waiting on this PR to close, so it must hold the PR for a human
+// (escalateAndHold) instead of discarding the branch. Either way no
+// continuation fix issue is spawned once the limit is hit.
+func TestHandleCIFailed_IterationLimit_ExecutionModeGate(t *testing.T) {
+	tests := []struct {
+		name          string
+		executionMode string
+		wantClose     bool
+		wantLabel     string
+	}{
+		{name: "sequential closes and labels failed", executionMode: "sequential", wantClose: true, wantLabel: github.LabelFailed},
+		{name: "auto holds, no close", executionMode: "auto", wantClose: false, wantLabel: ""},
+		{name: "parallel holds, no close", executionMode: "parallel", wantClose: false, wantLabel: ""},
+		{name: "unset (empty) holds, no close", executionMode: "", wantClose: false, wantLabel: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var closeCalled bool
+			var fixIssueSpawned bool
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/issues/") && !strings.Contains(r.URL.Path, "/comments"):
+					// Iteration counter at the limit (3).
+					_, _ = fmt.Fprintf(w, `{"number":10,"body":"<!-- autopilot-meta iteration:3 -->"}`)
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+					// GH-4779: a genuine code failure so classifyPRFailure sees
+					// positive evidence and reaches the iteration-limit check
+					// instead of short-circuiting into the zero-evidence guard.
+					_, _ = fmt.Fprintf(w, `{"total_count":1,"check_runs":[{"id":200,"name":"test","status":"completed","conclusion":"failure"}]}`)
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/actions/jobs/200/logs"):
+					_, _ = w.Write([]byte("--- FAIL: TestSomething\nassertion failed: expected true, got false"))
+				case r.Method == http.MethodPatch && r.URL.Path == "/repos/owner/repo/pulls/42":
+					// ClosePullRequest issues a PATCH {"state":"closed"}, not a DELETE.
+					closeCalled = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"number":42,"state":"closed"}`))
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/repos/owner/repo/issues"):
+					fixIssueSpawned = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"number":99}`))
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.MaxCIFixIterations = 3 // iteration = 3 >= 3 → limit hit
+			cfg.ExecutionMode = tt.executionMode
+
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{
+				PRNumber:    42,
+				IssueNumber: 10,
+				HeadSHA:     "abc123",
+				BranchName:  "pilot/GH-10",
+			}
+
+			err := c.handleCIFailed(context.Background(), prState)
+			if err != nil {
+				t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+			}
+
+			if prState.Stage != StageFailed {
+				t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+			}
+			if !strings.Contains(prState.Error, "CI fix iteration limit reached") {
+				t.Errorf("Error = %q, want it to mention the CI fix iteration limit", prState.Error)
+			}
+			if prState.TerminalLabel != tt.wantLabel {
+				t.Errorf("TerminalLabel = %q, want %q", prState.TerminalLabel, tt.wantLabel)
+			}
+			if closeCalled != tt.wantClose {
+				t.Errorf("ClosePullRequest called = %v, want %v", closeCalled, tt.wantClose)
+			}
+			if fixIssueSpawned {
+				t.Error("no continuation fix issue should be spawned when the CI-fix iteration limit is hit")
 			}
 		})
 	}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -78,6 +78,12 @@ type PostMergeConfig struct {
 	DeployBranch string `yaml:"deploy_branch,omitempty"`
 }
 
+// executionModeSequential is the one config.ExecutionConfig.Mode value the
+// controller branches on directly (GH-5242/TASK-486): see Config.ExecutionMode.
+// Mirrors cmd/pilot/main.go's local executionMode enum, kept as a plain
+// string here since the two packages intentionally don't share that type.
+const executionModeSequential = "sequential"
+
 // Config holds autopilot configuration for automated PR handling.
 type Config struct {
 	// Enabled controls whether autopilot mode is active.
@@ -141,6 +147,19 @@ type Config struct {
 	// Safety
 	// MaxFailures is the circuit breaker threshold before pausing autopilot.
 	MaxFailures int `yaml:"max_failures"`
+	// ExecutionMode mirrors config.ExecutionConfig.Mode ("sequential",
+	// "parallel", "auto", or "" for unset/default) — threaded in from
+	// cmd/pilot/main.go's three NewController call sites (GH-5242/TASK-486)
+	// rather than read from this struct's own YAML block, since it is really
+	// orchestrator.execution.mode, a config sibling of orchestrator.autopilot.
+	// The controller only branches on it in one place today: the CI-fix and
+	// review-feedback iteration-limit handlers close the failed PR under
+	// "sequential" (unblocking the SDK poller's per-PR MergeWaiter, which
+	// would otherwise wait on a PR that will never merge) but hold it for a
+	// human under any other value, including empty/unset — nothing is
+	// blocked on this PR closing under parallel/auto dispatch, so closing
+	// there would discard salvageable work for no benefit.
+	ExecutionMode string `yaml:"-"`
 	// MaxCIFixIterations limits how many CI fix issues can be chained before giving up.
 	// Prevents infinite fix cascades where each fix creates a new issue that also fails CI.
 	// Default: 3. Set to 0 to disable the limit.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5242.

Closes #5242

## Changes

Bundle Phases 1+2+3. Add `ExecutionMode string` to `internal/autopilot.Config` in `types.go`; thread `cfg.Orchestrator.Execution.Mode` through all three `NewController` call sites in `cmd/pilot/main.go` (~934, ~2372, ~2438). In `controller.go` gate both limit branches: `handleCIFailed` (~3583) and `handleReviewRequested` (~4039). Under `sequential`: preserve the existing close + `StageFailed` + `TerminalLabel=LabelFailed` + board sync + metrics behavior verbatim. Under any other mode (including empty/unset → treat as auto): do NOT call `ClosePullRequest`, do NOT delete the branch — hold via the existing `escalateAndHold` idiom (~7097), set `pilot-needs-human`, set `prState.Error` with the limit reason (`CI fix iteration limit reached (N/M)` and `review feedback iteration limit reached (N/M)`), let `notifyExternalClose` write the audit trail. Do NOT reorder the outage-breaker check (~3520) relative to the iteration check (~3573). Do NOT touch the normal continuation closes (~3749, ~4128) or any other `ClosePullRequest` sites. Verify held-at-limit PRs are terminal for the controller — confirm the `StageFailed` early-return at ~2805 covers them so admission/sweep/repick loops don't re-enter. Also correct the stale GH-4191-era comment at `cmd/pilot/main.go:67-73` (same file as the wiring) to reflect PR #5207 wiring mode to the SDK poller. Extend existing table-driven tests for `handleCIFailed` and `handleReviewRequested` in `internal/autopilot/` to cover both branches × {sequential, auto, parallel, unset} — assert `ClosePullRequest` called/not-called, stage, label, and that no continuation issue is spawned at the limit. Verify: `make build && go test ./internal/autopilot/ -run 'TestHandleCIFailed|TestHandleReviewRequested|IterationLimit' -v && make lint`.