### PR TITLE
GH-5247: fix(autopilot): healthy continuation hand-offs are recorded as pipeline failures — StageFailed/TerminalLabel conflation (GH-5227 leg 2)

### DIFF
--- a/.agent/tasks/gh-5247.md
+++ b/.agent/tasks/gh-5247.md
@@ -1,0 +1,58 @@
+# GH-5247
+
+**Created:** 2026-08-27
+
+## Problem
+
+GitHub Issue GH-5247: fix(autopilot): healthy continuation hand-offs are recorded as pipeline failures — StageFailed/TerminalLabel conflation (GH-5227 leg 2)
+
+## Problem
+
+Follow-up leg 2 of GH-5227 (verified during that investigation; deliberately out of scope for #5241, which shipped in v2.271.0). The HEALTHY continuation hand-off — a fix or revision issue was spawned successfully and the old PR closed by design — is recorded exactly like a genuine terminal failure:
+
+- After spawnFailureIssue or spawnReviewIssue succeeds, the old PR is staged StageFailed (pre-#5244 refs: `internal/autopilot/controller.go` ~3770 and ~4143 — re-verify line numbers, #5244 shifted this file).
+- Both spawn seams unconditionally set TerminalLabel to the failed label (~3408, ~4004) — even on success.
+- notifyExternalClose (~9118) branches on TerminalLabel, so a successful hand-off gets ReclassifyCompletionAsFailed plus an unconditional monitor Fail call (~9190).
+
+Consequence: every routine revision cycle is counted as a pipeline failure in the execution ledger, dashboard, and the RecordPRFailed metrics. Failure counts overcount by the healthy-revision rate and cannot be trusted as defect rates. This conflation is what made PR#615 in the reporter's log read as "defective" when it was a healthy hand-off. Feeds the TASK-460 delivery-evidence class.
+
+## Why this was not fixed casually
+
+Disambiguation today is via auxiliary flags (BreakerHoldActive, RebaseHoldActive, TerminalLabel), not distinct stage values. StageFailed is set by ~25 sites in `internal/autopilot/controller.go`, and several consumers gate on it. Any fix must inventory ALL of:
+
+1. ProcessPR terminal switch (~2805 — StageFailed is a terminal no-op)
+2. RestoreState skip-list (restart rehydration)
+3. `internal/autopilot/release_backfill.go:198` two-stage check
+4. isStackBaseCandidateStage (~6815)
+5. The three re-drive guards that gate on StageFailed + a hold flag: reAdoptHeldRebasePR (~7167), redriveFailedPRForBaseRetarget (~7257), ReDriveBreakerHeldPRs (~7336)
+6. notifyExternalClose — needs the least change; it already keys off TerminalLabel
+
+## Approach (decide in-task, but constraints are firm)
+
+Two viable shapes:
+- **A. New stage value** (e.g. a superseded/handed-off stage) set by the two healthy-close sites. Every consumer above must treat it exactly as it treats StageFailed for terminality/rehydration/re-drive purposes, differing ONLY in ledger/metrics/notification classification.
+- **B. Keep StageFailed, fix classification at the seams**: spawn seams set a distinct TerminalLabel (a superseded-style label already exists in the vocabulary per GH-4932) on the SUCCESS path only; notifyExternalClose then routes hand-offs away from ReclassifyCompletionAsFailed and the monitor Fail call. Smaller blast radius; re-drive guards and rehydration untouched.
+
+Option B is likely correct-sized — but whichever is chosen, the decision and the consumer inventory walk-through must be in the PR description.
+
+## Acceptance
+
+- A healthy continuation hand-off (revision issue spawned, old PR closed) is NOT recorded as a failure: no ReclassifyCompletionAsFailed, no monitor Fail, RecordPRFailed not incremented. Ledger row and dashboard reflect a hand-off/supersede outcome.
+- Genuine terminal failures (iteration limit under sequential, merge-conflict cap, spawn FAILURE — i.e. the continuation issue could not be created) are still recorded as failures, byte-identical to today.
+- All 6 consumer groups above verified against the change, with the walk-through in the PR description; restart rehydration and the three re-drive guards behave identically for held/failed PRs.
+- Table-driven tests: healthy hand-off vs spawn-failure vs limit-close, asserting ledger classification, monitor call, TerminalLabel, and notifyExternalClose routing for each.
+- No change to when PRs are closed or branches deleted — this leg is classification only. #5241's mode-gate behavior untouched.
+
+## Out of scope
+
+- Any change to close/hold behavior (shipped in #5241).
+- Backfilling historical ledger rows (note the overcount cutoff date in the PR description instead).
+
+## Refs
+
+- GH-5227 (external report; this leg is the "stage=failed on healthy hand-off" conflation acknowledged there)
+- #5241 / PR#5244 / PR#5245 (leg 1, shipped v2.271.0)
+- Related prior art: GH-4932 supersede label; GH-3806 notifyExternalClose audit-trail discipline
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3389,10 +3389,20 @@ func ciFailedChecksSummary(failedChecks []string) string {
 // having to remember it on its own:
 //
 //   - CreateFailureIssue succeeds (issueNum > 0, err == nil): the fix issue
-//     now owns recovery — prState.TerminalLabel is set to github.LabelFailed
-//     so notifyExternalClose (GH-3806) marks the source issue pilot-failed
+//     now owns recovery — prState.TerminalLabel is set to github.LabelSuperseded
+//     so notifyExternalClose (GH-3806) marks the source issue pilot-superseded
 //     instead of pilot-retry-ready, and it is never re-queued alongside the
-//     fix issue that already continues the work.
+//     fix issue that already continues the work. GH-5247: this is a HEALTHY
+//     hand-off (the source PR is being closed by design because a fix issue
+//     now continues the work), not a terminal failure — it must not be
+//     classified or metered as one. Before GH-5247 this branch set
+//     github.LabelFailed, which fed the source PR into notifyExternalClose's
+//     failure path (ReclassifyCompletionAsFailed + monitor.Fail) even though
+//     nothing failed; every routine revision cycle was overcounted as a
+//     pipeline failure. LabelSuperseded already carries the "closed on
+//     purpose, not a defect" semantics GH-4657/GH-4701 built for the sibling
+//     conflict-close path, and notifyExternalClose already branches on it via
+//     supersededClose — reusing it here needed no new plumbing.
 //   - CreateFailureIssue declines or fails (dedup/budget claim in flight,
 //     GH-4307; or a transient create error): no fix issue exists to own the
 //     work, so prState.TerminalLabel is left untouched — the source retry
@@ -3405,7 +3415,7 @@ func ciFailedChecksSummary(failedChecks []string) string {
 func (c *Controller) spawnFailureIssue(ctx context.Context, prState *PRState, failureType FailureType, failedChecks []string, logs string, iteration int) (int, error) {
 	issueNum, err := c.feedbackLoop.CreateFailureIssue(ctx, prState, failureType, failedChecks, logs, iteration)
 	if err == nil && issueNum > 0 {
-		prState.TerminalLabel = github.LabelFailed
+		prState.TerminalLabel = github.LabelSuperseded
 	}
 	return issueNum, err
 }
@@ -3778,14 +3788,19 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 
 	// GH-3806/GH-4826: name the reason (and the follow-up issue that now owns
 	// this work) so notifyExternalClose can post the audit-trail comments and
-	// mark this issue pilot-failed instead of leaving it stranded on a stale
-	// label. prState.TerminalLabel itself was already set by spawnFailureIssue
-	// above the moment CreateFailureIssue succeeded — it is not set here, so
-	// this rung cannot forget it the way the post-merge rung once did.
+	// mark this issue pilot-superseded instead of leaving it stranded on a
+	// stale label. prState.TerminalLabel itself was already set by
+	// spawnFailureIssue above the moment CreateFailureIssue succeeded — it is
+	// not set here, so this rung cannot forget it the way the post-merge rung
+	// once did. GH-5247: this is a healthy hand-off, not a pipeline failure —
+	// c.metrics.RecordPRFailed()/RecordPRFailedClass() are deliberately NOT
+	// called here (they overcounted every routine revision cycle as a
+	// defect). c.recordCIFailVerdict is kept: the CI run genuinely failed,
+	// which is an orthogonal, still-true fact tracked independently of
+	// whether the resulting PR close is classified as a failure or a
+	// hand-off.
 	prState.Stage = StageFailed
 	prState.Error = fmt.Sprintf("%s; fix issue #%d created to continue this work%s", ciFailedChecksSummary(failedChecks), issueNum, infraNote)
-	c.metrics.RecordPRFailed()
-	c.metrics.RecordPRFailedClass(failureClass)
 	c.recordCIFailVerdict(failureClass)
 	return nil
 }
@@ -4012,11 +4027,15 @@ func (c *Controller) logCIFailureClassification(prState *PRState, checks []Faile
 // GH-4826 fixed for CI failures, reintroduced on this sibling path. Routing
 // through this seam instead means the designation happens the moment
 // CreateReviewIssue actually returns a live issue, strictly before the PR is
-// ever closed, matching spawnFailureIssue's ordering exactly.
+// ever closed, matching spawnFailureIssue's ordering exactly. GH-5247: on
+// success this is a healthy hand-off (a revision issue now continues the
+// work), so TerminalLabel is set to github.LabelSuperseded rather than
+// github.LabelFailed — see spawnFailureIssue's doc comment for the full
+// rationale, which applies identically here.
 func (c *Controller) spawnReviewIssue(ctx context.Context, prState *PRState, reviews []*github.PullRequestReview, comments []*github.PRReviewComment, iteration int) (int, error) {
 	issueNum, err := c.feedbackLoop.CreateReviewIssue(ctx, prState, reviews, comments, iteration)
 	if err == nil && issueNum > 0 {
-		prState.TerminalLabel = github.LabelFailed
+		prState.TerminalLabel = github.LabelSuperseded
 	}
 	return issueNum, err
 }
@@ -4166,10 +4185,13 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 	// audit-trail comments. prState.TerminalLabel itself was already set by
 	// spawnReviewIssue above the moment CreateReviewIssue succeeded — it is
 	// not set here, so this rung cannot forget it (mirrors the matching
-	// comment on handleCIFailed's main CI-fail branch).
+	// comment on handleCIFailed's main CI-fail branch). GH-5247: a revision
+	// issue was spawned successfully, so this is a healthy hand-off rather
+	// than a pipeline failure — c.metrics.RecordPRFailed() is deliberately
+	// NOT called here (see spawnFailureIssue's doc comment for the full
+	// rationale).
 	prState.Stage = StageFailed
 	prState.Error = fmt.Sprintf("changes requested by reviewer; revision issue #%d created to continue this work", issueNum)
-	c.metrics.RecordPRFailed()
 	return nil
 }
 
@@ -9268,7 +9290,14 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 	// (subtask 1 only rescues Running/Queued/Pending cards). Without this
 	// event-driven call the card is left showing "done" indefinitely even
 	// though the PR it shipped was discarded unmerged.
-	if c.monitor != nil && prState.IssueNumber > 0 {
+	//
+	// GH-5247: skip this for a supersededClose — the card's existing
+	// StatusCompleted (set by monitor.Complete() above) already reflects a
+	// healthy hand-off; there is no dedicated "superseded" Monitor status, so
+	// leaving the card at Completed rather than flipping it to Failed is the
+	// accurate outcome (mirrors the same supersededClose split used for the
+	// evalStore reclassify calls above).
+	if c.monitor != nil && prState.IssueNumber > 0 && !supersededClose {
 		c.monitor.Fail(fmt.Sprintf("GH-%d", prState.IssueNumber), reason)
 	}
 

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -3067,8 +3067,8 @@ func TestHandleCIFailed_InfraFailure_RetryBudgetExhausted(t *testing.T) {
 	if got := snap.CIRuns["fail"]; got != 0 {
 		t.Errorf("CIRuns[fail] = %d, want 0 (budget-exhausted infra failure records infra_fail)", got)
 	}
-	if got := snap.PRFailureClasses["infra"]; got != 1 {
-		t.Errorf("PRFailureClasses[infra] = %d, want 1", got)
+	if got := snap.PRFailureClasses["infra"]; got != 0 {
+		t.Errorf("PRFailureClasses[infra] = %d, want 0 (GH-5247: a fix issue was spawned — this is a healthy hand-off, not a pipeline failure)", got)
 	}
 }
 
@@ -3393,8 +3393,8 @@ internal/autopilot/controller.go:1234:6: Error return value of c.ghClient.CloseP
 	if got := snap.CIRuns["infra_fail"]; got != 0 {
 		t.Errorf("CIRuns[infra_fail] = %d, want 0", got)
 	}
-	if got := snap.PRFailureClasses["code"]; got != 1 {
-		t.Errorf("PRFailureClasses[code] = %d, want 1", got)
+	if got := snap.PRFailureClasses["code"]; got != 0 {
+		t.Errorf("PRFailureClasses[code] = %d, want 0 (GH-5247: a fix issue was spawned — this is a healthy hand-off, not a pipeline failure)", got)
 	}
 }
 

--- a/internal/autopilot/gh4826_test.go
+++ b/internal/autopilot/gh4826_test.go
@@ -110,29 +110,31 @@ internal/autopilot/controller.go:1234:6: Error return value of c.ghClient.CloseP
 	// The core invariant: the spawn seam must have marked the source PR
 	// state terminal so the source issue is not left eligible for a
 	// competing retry re-queue. This is recorded controller state, not a
-	// mock echo.
-	if prState.TerminalLabel != github.LabelFailed {
-		t.Fatalf("prState.TerminalLabel = %q, want %q (fix issue now owns recovery)", prState.TerminalLabel, github.LabelFailed)
+	// mock echo. GH-5247: a successful spawn is a healthy hand-off, not a
+	// pipeline failure, so the recorded label is LabelSuperseded rather than
+	// LabelFailed.
+	if prState.TerminalLabel != github.LabelSuperseded {
+		t.Fatalf("prState.TerminalLabel = %q, want %q (fix issue now owns recovery)", prState.TerminalLabel, github.LabelSuperseded)
 	}
 
 	// Downstream: notifyExternalClose (GH-3806) must read that recorded
-	// state and label the source issue pilot-failed, never
+	// state and label the source issue pilot-superseded, never
 	// pilot-retry-ready — the exact #4818 shape where both fix-issue and
 	// source-retry chains armed simultaneously.
 	c.notifyExternalClose(context.Background(), prState)
 
-	foundFailed := false
+	foundSuperseded := false
 	foundRetryReady := false
 	for _, l := range issueLabelsAdded {
-		if l == github.LabelFailed {
-			foundFailed = true
+		if l == github.LabelSuperseded {
+			foundSuperseded = true
 		}
 		if l == github.LabelRetryReady {
 			foundRetryReady = true
 		}
 	}
-	if !foundFailed {
-		t.Errorf("expected source issue to be labeled %q, got labels added: %v", github.LabelFailed, issueLabelsAdded)
+	if !foundSuperseded {
+		t.Errorf("expected source issue to be labeled %q, got labels added: %v", github.LabelSuperseded, issueLabelsAdded)
 	}
 	if foundRetryReady {
 		t.Errorf("source issue must NOT be labeled %q once a fix issue owns recovery — this is the #4818 dual-arm shape; labels added: %v", github.LabelRetryReady, issueLabelsAdded)
@@ -316,9 +318,11 @@ func TestGH4826_TerminalLabelOwnershipLivesAtSpawnSeam(t *testing.T) {
 		t.Errorf("the single direct CreateFailureIssue call must be inside spawnFailureIssue (bytes %d-%d), found at byte %d", seamStart, seamEnd, directCalls[0][0])
 	}
 
-	// The TerminalLabel = github.LabelFailed assignment that fires on spawn
-	// success must appear exactly once inside that same seam.
-	spawnSuccessAssignRe := regexp.MustCompile(`prState\.TerminalLabel = github\.LabelFailed`)
+	// The TerminalLabel = github.LabelSuperseded assignment that fires on
+	// spawn success must appear exactly once inside that same seam. GH-5247:
+	// a successful spawn is a healthy hand-off, not a pipeline failure, so
+	// the seam marks the source LabelSuperseded rather than LabelFailed.
+	spawnSuccessAssignRe := regexp.MustCompile(`prState\.TerminalLabel = github\.LabelSuperseded`)
 	allAssigns := spawnSuccessAssignRe.FindAllStringIndex(text, -1)
 	inSeam := 0
 	for _, m := range allAssigns {
@@ -327,7 +331,7 @@ func TestGH4826_TerminalLabelOwnershipLivesAtSpawnSeam(t *testing.T) {
 		}
 	}
 	if inSeam != 1 {
-		t.Errorf("expected exactly 1 `prState.TerminalLabel = github.LabelFailed` assignment inside spawnFailureIssue, found %d", inSeam)
+		t.Errorf("expected exactly 1 `prState.TerminalLabel = github.LabelSuperseded` assignment inside spawnFailureIssue, found %d", inSeam)
 	}
 
 	// Both known CI-failure rungs must call the seam, not the raw method.

--- a/internal/autopilot/gh4841_test.go
+++ b/internal/autopilot/gh4841_test.go
@@ -123,8 +123,14 @@ internal/autopilot/controller.go:1:1: some lint error (errcheck)
 	if !prClosed {
 		t.Fatal("expected the source PR to be closed once the fix issue was spawned")
 	}
-	if seedPR.TerminalLabel != github.LabelFailed {
-		t.Fatalf("prState.TerminalLabel = %q, want %q before the simulated crash", seedPR.TerminalLabel, github.LabelFailed)
+	// GH-5247: a successful spawn is a healthy hand-off, so the in-memory
+	// designation is LabelSuperseded, not LabelFailed. The durable fallback
+	// exercised after the simulated crash below is unaffected by GH-5247 —
+	// it still hardcodes LabelFailed (accepted residual: a restart loses
+	// TerminalLabel entirely, so the fallback cannot distinguish a lost
+	// hand-off designation from a lost failure designation).
+	if seedPR.TerminalLabel != github.LabelSuperseded {
+		t.Fatalf("prState.TerminalLabel = %q, want %q before the simulated crash", seedPR.TerminalLabel, github.LabelSuperseded)
 	}
 	// Deliberately do NOT call controllerA.persistPRState(seedPR) here — this
 	// is the crash.
@@ -257,8 +263,10 @@ func TestGH4841_ReviewRequestedCrashWindow_RetryNotArmedAfterRestart(t *testing.
 	if !prClosed {
 		t.Fatal("expected the source PR to be closed once the revision issue was spawned")
 	}
-	if seedPR.TerminalLabel != github.LabelFailed {
-		t.Fatalf("prState.TerminalLabel = %q, want %q before the simulated crash", seedPR.TerminalLabel, github.LabelFailed)
+	// GH-5247: healthy hand-off — see the matching comment in the CI-failure
+	// crash-window test above.
+	if seedPR.TerminalLabel != github.LabelSuperseded {
+		t.Fatalf("prState.TerminalLabel = %q, want %q before the simulated crash", seedPR.TerminalLabel, github.LabelSuperseded)
 	}
 	// Simulated crash: no persistPRState call.
 

--- a/internal/autopilot/gh4856_test.go
+++ b/internal/autopilot/gh4856_test.go
@@ -155,8 +155,8 @@ func TestHandleReviewRequested_CreateIssueErrors_EscalatesInsteadOfClosing(t *te
 	if !branchDeleted.Load() {
 		t.Error("expected branch to be deleted once the review issue was successfully created on retry")
 	}
-	if prState.TerminalLabel != github.LabelFailed {
-		t.Errorf("TerminalLabel = %q, want %q after a successful review-issue create", prState.TerminalLabel, github.LabelFailed)
+	if prState.TerminalLabel != github.LabelSuperseded {
+		t.Errorf("TerminalLabel = %q, want %q after a successful review-issue create (GH-5247: healthy hand-off, not a failure)", prState.TerminalLabel, github.LabelSuperseded)
 	}
 }
 

--- a/internal/autopilot/gh5247_test.go
+++ b/internal/autopilot/gh5247_test.go
@@ -1,0 +1,280 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestGH5247_HandleCIFailed_Classification is the GH-5247 regression guard:
+// a HEALTHY continuation hand-off (a fix issue was spawned and the old PR
+// closed by design, GH-4826/GH-4841's spawnFailureIssue seam) must not be
+// recorded as a pipeline failure, while genuine terminal failures — the
+// continuation issue could not be created (spawn-failure, GH-4459) and the
+// CI-fix iteration limit under sequential mode (limit-close, GH-5227/
+// TASK-486) — must still be recorded exactly as before.
+//
+// Table-driven across all three shapes, each asserting:
+//   - TerminalLabel the handler leaves on prState (spawn-seam ownership)
+//   - whether c.metrics.RecordPRFailed fired during the handler itself
+//   - how notifyExternalClose routes the eventual close: which evalStore
+//     reclassify/terminate variant fires, and whether monitor.Fail fires
+//
+// Before GH-5247 all three cases behaved identically (LabelFailed,
+// RecordPRFailed, ReclassifyCompletionAsFailed, monitor.Fail) — this test
+// would have failed to distinguish the healthy hand-off case at all.
+func TestGH5247_HandleCIFailed_Classification(t *testing.T) {
+	type wantShape struct {
+		terminalLabel       string
+		wantPRsFailed       int64
+		wantReclassifySuper bool // Superseded variant vs the plain Failed variant
+		wantTerminateSuper  bool
+		wantMonitorFail     bool
+	}
+
+	tests := []struct {
+		name       string
+		buildState func(t *testing.T) (*Controller, *PRState)
+		want       wantShape
+	}{
+		{
+			// GH-4826/GH-4826 spawn seam: CreateFailureIssue succeeds, so a fix
+			// issue now owns the work and the source PR is closed by design —
+			// a healthy hand-off, not a failure.
+			name: "healthy hand-off: fix issue spawned, PR closed by design",
+			buildState: func(t *testing.T) (*Controller, *PRState) {
+				const codeLog = `Run golangci-lint run ./...
+internal/autopilot/controller.go:1:1: some lint error (errcheck)
+##[error]Process completed with exit code 1.`
+
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.URL.Path == "/repos/owner/repo/commits/gh5247hoff/check-runs":
+						resp := github.CheckRunsResponse{
+							TotalCount: 1,
+							CheckRuns: []github.CheckRun{
+								{ID: 601, Name: "lint", Status: "completed", Conclusion: "failure"},
+							},
+						}
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(mustJSON(t, resp))
+					case r.URL.Path == "/repos/owner/repo/actions/jobs/601/logs":
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte(codeLog))
+					case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/53002":
+						// Iteration counter well below the limit.
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(mustJSON(t, github.Issue{Number: 53002, Body: "no-meta"}))
+					case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+						w.WriteHeader(http.StatusCreated)
+						_, _ = w.Write(mustJSON(t, github.Issue{Number: 53003}))
+					case r.URL.Path == "/repos/owner/repo/pulls/53001" && r.Method == http.MethodPatch:
+						w.WriteHeader(http.StatusOK)
+					default:
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte("{}"))
+					}
+				}))
+				t.Cleanup(server.Close)
+
+				ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+				c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+				prState := &PRState{
+					PRNumber:    53001,
+					IssueNumber: 53002,
+					HeadSHA:     "gh5247hoff",
+					Stage:       StageCIFailed,
+				}
+				if err := c.handleCIFailed(context.Background(), prState); err != nil {
+					t.Fatalf("handleCIFailed: %v", err)
+				}
+				return c, prState
+			},
+			want: wantShape{
+				terminalLabel:       github.LabelSuperseded,
+				wantPRsFailed:       0,
+				wantReclassifySuper: true,
+				wantTerminateSuper:  true,
+				wantMonitorFail:     false,
+			},
+		},
+		{
+			// GH-4459: CreateFailureIssue itself fails (transient create error),
+			// so no continuation exists to own the work — escalateAndHold holds
+			// the PR instead of closing it, and this remains a genuine failure.
+			name: "spawn-failure: continuation fix issue could not be created",
+			buildState: func(t *testing.T) (*Controller, *PRState) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.URL.Path == "/repos/owner/repo/commits/gh5247sfail/check-runs":
+						resp := github.CheckRunsResponse{
+							TotalCount: 1,
+							CheckRuns: []github.CheckRun{
+								{ID: 602, Name: "lint", Status: "completed", Conclusion: "failure"},
+							},
+						}
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(mustJSON(t, resp))
+					case r.URL.Path == "/repos/owner/repo/actions/jobs/602/logs":
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte("some failing log"))
+					case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/53102":
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(mustJSON(t, github.Issue{Number: 53102, Body: "no-meta"}))
+					case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+						// CreateFailureIssue fails.
+						w.WriteHeader(http.StatusInternalServerError)
+						_, _ = w.Write([]byte(`{"message":"internal server error"}`))
+					default:
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte("{}"))
+					}
+				}))
+				t.Cleanup(server.Close)
+
+				ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+				c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+				prState := &PRState{
+					PRNumber:    53101,
+					IssueNumber: 53102,
+					HeadSHA:     "gh5247sfail",
+					Stage:       StageCIFailed,
+				}
+				if err := c.handleCIFailed(context.Background(), prState); err != nil {
+					t.Fatalf("handleCIFailed: %v", err)
+				}
+				return c, prState
+			},
+			want: wantShape{
+				terminalLabel:       "",
+				wantPRsFailed:       1,
+				wantReclassifySuper: false,
+				wantTerminateSuper:  false,
+				wantMonitorFail:     true,
+			},
+		},
+		{
+			// GH-5227/TASK-486: the CI-fix iteration limit is reached under
+			// execution_mode "sequential" — the PR is closed unconditionally
+			// (no continuation issue is spawned at all) so the sequential
+			// poller's MergeWaiter can unblock. Unaffected by GH-5247: still a
+			// genuine terminal failure.
+			name: "limit-close: CI-fix iteration limit reached under sequential mode",
+			buildState: func(t *testing.T) (*Controller, *PRState) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/53202":
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(mustJSON(t, github.Issue{Number: 53202, Body: "<!-- autopilot-meta iteration:3 -->"}))
+					case r.URL.Path == "/repos/owner/repo/commits/gh5247limit/check-runs":
+						resp := github.CheckRunsResponse{
+							TotalCount: 1,
+							CheckRuns: []github.CheckRun{
+								{ID: 603, Name: "test", Status: "completed", Conclusion: "failure"},
+							},
+						}
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(mustJSON(t, resp))
+					case r.URL.Path == "/repos/owner/repo/actions/jobs/603/logs":
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte("--- FAIL: TestSomething\nassertion failed"))
+					case r.Method == http.MethodPatch && r.URL.Path == "/repos/owner/repo/pulls/53201":
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte(`{"number":53201,"state":"closed"}`))
+					default:
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte("{}"))
+					}
+				}))
+				t.Cleanup(server.Close)
+
+				ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+				cfg := DefaultConfig()
+				cfg.MaxCIFixIterations = 3 // iteration:3 >= 3 -> limit hit
+				cfg.ExecutionMode = "sequential"
+				c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+				prState := &PRState{
+					PRNumber:    53201,
+					IssueNumber: 53202,
+					HeadSHA:     "gh5247limit",
+					Stage:       StageCIFailed,
+				}
+				if err := c.handleCIFailed(context.Background(), prState); err != nil {
+					t.Fatalf("handleCIFailed: %v", err)
+				}
+				return c, prState
+			},
+			want: wantShape{
+				terminalLabel:       github.LabelFailed,
+				wantPRsFailed:       1,
+				wantReclassifySuper: false,
+				wantTerminateSuper:  false,
+				wantMonitorFail:     true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, prState := tt.buildState(t)
+
+			if prState.TerminalLabel != tt.want.terminalLabel {
+				t.Errorf("TerminalLabel = %q, want %q", prState.TerminalLabel, tt.want.terminalLabel)
+			}
+
+			snap := c.metrics.Snapshot()
+			if snap.PRsFailed != tt.want.wantPRsFailed {
+				t.Errorf("PRsFailed after handler = %d, want %d", snap.PRsFailed, tt.want.wantPRsFailed)
+			}
+
+			// Wire in fresh ledger/dashboard fakes and route the PR through
+			// notifyExternalClose exactly as the external-close poll scan
+			// would once it observes this PR closed — whether Pilot itself
+			// closed it (hand-off, limit-close) or a human closed it later
+			// while it sat held open (spawn-failure).
+			evalMock := &mockEvalStore{}
+			c.SetEvalStore(evalMock)
+			monitorMock := newMockTaskMonitor()
+			c.SetMonitor(monitorMock)
+
+			c.notifyExternalClose(context.Background(), prState)
+
+			gotReclassifySuper := len(evalMock.reclassifiedSuperseded) == 1
+			gotReclassifyFailed := len(evalMock.reclassified) == 1
+			if gotReclassifySuper != tt.want.wantReclassifySuper {
+				t.Errorf("ReclassifyCompletionAsSuperseded called = %v, want %v (calls: %+v)",
+					gotReclassifySuper, tt.want.wantReclassifySuper, evalMock.reclassifiedSuperseded)
+			}
+			if gotReclassifyFailed == tt.want.wantReclassifySuper {
+				t.Errorf("ReclassifyCompletionAsFailed called = %v, want %v (calls: %+v)",
+					gotReclassifyFailed, !tt.want.wantReclassifySuper, evalMock.reclassified)
+			}
+
+			gotTerminateSuper := len(evalMock.terminatedSuperseded) == 1
+			gotTerminateFailed := len(evalMock.terminated) == 1
+			if gotTerminateSuper != tt.want.wantTerminateSuper {
+				t.Errorf("TerminateNonTerminalExecutionAsSuperseded called = %v, want %v (calls: %+v)",
+					gotTerminateSuper, tt.want.wantTerminateSuper, evalMock.terminatedSuperseded)
+			}
+			if gotTerminateFailed == tt.want.wantTerminateSuper {
+				t.Errorf("TerminateNonTerminalExecution called = %v, want %v (calls: %+v)",
+					gotTerminateFailed, !tt.want.wantTerminateSuper, evalMock.terminated)
+			}
+
+			taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
+			_, gotMonitorFail := monitorMock.failedTasks[taskID]
+			if gotMonitorFail != tt.want.wantMonitorFail {
+				t.Errorf("monitor.Fail called for %s = %v, want %v (failedTasks: %+v)",
+					taskID, gotMonitorFail, tt.want.wantMonitorFail, monitorMock.failedTasks)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5247.

Closes #5247

## Changes

GitHub Issue GH-5247: fix(autopilot): healthy continuation hand-offs are recorded as pipeline failures — StageFailed/TerminalLabel conflation (GH-5227 leg 2)

## Problem

Follow-up leg 2 of GH-5227 (verified during that investigation; deliberately out of scope for #5241, which shipped in v2.271.0). The HEALTHY continuation hand-off — a fix or revision issue was spawned successfully and the old PR closed by design — is recorded exactly like a genuine terminal failure:

- After spawnFailureIssue or spawnReviewIssue succeeds, the old PR is staged StageFailed (pre-#5244 refs: `internal/autopilot/controller.go` ~3770 and ~4143 — re-verify line numbers, #5244 shifted this file).
- Both spawn seams unconditionally set TerminalLabel to the failed label (~3408, ~4004) — even on success.
- notifyExternalClose (~9118) branches on TerminalLabel, so a successful hand-off gets ReclassifyCompletionAsFailed plus an unconditional monitor Fail call (~9190).

Consequence: every routine revision cycle is counted as a pipeline failure in the execution ledger, dashboard, and the RecordPRFailed metrics. Failure counts overcount by the healthy-revision rate and cannot be trusted as defect rates. This conflation is what made PR#615 in the reporter's log read as "defective" when it was a healthy hand-off. Feeds the TASK-460 delivery-evidence class.

## Why this was not fixed casually

Disambiguation today is via auxiliary flags (BreakerHoldActive, RebaseHoldActive, TerminalLabel), not distinct stage values. StageFailed is set by ~25 sites in `internal/autopilot/controller.go`, and several consumers gate on it. Any fix must inventory ALL of:

1. ProcessPR terminal switch (~2805 — StageFailed is a terminal no-op)
2. RestoreState skip-list (restart rehydration)
3. `internal/autopilot/release_backfill.go:198` two-stage check
4. isStackBaseCandidateStage (~6815)
5. The three re-drive guards that gate on StageFailed + a hold flag: reAdoptHeldRebasePR (~7167), redriveFailedPRForBaseRetarget (~7257), ReDriveBreakerHeldPRs (~7336)
6. notifyExternalClose — needs the least change; it already keys off TerminalLabel

## Approach (decide in-task, but constraints are firm)

Two viable shapes:
- **A. New stage value** (e.g. a superseded/handed-off stage) set by the two healthy-close sites. Every consumer above must treat it exactly as it treats StageFailed for terminality/rehydration/re-drive purposes, differing ONLY in ledger/metrics/notification classification.
- **B. Keep StageFailed, fix classification at the seams**: spawn seams set a distinct TerminalLabel (a superseded-style label already exists in the vocabulary per GH-4932) on the SUCCESS path only; notifyExternalClose then routes hand-offs away from ReclassifyCompletionAsFailed and the monitor Fail call. Smaller blast radius; re-drive guards and rehydration untouched.

Option B is likely correct-sized — but whichever is chosen, the decision and the consumer inventory walk-through must be in the PR description.

## Acceptance

- A healthy continuation hand-off (revision issue spawned, old PR closed) is NOT recorded as a failure: no ReclassifyCompletionAsFailed, no monitor Fail, RecordPRFailed not incremented. Ledger row and dashboard reflect a hand-off/supersede outcome.
- Genuine terminal failures (iteration limit under sequential, merge-conflict cap, spawn FAILURE — i.e. the continuation issue could not be created) are still recorded as failures, byte-identical to today.
- All 6 consumer groups above verified against the change, with the walk-through in the PR description; restart rehydration and the three re-drive guards behave identically for held/failed PRs.
- Table-driven tests: healthy hand-off vs spawn-failure vs limit-close, asserting ledger classification, monitor call, TerminalLabel, and notifyExternalClose routing for each.
- No change to when PRs are closed or branches deleted — this leg is classification only. #5241's mode-gate behavior untouched.

## Out of scope

- Any change to close/hold behavior (shipped in #5241).
- Backfilling historical ledger rows (note the overcount cutoff date in the PR description instead).

## Refs

- GH-5227 (external report; this leg is the "stage=failed on healthy hand-off" conflation acknowledged there)
- #5241 / PR#5244 / PR#5245 (leg 1, shipped v2.271.0)
- Related prior art: GH-4932 supersede label; GH-3806 notifyExternalClose audit-trail discipline