### PR TITLE
GH-5249: fix(autopilot): open pilot-superseded hand-off sources are re-dispatched unbounded — count superseded as terminal (PR#5248 remediation)

### DIFF
--- a/.agent/tasks/gh-5249.md
+++ b/.agent/tasks/gh-5249.md
@@ -1,0 +1,65 @@
+# GH-5249
+
+**Created:** 2026-08-27
+
+## Problem
+
+GitHub Issue GH-5249: fix(autopilot): open pilot-superseded hand-off sources are re-dispatched unbounded — count superseded as terminal (PR#5248 remediation)
+
+## Problem
+
+PR#5248 (GH-5247, StageFailed/TerminalLabel conflation fix) correctly stops recording healthy hand-offs as failures, but it mints a state nothing downstream expects: an **OPEN** issue labeled `{pilot, pilot-superseded}`. Historically every `pilot-superseded` issue was closed. Post-merge review verdict on PR#5248 has the full analysis; this issue is the remediation. **Deadline-relevant: PR#5248 merged after today's train cut, so the regression is not yet on the box — this fix must merge before the next 14:00Z train or the two ride together.**
+
+### Primary defect — unbounded re-dispatch of hand-off sources (dual-arm)
+
+After a hand-off close, the source issue stays open with `pilot-superseded`. The SDK poller's decision walk has no skip rung for that label on the issue itself:
+
+1. Pre-#5248, the `pilot-failed` rung routed the source to a bounded retry budget (3), then permanent failed-skip.
+2. Post-#5248: no label rung matches → processed-grace (~5 min) expires → no merged work (PR closed unmerged) → no terminal completion — `HasTerminalCompletion` (`internal/memory/store.go`, wired in `cmd/pilot/main.go`) counts only completed / no_op / canceled, and the hand-off demoted the row to `superseded` → **the source is dispatched again**, concurrently with the fix issue that owns the work (the #4818 dual-arm class; the spawn seam's own doc comment in `internal/autopilot/controller.go` claims this cannot happen).
+3. Unbounded: each re-run that fails CI spawns a NEW fix issue — spawn dedup is keyed per-PR and the source body carries no iteration meta, so the cascade limit reads 0 every time.
+
+### Secondary defects (same root, fix here)
+
+- `rearmDeadOwnerSource` (`internal/autopilot/owner_death.go`) strips `pilot-failed` but not `pilot-superseded` → a re-armed source carries contradictory `{pilot-retry-ready, pilot-superseded}`. Owner-death designation also no longer matches on `pilot-failed` for hand-off sources and leans entirely on the GH-4852 durable-claim fallback — verify that path has test coverage.
+- The GH-1870 board-sync block in the hand-off branch still moves the card to the fail column — the external board contradicts the ledger's `superseded` row.
+- `internal/adapters/github/cleanup.go` grooms stale `pilot-failed` but nothing grooms open `pilot-superseded`.
+
+## Fix — recommended shape
+
+**Count `superseded` as terminal in `HasTerminalCompletion`** (pilot-side; no sdk release needed). Semantics are honest: the hand-off comment already tells the reporter the issue "will not be retried automatically under its own number" — the ledger should agree. The GH-5139/GH-5215 re-arm probes key on fresh label/reopen EVENTS, so deliberate operator re-arm via label-cycle must still work — verify, don't assume.
+
+Additionally (small, same PR): make `rearmDeadOwnerSource` strip `pilot-superseded` alongside `pilot-failed`; route the hand-off branch's board sync to a superseded/neutral status instead of the fail column.
+
+An SDK skip rung for `pilot-superseded` is defense-in-depth — file it as an sdk follow-up, do not block this fix on an sdk release.
+
+## Acceptance
+
+- A hand-off source issue (open, `pilot-superseded`, superseded ledger row) is NEVER re-dispatched by the poller after processed-grace expiry: `HasTerminalCompletion` returns true for it. Regression test at the store level plus a wiring-level test for the poller callback.
+- Operator re-arm still works: a fresh `pilot` label-cycle or reopen event after the hand-off re-dispatches it (assert via the GH-5139 probe path).
+- Genuine terminal failures, canceled tasks, and the #5244 hold path are untouched.
+- `rearmDeadOwnerSource` leaves no `{pilot-retry-ready, pilot-superseded}` contradiction; test updated.
+- Hand-off board sync no longer moves the card to the fail column.
+- Explicitly out of scope: the restart-window durable fallback (`notifyExternalClose` hardcodes `pilot-failed` when in-memory state is lost) — accepted residual from PR#5248, note it in the PR description; and `pilot-superseded` grooming in cleanup.go (nice-to-have, only if trivial).
+
+## Refs
+
+- PR#5248 review verdict (full walk-through, all five findings)
+- #5247 (parent), GH-5227 (original external report)
+- #4818 (dual-arm class) · GH-4852 (durable claim fallback) · GH-5139/GH-5215 (re-arm probe semantics) · GH-1870 (board sync)
+
+## Resolution
+
+Implemented exactly the recommended shape:
+
+- `internal/memory/store.go`: `HasTerminalCompletion` now counts `status = 'superseded'` as terminal, alongside `completed`/`no_op`/`canceled`. Added `LatestSupersededExecution` and `ReclassifySupersededForRearm` (mirror the existing `*Canceled*` pair) for the demote-don't-delete re-arm path.
+- `cmd/pilot/rearm_superseded.go` (new, mirrors `rearm_canceled.go`): `tryRearmSuperseded` probes GitHub for an open issue still carrying the trigger label with a `labeled`/`reopened` event timestamped after the supersede — same GH-5139 probe pattern as canceled re-arm. Wired into `terminalCompletionChecker.HasCompletedExecution` in `cmd/pilot/main.go`, chained after `tryRearmCanceled`.
+- `internal/autopilot/owner_death.go`: `rearmDeadOwnerSource` now also strips `pilot-superseded` (best-effort, alongside the existing `pilot-failed` strip) so a re-armed source never carries the `{pilot-retry-ready, pilot-superseded}` contradiction. The GH-4852 durable-claim fallback in `reactToDeadFixIssue` was left as-is — `gh4852_test.go` already covers designation without `pilot-failed` for hand-off sources.
+- `internal/autopilot/controller.go`: both board-sync call sites that could fire on a healthy hand-off (GH-1870 in `handleCIFailed`, GH-4475 in the general external-close path) now skip the fail-column sync when `prState.TerminalLabel == github.LabelSuperseded`. The iteration-limit and CI-fix-size-guard board-sync call sites (genuine failures, `TerminalLabel = LabelFailed`) were deliberately left unguarded.
+- Updated a pre-existing test, `TestController_handleCIFailed_BoardSync_Regression_NormalPath`, whose fixture spawns a fix issue successfully (a healthy hand-off) but asserted the old (buggy) unconditional board sync — it now asserts the corrected no-sync behavior.
+
+New regression coverage: `internal/memory/store_test.go` (3 tests), `cmd/pilot/rearm_superseded_test.go` (4 tests), `internal/autopilot/owner_death_test.go` (extended table case), `internal/autopilot/gh5249_test.go` (2 tests). Full suite (`internal/memory`, `internal/executor`, `internal/autopilot`, `cmd/pilot`) passes; `go vet` and `golangci-lint run --new-from-rev=origin/main ./...` both clean.
+
+Accepted residuals (explicitly out of scope, per this doc's own Acceptance section): the restart-window durable fallback in `notifyExternalClose` still hardcodes `pilot-failed` when in-memory state is lost after a daemon restart; `pilot-superseded` grooming was not added to `internal/adapters/github/cleanup.go`.
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -4319,11 +4319,13 @@ func (c terminalCompletionChecker) HasCompletedExecution(taskID, projectPath str
 		return done, err
 	}
 
-	// GH-5139: `done` may be a genuine completed/no_op row (never re-arm — no
-	// GitHub probe, no throttling change) or an operator cancel, which alone
-	// among the terminal reasons is documented as re-armable via GitHub
-	// reopen/relabel. tryRearmCanceled tells the two apart internally (via
-	// LatestCanceledExecution) and only spends an API call on the latter.
+	// GH-5139/GH-5249: `done` may be a genuine completed/no_op row (never
+	// re-arm — no GitHub probe, no throttling change), an operator cancel, or
+	// a hand-off supersede — the latter two alone among the terminal reasons
+	// are documented as re-armable via GitHub reopen/relabel.
+	// tryRearmCanceled/tryRearmSuperseded each tell their case apart
+	// internally (via LatestCanceledExecution/LatestSupersededExecution) and
+	// only spend an API call when their own row type is present.
 	if c.ghClient == nil {
 		return true, nil
 	}
@@ -4334,11 +4336,22 @@ func (c terminalCompletionChecker) HasCompletedExecution(taskID, projectPath str
 		repickBackoff.recordClaimLostDrop(key)
 		return true, nil
 	}
+	if rearmed {
+		return false, nil
+	}
+	rearmed, probeErr = c.tryRearmSuperseded(taskID, projectPath, key)
+	if probeErr != nil {
+		logging.WithComponent("dispatch").Warn("GH-5249 re-arm probe failed — treating superseded task as still terminal",
+			slog.String("task_id", taskID), slog.Any("error", probeErr))
+		repickBackoff.recordClaimLostDrop(key)
+		return true, nil
+	}
 	if !rearmed {
-		// Either no canceled row (nothing to probe) or no re-arm evidence yet.
+		// Neither probe found a matching row + fresh re-arm evidence.
 		// Throttle via the same repick-backoff window GH-4469 already built,
-		// so an open+labeled-but-not-yet-relabeled canceled issue does not
-		// pay for a GetIssue+ListIssueEvents call on every ~30s poll tick.
+		// so an open+labeled-but-not-yet-relabeled canceled/superseded issue
+		// does not pay for a GetIssue+ListIssueEvents call on every ~30s poll
+		// tick.
 		repickBackoff.recordClaimLostDrop(key)
 		return true, nil
 	}

--- a/cmd/pilot/rearm_superseded.go
+++ b/cmd/pilot/rearm_superseded.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/logging"
+)
+
+// tryRearmSuperseded is GH-5249's re-arm probe: notifyExternalClose's
+// supersededClose hand-off tells the reporter the source issue "will not be
+// retried automatically under its own number" — but a deliberate operator
+// relabel/reopen after that hand-off must still be able to re-admit the
+// task_id, the same GH-5139 established for `pilot task cancel`. Before this
+// existed, counting 'superseded' as terminal in HasTerminalCompletion (see
+// store.go) would have made that promise permanent even for a source an
+// operator explicitly wants back in the retry ladder.
+//
+// backoffKey is threaded through so a successful re-arm can clear the
+// repick-backoff window immediately (recordSuccess) rather than waiting out
+// whatever cooldown the last "not yet re-armed" probe set.
+//
+// Returns rearmed=false, err=nil for the ordinary "nothing to do" cases: no
+// superseded row (the terminal evidence was a genuine completed/no_op/
+// canceled row instead — callers must not reach here in that case, but this
+// stays a safe no-op if they do), a non-GitHub task_id, or an open+labeled
+// issue with no labeled/reopened event timestamped after the supersede.
+// Returns err != nil only on an actual GitHub API failure, so the caller can
+// distinguish "confirmed not re-armed" from "couldn't tell" (see
+// HasCompletedExecution's error-handling comment for why that distinction
+// matters for backoff).
+func (c terminalCompletionChecker) tryRearmSuperseded(taskID, projectPath, backoffKey string) (bool, error) {
+	exec, found, err := c.store.LatestSupersededExecution(taskID, projectPath)
+	if err != nil {
+		return false, fmt.Errorf("looking up superseded execution: %w", err)
+	}
+	if !found || exec.CompletedAt == nil {
+		// No superseded row (terminal evidence was completed/no_op/canceled
+		// instead) or a superseded row somehow missing its supersede
+		// timestamp — either way, nothing GH-5249 can evaluate re-arm
+		// evidence against.
+		return false, nil
+	}
+
+	var issueNum int
+	if _, scanErr := fmt.Sscanf(taskID, "GH-%d", &issueNum); scanErr != nil || issueNum <= 0 {
+		// Not a GitHub-issue-shaped task_id — this checker is only wired for
+		// the GitHub SDK poller, but stay defensive rather than assume.
+		return false, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rearmProbeTimeout)
+	defer cancel()
+
+	issue, err := c.ghClient.GetIssue(ctx, c.repoOwner, c.repoName, issueNum)
+	if err != nil {
+		return false, fmt.Errorf("fetching issue #%d: %w", issueNum, err)
+	}
+	if issue.State != "open" || !github.HasLabel(issue, c.triggerLabel) {
+		// Re-arm requires BOTH open and labeled right now — an operator who
+		// relabels a still-closed issue, or reopens without the trigger
+		// label, hasn't finished the deliberate re-arm gesture yet.
+		return false, nil
+	}
+
+	events, err := c.ghClient.ListIssueEvents(ctx, c.repoOwner, c.repoName, issueNum)
+	if err != nil {
+		return false, fmt.Errorf("listing issue #%d events: %w", issueNum, err)
+	}
+	rearmEvent := latestRearmEvent(events, c.triggerLabel, *exec.CompletedAt)
+	if rearmEvent == nil {
+		// Open + labeled, but nothing in the timeline shows that state was
+		// reached AFTER the supersede — e.g. the label was already there
+		// before the hand-off and never touched again. Not a deliberate
+		// re-arm gesture.
+		return false, nil
+	}
+
+	reason := fmt.Sprintf("GH-5249: re-armed by issue #%d %s event at %s (superseded at %s)",
+		issueNum, rearmEvent.Event, rearmEvent.CreatedAt.Format(time.RFC3339), exec.CompletedAt.Format(time.RFC3339))
+	if err := c.store.ReclassifySupersededForRearm(taskID, projectPath, reason); err != nil {
+		return false, fmt.Errorf("reclassifying superseded row: %w", err)
+	}
+	if err := c.ghClient.RemoveLabel(ctx, c.repoOwner, c.repoName, issueNum, github.LabelSuperseded); err != nil {
+		// Best-effort: the store-side reclassify above is what actually
+		// un-wedges dispatch (HasTerminalCompletion no longer sees this row
+		// as done); a surviving pilot-superseded label is cosmetic
+		// staleness, not a correctness problem, since (unlike pilot-blocked)
+		// it never excluded the issue from poller candidacy in the first
+		// place.
+		logging.WithComponent("dispatch").Warn("GH-5249: failed to remove pilot-superseded label after re-arm",
+			slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.Any("error", err))
+	}
+	repickBackoff.recordSuccess(backoffKey)
+	logging.WithComponent("dispatch").Info("GH-5249: superseded task re-armed via GitHub reopen/relabel",
+		slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.String("event", rearmEvent.Event))
+	return true, nil
+}

--- a/cmd/pilot/rearm_superseded_test.go
+++ b/cmd/pilot/rearm_superseded_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// newRearmSupersededTestServer mirrors newRearmTestServer (rearm_canceled_test.go)
+// but serves issue #5249 — a distinct number from the canceled tests' fixed
+// #5139 fixture, since both test files share the terminalCompletionChecker
+// struct and could otherwise collide if ever exercised against the same
+// httptest.Server. Also handles the DELETE .../labels/pilot-superseded call
+// tryRearmSuperseded makes on a successful re-arm (tryRearmCanceled never
+// removes labels, so that call site has no counterpart in the sibling
+// fixture).
+func newRearmSupersededTestServer(t *testing.T, issue *github.Issue, events []*github.IssueEvent) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/5249" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(issue)
+		case r.URL.Path == "/repos/owner/repo/issues/5249/events" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(events)
+		case r.URL.Path == "/repos/owner/repo/issues/5249/labels/"+github.LabelSuperseded && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func seedSupersededRow(t *testing.T, store *memory.Store, id, taskID, projectPath string, completedAt time.Time) {
+	t.Helper()
+	if err := store.SaveExecution(&memory.Execution{
+		ID: id, TaskID: taskID, ProjectPath: projectPath,
+		Status: "superseded", Error: "GH-5247: healthy hand-off to fix issue #5250", CompletedAt: &completedAt,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+}
+
+// TestTerminalCompletionChecker_NilGHClient_SupersededStaysPermanent proves
+// GH-5249 does not change behavior for any checker built the old way (nil
+// ghClient) — mirrors TestTerminalCompletionChecker_NilGHClient_CanceledStaysPermanent
+// for status='superseded'.
+func TestTerminalCompletionChecker_NilGHClient_SupersededStaysPermanent(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	checker := terminalCompletionChecker{store: store} // no ghClient — old behavior
+
+	taskID, projectPath := "GH-5249-NILCLIENT", "/project-nilclient-superseded"
+	seedSupersededRow(t, store, "exec-nilclient-superseded", taskID, projectPath, time.Now().Add(-time.Hour))
+
+	done, err := checker.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !done {
+		t.Fatal("expected a superseded row to still report done=true with no ghClient wired")
+	}
+}
+
+// TestTerminalCompletionChecker_SupersededNoRearmEvidence_StaysTerminal
+// mirrors TestTerminalCompletionChecker_CanceledNoRearmEvidence_StaysTerminal:
+// the issue is currently open and carries the trigger label, but the
+// timeline shows no labeled/reopened event AFTER the supersede — must stay
+// permanent-for-now and arm the repick backoff (GH-4469).
+func TestTerminalCompletionChecker_SupersededNoRearmEvidence_StaysTerminal(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	supersedeTime := time.Now().Add(-time.Hour)
+
+	srv := newRearmSupersededTestServer(t,
+		&github.Issue{Number: 5249, State: "open", Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelSuperseded}}},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: supersedeTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5249", "/project-no-evidence-superseded"
+	seedSupersededRow(t, store, "exec-no-evidence-superseded", taskID, projectPath, supersedeTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	done, err := checker.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !done {
+		t.Fatal("expected the task to remain terminal — no re-arm evidence after the supersede timestamp")
+	}
+
+	exec, err := store.GetExecution("exec-no-evidence-superseded")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "superseded" {
+		t.Errorf("expected the row to remain status=superseded (not reclassified), got %q", exec.Status)
+	}
+
+	if gated, _ := repickBackoff.gateStatus(key); !gated {
+		t.Error("expected the repick backoff to be armed after a failed re-arm probe, throttling the next GitHub call (GH-4469)")
+	}
+}
+
+// TestTerminalCompletionChecker_SupersededWithRelabelAfterSupersede_Rearms
+// mirrors TestTerminalCompletionChecker_CanceledWithRelabelAfterCancel_Rearms:
+// a genuine relabel (timestamped after the supersede) on an open, labeled
+// issue must re-admit the task_id, reclassifying the superseded row to
+// 'failed' AND removing the pilot-superseded label (best-effort cosmetic
+// cleanup, since — unlike pilot-blocked — it never excluded the issue from
+// poller candidacy).
+func TestTerminalCompletionChecker_SupersededWithRelabelAfterSupersede_Rearms(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	supersedeTime := time.Now().Add(-time.Hour)
+	relabelTime := supersedeTime.Add(30 * time.Minute)
+
+	srv := newRearmSupersededTestServer(t,
+		&github.Issue{Number: 5249, State: "open", Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelSuperseded}}},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: supersedeTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+			{Event: "unlabeled", CreatedAt: supersedeTime.Add(-time.Minute), Label: &github.Label{Name: "pilot"}},
+			{Event: "labeled", CreatedAt: relabelTime, Label: &github.Label{Name: "pilot"}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5249", "/project-rearmed-superseded"
+	seedSupersededRow(t, store, "exec-rearmed-superseded", taskID, projectPath, supersedeTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	done, err := checker.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if done {
+		t.Fatal("expected the task to be re-armed (done=false) — a labeled event postdates the supersede on an open, labeled issue")
+	}
+
+	exec, err := store.GetExecution("exec-rearmed-superseded")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected the superseded row to be reclassified to status=failed (demote-don't-delete), got %q", exec.Status)
+	}
+
+	if gated, _ := repickBackoff.gateStatus(key); gated {
+		t.Error("expected repick backoff to be cleared on a successful re-arm, not left gated")
+	}
+
+	// The re-armed generation must flow through the ordinary retry path.
+	stillDone, err := store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion: %v", err)
+	}
+	if stillDone {
+		t.Fatal("expected HasTerminalCompletion to report false after re-arm, so nextRetryGeneration can grant the next generation normally")
+	}
+}
+
+// TestTerminalCompletionChecker_SupersededClosedIssue_NotRearmed mirrors
+// TestTerminalCompletionChecker_CanceledClosedIssue_NotRearmed: even with a
+// labeled event after supersede, a currently-CLOSED issue must not re-arm.
+func TestTerminalCompletionChecker_SupersededClosedIssue_NotRearmed(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	supersedeTime := time.Now().Add(-time.Hour)
+
+	srv := newRearmSupersededTestServer(t,
+		&github.Issue{Number: 5249, State: "closed", Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelSuperseded}}},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: supersedeTime.Add(time.Minute), Label: &github.Label{Name: "pilot"}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5249", "/project-closed-superseded"
+	seedSupersededRow(t, store, "exec-closed-superseded", taskID, projectPath, supersedeTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	done, err := checker.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !done {
+		t.Fatal("expected no re-arm — the issue is currently closed, regardless of a post-supersede labeled event")
+	}
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3778,8 +3778,14 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 		c.log.Info("closed failed PR", "pr", prState.PRNumber, "fix_issue", issueNum)
 	}
 
-	// GH-1870: Sync board card to "Failed" column on CI failure
-	if c.boardSync != nil && prState.IssueNodeID != "" && c.failStatus != "" {
+	// GH-1870/GH-5249: Sync board card to "Failed" column on CI failure —
+	// but never when this rung already handed off to a fix issue. By this
+	// point (past the err != nil || issueNum <= 0 guard above) that hand-off
+	// always succeeded, so prState.TerminalLabel is always LabelSuperseded
+	// (set by spawnFailureIssue) — moving the card to the fail column here
+	// would contradict the healthy-hand-off treatment the rest of this rung
+	// already gives it (no RecordPRFailed, no c.monitor.Fail equivalent).
+	if c.boardSync != nil && prState.IssueNodeID != "" && c.failStatus != "" && prState.TerminalLabel != github.LabelSuperseded {
 		if err := c.boardSync.UpdateProjectItemStatus(ctx, prState.IssueNodeID, c.failStatus); err != nil {
 			c.log.Warn("board sync on CI fail failed", "pr", prState.PRNumber, "error", err)
 			c.alertBoardSyncScopeFailureOnce(err)
@@ -9058,7 +9064,13 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 		// GH-4475: Sync board card to the failed status on external close
 		// (unmerged) — mirrors the Done sync above for external merge, and
 		// the failStatus syncs used on internal execution failures.
-		if c.boardSync != nil && prState.IssueNodeID != "" && c.failStatus != "" {
+		//
+		// GH-5249: skip when notifyExternalClose (just above) classified this
+		// as a supersededClose — a healthy hand-off to a fix/revision issue,
+		// not a failure. Moving the card to the fail column here would
+		// contradict the ledger, which notifyExternalClose already reclassified
+		// as 'superseded' rather than 'failed' for exactly this case.
+		if c.boardSync != nil && prState.IssueNodeID != "" && c.failStatus != "" && prState.TerminalLabel != github.LabelSuperseded {
 			if err := c.boardSync.UpdateProjectItemStatus(ctx, prState.IssueNodeID, c.failStatus); err != nil {
 				c.log.Warn("board sync on external close failed", "pr", prState.PRNumber, "error", err)
 				c.alertBoardSyncScopeFailureOnce(err)

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -11681,7 +11681,16 @@ func TestHandleCIFailed_IterationLimit_ExecutionModeGate(t *testing.T) {
 }
 
 // TestController_handleCIFailed_BoardSync_Regression_NormalPath is a regression guard
-// that verifies the existing normal CI failure board sync (non-iteration-limit) still fires.
+// for the normal (non-iteration-limit) CI failure board sync in handleCIFailed.
+//
+// GH-5249: this fixture's spawnFailureIssue call succeeds (POST /issues ->
+// {"number":99}), so by the time board sync is reached prState.TerminalLabel
+// is always github.LabelSuperseded — this is the same healthy hand-off
+// TestController_HandleCIFailed_BoardSyncSkipsFailColumnOnHandoff
+// (gh5249_test.go) covers. Before GH-5249 this test asserted the board sync
+// fired unconditionally on every CI failure, including this hand-off case;
+// that was exactly the bug (card moved to the fail column on a healthy
+// hand-off). It now asserts the corrected behavior: no sync call at all.
 func TestController_handleCIFailed_BoardSync_Regression_NormalPath(t *testing.T) {
 	const issueNodeID = "IssueNodeID_normal"
 	mock := &mockBoardSyncer{}
@@ -11730,19 +11739,15 @@ func TestController_handleCIFailed_BoardSync_Regression_NormalPath(t *testing.T)
 		BranchName:  "pilot/GH-10",
 	}
 
-	// handleCIFailed should reach the normal path and fire board sync with failStatus.
+	// handleCIFailed should reach the normal path, successfully hand off to a
+	// fix issue, and skip the fail-column board sync (GH-5249).
 	_ = c.handleCIFailed(context.Background(), prState)
 
-	// The normal path fires one board sync call with failStatus.
-	found := false
 	for _, call := range mock.calls {
 		if call.issueNodeID == issueNodeID && call.statusName == "Blocked" {
-			found = true
+			t.Errorf("expected no board sync call to %q on a healthy hand-off (GH-5249), got calls: %+v",
+				"Blocked", mock.calls)
 		}
-	}
-	if !found {
-		t.Errorf("expected board sync call with issueNodeID=%q statusName=%q, got calls: %+v",
-			issueNodeID, "Blocked", mock.calls)
 	}
 }
 

--- a/internal/autopilot/gh5249_test.go
+++ b/internal/autopilot/gh5249_test.go
@@ -1,0 +1,145 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestController_HandleCIFailed_BoardSyncSkipsFailColumnOnHandoff is GH-5249's
+// regression guard for the GH-1870 board sync inside handleCIFailed: once a
+// fix issue has been spawned (spawnFailureIssue set prState.TerminalLabel to
+// github.LabelSuperseded), this is a healthy hand-off, not a failure — the
+// board card must not be moved to the fail column, mirroring the GH-5247
+// split already applied to c.metrics/c.monitor.Fail for this same branch.
+// Before this fix the card moved to Failed even on the routine-revision path
+// TestGH5247_HandleCIFailed_Classification proves is not a pipeline defect.
+func TestController_HandleCIFailed_BoardSyncSkipsFailColumnOnHandoff(t *testing.T) {
+	const codeLog = `Run golangci-lint run ./...
+internal/autopilot/controller.go:1:1: some lint error (errcheck)
+##[error]Process completed with exit code 1.`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/gh5249hoff/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{ID: 701, Name: "lint", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/701/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(codeLog))
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/54002":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 54002, Body: "no-meta"}))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 54003}))
+		case r.URL.Path == "/repos/owner/repo/pulls/54001" && r.Method == http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	mock := &mockBoardSyncer{}
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo",
+		withBoardSyncerForTest(mock, "Done", "Failed", "In Review", "In Dev"))
+
+	prState := &PRState{
+		PRNumber:    54001,
+		IssueNumber: 54002,
+		IssueNodeID: "IssueNodeID_gh5249hoff",
+		HeadSHA:     "gh5249hoff",
+		Stage:       StageCIFailed,
+	}
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed: %v", err)
+	}
+
+	if prState.TerminalLabel != github.LabelSuperseded {
+		t.Fatalf("TerminalLabel = %q, want %q (precondition: this must be the healthy hand-off branch)",
+			prState.TerminalLabel, github.LabelSuperseded)
+	}
+	for _, call := range mock.calls {
+		if call.statusName == "Failed" {
+			t.Errorf("board sync moved card to Failed on a healthy hand-off, calls=%+v", mock.calls)
+		}
+	}
+}
+
+// TestController_NotifyExternalClose_BoardSyncSkipsFailColumnOnSupersededClose
+// is GH-5249's regression guard for the GH-4475 board sync in the general
+// external-close path (checkExternalMergeOrClose -> notifyExternalClose):
+// when the close is a supersededClose (prState.TerminalLabel already
+// github.LabelSuperseded — e.g. set earlier by spawnFailureIssue/
+// spawnReviewIssue), the card must not move to the fail column, mirroring
+// TestController_CheckExternalClose_BoardSync's genuine-failure case, which
+// still expects "Failed".
+func TestController_NotifyExternalClose_BoardSyncSkipsFailColumnOnSupersededClose(t *testing.T) {
+	const issueNodeID = "IssueNodeID_gh5249superseded"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls/42":
+			resp := github.PullRequest{
+				Number:  42,
+				State:   "closed",
+				Merged:  false,
+				HTMLURL: "https://github.com/owner/repo/pull/42",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/issues/10":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"node_id": issueNodeID})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+
+	mock := &mockBoardSyncer{}
+	c := NewController(cfg, ghClient, nil, "owner", "repo",
+		withBoardSyncerForTest(mock, "Done", "Failed", "In Review", "In Dev"))
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", issueNodeID)
+	// OnPRCreated itself fires a reviewStatus sync — reset so we only observe
+	// the external-close sync under test.
+	mock.calls = nil
+
+	// GH-4570: back-date CreatedAt past externalCloseGraceWindow so a single
+	// closed read is trusted. GH-5249: pre-mark TerminalLabel as it would be
+	// by the time a real supersededClose reaches this poll tick (set earlier
+	// by spawnFailureIssue/spawnReviewIssue the moment the fix/revision issue
+	// was created, well before the PR close is ever observed here).
+	c.mu.Lock()
+	c.activePRs[42].CreatedAt = time.Now().Add(-10 * time.Minute)
+	c.activePRs[42].TerminalLabel = github.LabelSuperseded
+	c.mu.Unlock()
+
+	c.processAllPRs(context.Background())
+
+	for _, call := range mock.calls {
+		if call.statusName == "Failed" {
+			t.Errorf("board sync moved card to Failed on a supersededClose, calls=%+v", mock.calls)
+		}
+	}
+}

--- a/internal/autopilot/owner_death.go
+++ b/internal/autopilot/owner_death.go
@@ -229,6 +229,17 @@ func (c *Controller) rearmDeadOwnerSource(ctx context.Context, source *github.Is
 	if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, source.Number, github.LabelFailed); err != nil {
 		c.log.Debug("owner-death: failed to remove pilot-failed label (may not exist)", "issue", source.Number, "error", err)
 	}
+	// GH-5249: also strip pilot-superseded — the durable-claim fallback above
+	// means `designated` can now be reached via a source that hand off (not
+	// pilot-failed) designated to the dead fix issue, which carries
+	// pilot-superseded rather than pilot-failed. Leaving it on would land the
+	// re-armed issue in a contradictory {pilot-retry-ready, pilot-superseded}
+	// state — the SDK poller has no skip rung for pilot-superseded (that's
+	// the GH-5249 root defect), but a human reading the labels would still
+	// see "superseded" and "retry-ready" fighting each other.
+	if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, source.Number, github.LabelSuperseded); err != nil {
+		c.log.Debug("owner-death: failed to remove pilot-superseded label (may not exist)", "issue", source.Number, "error", err)
+	}
 	comment := fmt.Sprintf(
 		"\U0001F501 **Owner-death recovery**: %s. Re-armed for automatic retry (`%s` restored).",
 		reasonMsg, github.LabelRetryReady,

--- a/internal/autopilot/owner_death_test.go
+++ b/internal/autopilot/owner_death_test.go
@@ -193,6 +193,18 @@ func (s *ownerDeathGHServer) hasAddLabel(issue int, label string) bool {
 	return false
 }
 
+func (s *ownerDeathGHServer) hasRemoveLabel(issue int, label string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	want := fmt.Sprintf("%d:%s", issue, label)
+	for _, c := range s.removeLabelCalls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
 // TestController_ReactToDeadFixIssue covers item 2 of GH-4842: react to a
 // dead designated fix issue by either re-arming its source for retry, or
 // escalating to needs-human when the source's retries are already
@@ -202,11 +214,12 @@ func TestController_ReactToDeadFixIssue(t *testing.T) {
 	fixIssueBody := "Fixes CI failure.\n\nDepends on: #100\n\n<!-- autopilot-meta branch:pilot/GH-100 pr:7 iteration:1 -->"
 
 	tests := []struct {
-		name           string
-		sourceIssue    *github.Issue
-		wantRearm      bool
-		wantEscalate   bool
-		wantNoReaction bool
+		name             string
+		sourceIssue      *github.Issue
+		wantRearm        bool
+		wantEscalate     bool
+		wantNoReaction   bool
+		wantRemoveLabels []string // GH-5249: labels rearmDeadOwnerSource must strip
 	}{
 		{
 			name: "source open with pilot-failed and no retry-exhausted — rearmed",
@@ -216,6 +229,22 @@ func TestController_ReactToDeadFixIssue(t *testing.T) {
 				Labels: []github.Label{{Name: github.LabelFailed}},
 			},
 			wantRearm: true,
+		},
+		{
+			// GH-5249: a source can carry pilot-failed AND pilot-superseded at
+			// once — e.g. a prior hand-off superseded it, then a later
+			// designated fix issue (from a subsequent failure on the same
+			// source) died. rearmDeadOwnerSource must strip BOTH, not just
+			// pilot-failed, so the re-armed issue doesn't carry a
+			// contradictory {pilot-retry-ready, pilot-superseded} state.
+			name: "source open with pilot-failed and pilot-superseded — rearmed, both labels stripped",
+			sourceIssue: &github.Issue{
+				Number: 100,
+				State:  github.StateOpen,
+				Labels: []github.Label{{Name: github.LabelFailed}, {Name: github.LabelSuperseded}},
+			},
+			wantRearm:        true,
+			wantRemoveLabels: []string{github.LabelFailed, github.LabelSuperseded},
 		},
 		{
 			name: "source open with pilot-failed and retry-exhausted — escalated",
@@ -269,6 +298,11 @@ func TestController_ReactToDeadFixIssue(t *testing.T) {
 				}
 				if len(sink.events) != 1 {
 					t.Errorf("expected exactly 1 alert, got %d", len(sink.events))
+				}
+				for _, label := range tt.wantRemoveLabels {
+					if !srv.hasRemoveLabel(100, label) {
+						t.Errorf("expected %q to be removed from source #100, calls=%v", label, srv.removeLabelCalls)
+					}
 				}
 			case tt.wantEscalate:
 				if !srv.hasAddLabel(100, labelNeedsHuman) {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1265,19 +1265,39 @@ func (s *Store) HasCompletedExecution(taskID, projectPath string) (bool, error) 
 // deliverable), a no_op row with no error ("nothing to change" is itself
 // a legitimate completion — the same definition childCompletionEvidence
 // uses in internal/executor/dispatcher.go for decomposed-child evidence),
-// or a canceled row (GH-4678: an operator ran `pilot task cancel` — that is
+// a canceled row (GH-4678: an operator ran `pilot task cancel` — that is
 // a deliberate "stop dispatching this" decision, not a failure to retry;
 // unlike the no_op branch this one does NOT require an empty error, since
-// Cancel always records the operator's reason in the error column).
+// Cancel always records the operator's reason in the error column), or a
+// superseded row (GH-5249: see below).
 //
-// GH-5139: "canceled" here is a default, not an unconditional forever — the
-// GitHub admission path (cmd/pilot's terminalCompletionChecker) independently
-// probes for genuine re-arm evidence (issue relabeled/reopened after the
-// cancel) and, when found, calls ReclassifyCanceledForRearm to demote the row
-// to 'failed' BEFORE this ever runs again, so a re-armed task_id naturally
-// stops counting as terminal here too — this function itself never consults
-// GitHub state and keeps treating a still-canceled row as done, which is the
-// correct default for every caller that has no re-arm evidence of its own.
+// GH-5249: a 'superseded' row is written by notifyExternalClose's
+// supersededClose branch (controller.go, GH-5247/PR#5248) when a healthy
+// continuation hand-off closes a PR without merging — a fix/revision issue
+// now owns the work, and the source is left OPEN carrying pilot-superseded
+// rather than being retried under its own number ("this issue will not be
+// retried automatically under its own number", per the hand-off comment).
+// Before this branch existed, that OPEN+pilot-superseded issue had no
+// terminal ledger evidence at all: the SDK poller's label-rung skip list has
+// no entry for pilot-superseded on the issue itself (only pilot-failed
+// routes to a bounded retry budget), so once the ~5min processed-grace
+// window expired the poller re-dispatched the source — concurrently with
+// the fix issue that already continues the work (the #4818 dual-arm class),
+// unbounded, since spawn dedup is keyed per-PR and the source body carries
+// no iteration meta for the cascade limit to read. Counting 'superseded' as
+// terminal here closes that gap; the hand-off comment's promise and the
+// ledger now agree.
+//
+// GH-5139/GH-5249: "canceled"/"superseded" here are defaults, not an
+// unconditional forever — the GitHub admission path (cmd/pilot's
+// terminalCompletionChecker) independently probes for genuine re-arm
+// evidence (issue relabeled/reopened after the cancel/supersede) and, when
+// found, calls ReclassifyCanceledForRearm/ReclassifySupersededForRearm to
+// demote the row to 'failed' BEFORE this ever runs again, so a re-armed
+// task_id naturally stops counting as terminal here too — this function
+// itself never consults GitHub state and keeps treating a still-canceled or
+// still-superseded row as done, which is the correct default for every
+// caller that has no re-arm evidence of its own.
 //
 // GH-4347: deliberately an ANY-row check, unlike childCompletionEvidence's
 // no_op fallback (which inspects only GetLatestExecutionByTaskID's most
@@ -1302,6 +1322,7 @@ func (s *Store) HasTerminalCompletion(taskID, projectPath string) (bool, error) 
 		WHERE task_id = ? AND project_path = ? AND (
 			(status = 'no_op' AND (error IS NULL OR error = ''))
 			OR status = 'canceled'
+			OR status = 'superseded'
 		)
 	`, taskID, projectPath).Scan(&count)
 	if err != nil {
@@ -1425,6 +1446,70 @@ func (s *Store) ReclassifyStalledForRearm(taskID, projectPath, reason string) er
 			UPDATE executions
 			SET status = 'failed', error = ?, completed_at = CURRENT_TIMESTAMP
 			WHERE task_id = ? AND project_path = ? AND status = 'stalled'
+		`, reason, taskID, projectPath)
+		return err
+	})
+}
+
+// LatestSupersededExecution returns the most recent status='superseded' row
+// for taskID/projectPath — GH-5249's counterpart to LatestCanceledExecution,
+// extending the GH-5139 re-arm pattern from operator-canceled rows to
+// hand-off supersede closes (notifyExternalClose's supersededClose branch,
+// controller.go, GH-5247/PR#5248). Exact task_id + status match, same as
+// LatestCanceledExecution: filtering on the literal status='superseded'
+// column is what keeps this safe against the GH-4347 ordering trap (a fresh
+// 'queued' row for the same task_id sitting alongside the old superseded
+// one). found=false when no superseded row exists.
+//
+// completed_at on the returned row is the supersede timestamp
+// (UpdateExecutionStatusIfNotTerminal stamps it CURRENT_TIMESTAMP on every
+// terminal transition, supersede included) — the reference point a GH-5249
+// re-arm probe compares GitHub issue-event timestamps against to decide
+// whether a relabel/reopen happened AFTER the supersede, not before it.
+func (s *Store) LatestSupersededExecution(taskID, projectPath string) (exec *Execution, found bool, err error) {
+	row := s.db.QueryRow(`
+		SELECT `+executionDetailColumns+`
+		FROM executions
+		WHERE task_id = ? AND project_path = ? AND status = 'superseded'
+		ORDER BY completed_at DESC, rowid DESC
+		LIMIT 1
+	`, taskID, projectPath)
+	exec, err = scanExecutionDetail(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return exec, true, nil
+}
+
+// ReclassifySupersededForRearm demotes every status='superseded' row for
+// taskID/projectPath to 'failed' with reason recorded — GH-5249's
+// counterpart to ReclassifyCanceledForRearm, same "demote, don't delete"
+// idiom: the row (and its history) stays visible to `pilot trace`, but a
+// 'failed' row is not terminal per HasTerminalCompletion, so the ordinary
+// nextRetryGeneration retry-with-backoff/hard-cap path
+// (internal/executor/dispatcher.go) grants the next generation exactly the
+// way it would for any other post-failure retry — no bespoke bypass of
+// those invariants. The UPDATE's own `status = 'superseded'` filter is what
+// protects against the GH-4347 ordering trap (see LatestSupersededExecution):
+// a fresh 'queued' row for the same task_id is never touched by this call.
+//
+// Callers must independently confirm GitHub-side re-arm evidence (issue
+// open + carries the trigger label + a labeled/reopened event after the
+// supersede timestamp LatestSupersededExecution returned) before calling
+// this — it does not itself decide re-arm eligibility. Unlike
+// ReclassifyStalledForRearm's pilot-blocked label, a surviving
+// pilot-superseded label does not exclude the issue from poller candidacy
+// (that is the root defect GH-5249 fixes), so removing it is a hygiene step
+// for the caller, not a correctness requirement of this method.
+func (s *Store) ReclassifySupersededForRearm(taskID, projectPath, reason string) error {
+	return s.withRetry("ReclassifySupersededForRearm", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET status = 'failed', error = ?, completed_at = CURRENT_TIMESTAMP
+			WHERE task_id = ? AND project_path = ? AND status = 'superseded'
 		`, reason, taskID, projectPath)
 		return err
 	})

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -6084,3 +6084,192 @@ func TestReclassifyStalledForRearm_DemotesToFailedAndUnblocksRetry(t *testing.T)
 		t.Errorf("expected the other task's stalled row to remain untouched, got status %q", otherExec.Status)
 	}
 }
+
+// TestHasTerminalCompletion_CountsSupersededRow is GH-5249's regression test
+// for HasTerminalCompletion's "superseded" branch: a healthy hand-off close
+// (notifyExternalClose's supersededClose branch, controller.go, GH-5247/
+// PR#5248) must count as done — the same "never re-dispatch" signal a
+// genuine completion, no_op, or operator cancel already provides — closing
+// the gap where an OPEN issue carrying pilot-superseded had no terminal
+// ledger evidence at all and was re-dispatched unbounded after processed-
+// grace expired.
+func TestHasTerminalCompletion_CountsSupersededRow(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	taskID, projectPath := "GH-5249-HTC", "/project-htc-superseded"
+
+	done, err := store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion (before any row): %v", err)
+	}
+	if done {
+		t.Fatal("expected done=false before any execution row exists")
+	}
+
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-superseded", TaskID: taskID, ProjectPath: projectPath,
+		Status: "superseded", Error: "GH-5247: healthy hand-off to fix issue #5250",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	done, err = store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion (after supersede): %v", err)
+	}
+	if !done {
+		t.Error("expected done=true once a superseded row exists — this is the primary GH-5249 defect fix")
+	}
+}
+
+// TestLatestSupersededExecution_FindsMostRecentSupersededRow is GH-5249's
+// coverage for the lookup the re-arm probe (cmd/pilot/rearm_superseded.go)
+// uses to find the supersede timestamp it compares GitHub issue-event times
+// against — mirrors TestLatestCanceledExecution_FindsMostRecentCanceledRow
+// exactly, for status='superseded' instead of 'canceled'.
+func TestLatestSupersededExecution_FindsMostRecentSupersededRow(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	taskID, projectPath := "GH-5249-LSE", "/project-lse-superseded"
+
+	_, found, err := store.LatestSupersededExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestSupersededExecution (before any row): %v", err)
+	}
+	if found {
+		t.Fatal("expected found=false before any execution row exists")
+	}
+
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-completed-first", TaskID: taskID, ProjectPath: projectPath,
+		Status: "completed", PRUrl: "https://github.com/o/r/pull/1",
+	}); err != nil {
+		t.Fatalf("SaveExecution (completed): %v", err)
+	}
+	_, found, err = store.LatestSupersededExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestSupersededExecution (only a completed row): %v", err)
+	}
+	if found {
+		t.Fatal("expected found=false when the only row is completed, not superseded")
+	}
+
+	// CompletedAt is set explicitly here to mirror production:
+	// UpdateExecutionStatusIfNotTerminal stamps completed_at =
+	// CURRENT_TIMESTAMP on every terminal transition (that stamp becomes the
+	// "supersede timestamp" the GH-5249 re-arm probe compares GitHub event
+	// times against) — SaveExecution itself does not default it.
+	supersedeTime := time.Now()
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-superseded", TaskID: taskID, ProjectPath: projectPath,
+		Status: "superseded", Error: "GH-5247: healthy hand-off to fix issue #5250", CompletedAt: &supersedeTime,
+	}); err != nil {
+		t.Fatalf("SaveExecution (superseded): %v", err)
+	}
+
+	exec, found, err := store.LatestSupersededExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestSupersededExecution (after supersede): %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true once a superseded row exists")
+	}
+	if exec.ID != "exec-superseded" {
+		t.Errorf("expected the superseded row, got %q", exec.ID)
+	}
+	if exec.CompletedAt == nil {
+		t.Error("expected CompletedAt to be set (the supersede timestamp) on the superseded row")
+	}
+
+	// Different task_id / project_path must not match (exact-key isolation,
+	// mirroring HasTerminalCompletion's own query).
+	if _, found, err := store.LatestSupersededExecution("GH-OTHER", projectPath); err != nil || found {
+		t.Errorf("expected no match for a different task_id, found=%v err=%v", found, err)
+	}
+	if _, found, err := store.LatestSupersededExecution(taskID, "/other-project"); err != nil || found {
+		t.Errorf("expected no match for a different project_path, found=%v err=%v", found, err)
+	}
+}
+
+// TestReclassifySupersededForRearm_DemotesToFailedAndUnblocksRetry is
+// GH-5249's coverage for the "demote don't delete" re-arm write: after
+// reclassifying, the row must no longer count as terminal
+// (HasTerminalCompletion), so the ordinary nextRetryGeneration retry path
+// can grant the next generation — no bespoke bypass of the retry/backoff/
+// hard-cap machinery.
+func TestReclassifySupersededForRearm_DemotesToFailedAndUnblocksRetry(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	taskID, projectPath := "GH-5249-RSFR", "/project-rsfr-superseded"
+
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-superseded-rsfr", TaskID: taskID, ProjectPath: projectPath,
+		Status: "superseded", Error: "GH-5247: healthy hand-off to fix issue #5250",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	done, err := store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion (before reclassify): %v", err)
+	}
+	if !done {
+		t.Fatal("expected done=true before reclassify — the superseded row is terminal")
+	}
+
+	reason := "GH-5249: re-armed by issue #5249 reopened event"
+	if err := store.ReclassifySupersededForRearm(taskID, projectPath, reason); err != nil {
+		t.Fatalf("ReclassifySupersededForRearm: %v", err)
+	}
+
+	exec, err := store.GetExecution("exec-superseded-rsfr")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status=failed after reclassify, got %q", exec.Status)
+	}
+	if exec.Error != reason {
+		t.Errorf("expected error=%q, got %q", reason, exec.Error)
+	}
+
+	done, err = store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion (after reclassify): %v", err)
+	}
+	if done {
+		t.Fatal("expected done=false after reclassify — a failed row is not terminal, unblocking the normal retry path")
+	}
+
+	// A different task_id's superseded row must be untouched (exact-key
+	// isolation, mirroring ReclassifyCanceledForRearm's own cross-task test).
+	otherTaskID := "GH-5249-RSFR-OTHER"
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-superseded-other", TaskID: otherTaskID, ProjectPath: projectPath,
+		Status: "superseded", Error: "unrelated",
+	}); err != nil {
+		t.Fatalf("SaveExecution (other task): %v", err)
+	}
+	if err := store.ReclassifySupersededForRearm(taskID, projectPath, "unrelated reclassify"); err != nil {
+		t.Fatalf("ReclassifySupersededForRearm (second call): %v", err)
+	}
+	otherExec, err := store.GetExecution("exec-superseded-other")
+	if err != nil {
+		t.Fatalf("GetExecution (other task): %v", err)
+	}
+	if otherExec.Status != "superseded" {
+		t.Errorf("expected the other task's superseded row to remain untouched, got status %q", otherExec.Status)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5249.

Closes #5249

## Changes

GitHub Issue GH-5249: fix(autopilot): open pilot-superseded hand-off sources are re-dispatched unbounded — count superseded as terminal (PR#5248 remediation)

## Problem

PR#5248 (GH-5247, StageFailed/TerminalLabel conflation fix) correctly stops recording healthy hand-offs as failures, but it mints a state nothing downstream expects: an **OPEN** issue labeled `{pilot, pilot-superseded}`. Historically every `pilot-superseded` issue was closed. Post-merge review verdict on PR#5248 has the full analysis; this issue is the remediation. **Deadline-relevant: PR#5248 merged after today's train cut, so the regression is not yet on the box — this fix must merge before the next 14:00Z train or the two ride together.**

### Primary defect — unbounded re-dispatch of hand-off sources (dual-arm)

After a hand-off close, the source issue stays open with `pilot-superseded`. The SDK poller's decision walk has no skip rung for that label on the issue itself:

1. Pre-#5248, the `pilot-failed` rung routed the source to a bounded retry budget (3), then permanent failed-skip.
2. Post-#5248: no label rung matches → processed-grace (~5 min) expires → no merged work (PR closed unmerged) → no terminal completion — `HasTerminalCompletion` (`internal/memory/store.go`, wired in `cmd/pilot/main.go`) counts only completed / no_op / canceled, and the hand-off demoted the row to `superseded` → **the source is dispatched again**, concurrently with the fix issue that owns the work (the #4818 dual-arm class; the spawn seam's own doc comment in `internal/autopilot/controller.go` claims this cannot happen).
3. Unbounded: each re-run that fails CI spawns a NEW fix issue — spawn dedup is keyed per-PR and the source body carries no iteration meta, so the cascade limit reads 0 every time.

### Secondary defects (same root, fix here)

- `rearmDeadOwnerSource` (`internal/autopilot/owner_death.go`) strips `pilot-failed` but not `pilot-superseded` → a re-armed source carries contradictory `{pilot-retry-ready, pilot-superseded}`. Owner-death designation also no longer matches on `pilot-failed` for hand-off sources and leans entirely on the GH-4852 durable-claim fallback — verify that path has test coverage.
- The GH-1870 board-sync block in the hand-off branch still moves the card to the fail column — the external board contradicts the ledger's `superseded` row.
- `internal/adapters/github/cleanup.go` grooms stale `pilot-failed` but nothing grooms open `pilot-superseded`.

## Fix — recommended shape

**Count `superseded` as terminal in `HasTerminalCompletion`** (pilot-side; no sdk release needed). Semantics are honest: the hand-off comment already tells the reporter the issue "will not be retried automatically under its own number" — the ledger should agree. The GH-5139/GH-5215 re-arm probes key on fresh label/reopen EVENTS, so deliberate operator re-arm via label-cycle must still work — verify, don't assume.

Additionally (small, same PR): make `rearmDeadOwnerSource` strip `pilot-superseded` alongside `pilot-failed`; route the hand-off branch's board sync to a superseded/neutral status instead of the fail column.

An SDK skip rung for `pilot-superseded` is defense-in-depth — file it as an sdk follow-up, do not block this fix on an sdk release.

## Acceptance

- A hand-off source issue (open, `pilot-superseded`, superseded ledger row) is NEVER re-dispatched by the poller after processed-grace expiry: `HasTerminalCompletion` returns true for it. Regression test at the store level plus a wiring-level test for the poller callback.
- Operator re-arm still works: a fresh `pilot` label-cycle or reopen event after the hand-off re-dispatches it (assert via the GH-5139 probe path).
- Genuine terminal failures, canceled tasks, and the #5244 hold path are untouched.
- `rearmDeadOwnerSource` leaves no `{pilot-retry-ready, pilot-superseded}` contradiction; test updated.
- Hand-off board sync no longer moves the card to the fail column.
- Explicitly out of scope: the restart-window durable fallback (`notifyExternalClose` hardcodes `pilot-failed` when in-memory state is lost) — accepted residual from PR#5248, note it in the PR description; and `pilot-superseded` grooming in cleanup.go (nice-to-have, only if trivial).

## Refs

- PR#5248 review verdict (full walk-through, all five findings)
- #5247 (parent), GH-5227 (original external report)
- #4818 (dual-arm class) · GH-4852 (durable claim fallback) · GH-5139/GH-5215 (re-arm probe semantics) · GH-1870 (board sync)