### PR TITLE
GH-5251: fix(config): documented top-level autopilot block is silently ignored — loader only reads orchestrator.autopilot

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -4904,7 +4904,7 @@
       },
       "mem-160": {
         "type": "pitfall",
-        "summary": "Top-level autopilot: YAML binds to nothing (only orchestrator.autopilot) and Enabled is set only by --env \u2014 daemon opens PRs while no CI monitor or merger exists; tell is a missing autopilot_pr_state table",
+        "summary": "Top-level autopilot: YAML binds to nothing (only orchestrator.autopilot) and Enabled is set only by --env \u2014 daemon opens PRs while no CI monitor or merger exists; tell is a missing autopilot_pr_state table. GH-5251 (2026-08-27) fixed the silent-drop leg: Load() now lifts a top-level autopilot block into orchestrator.autopilot with a loud warning, and the example config/docs no longer document the dead top-level shape. The enabled-not-emitted and missing-`--env` legs are unchanged.",
         "path": "memories/pitfalls/top-level-autopilot-yaml-binds-to-nothing.md",
         "confidence": 0.98,
         "concepts": [
@@ -4918,7 +4918,7 @@
           "silent-failure"
         ],
         "created": "2026-07-26",
-        "last_validated": "2026-07-26"
+        "last_validated": "2026-08-27"
       },
       "stale-ledger-misdiagnosis": {
         "type": "learning",

--- a/.agent/knowledge/memories/pitfalls/top-level-autopilot-yaml-binds-to-nothing.md
+++ b/.agent/knowledge/memories/pitfalls/top-level-autopilot-yaml-binds-to-nothing.md
@@ -6,6 +6,17 @@ type: pitfall
 
 # Top-level `autopilot:` binds to nothing; without `--env` autopilot never starts
 
+**Status (2026-08-27, GH-5251):** leg 1 (silent-drop) is fixed. `config.Load`
+now detects a top-level `autopilot:` block via `liftTopLevelAutopilot`
+(`internal/config/config.go`): if `orchestrator.autopilot` is absent it lifts
+the top-level block into it (with a `DEPRECATED:` log), and if both are
+present it logs a `WARNING:` that the top-level duplicate is ignored in favor
+of the nested block. `configs/pilot.example.yaml` and every snippet in
+`docs/content/features/autopilot.mdx` were re-nested under `orchestrator:` —
+the dead top-level shape referenced in point 3 below no longer exists in
+either. This does not change the `enabled`-not-emitted (pilot-console
+renderer) or missing-`--env` legs below — those are separate mechanisms.
+
 **What happened (2026-07-24 → 07-26):** the hosted canary tenant
 (`i-0decbc0dcf225cf18`) executed issues with real tool-use and opened green PRs
 #103/#105 on `pilot-canary-sandbox` — which then sat OPEN and unmerged for two

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -291,6 +291,233 @@ orchestrator:
     poll_interval: 30s         # How often to check PR status
     pr_timeout: 1h             # Max time to wait for PR merge
 
+  # Autopilot settings
+  autopilot:
+    enabled: false
+    # Default environment used when --env is not specified (default: stage)
+    default_environment: "stage"
+    # Global autopilot settings
+    auto_merge: true
+    merge_method: "squash"
+    ci_wait_timeout: 30m
+    ci_poll_interval: 30s
+    approval_source: "telegram"   # telegram, slack, or github-review
+
+    # GH-4391: shared GitHub rate-limit budget. The GitHub primary rate limit
+    # is pooled per authenticated user across every client/session that user
+    # holds, so a startup burst of wide scans across many repos can silently
+    # starve the issue pollers even though `gh api rate_limit` looks fine from
+    # a different token/session's view of the same pool. These three settings
+    # bound that burst; defaults match the incident-driven values below.
+    #
+    # startup_merged_pr_scan_window: lookback for the one-time boot catch-up
+    # sweep (self-heal + board write-back for PRs merged while the daemon was
+    # down). Down from a hardcoded 720h (30d) — a restart minutes after the
+    # last startup scan doesn't need to re-walk a month of history; it also
+    # shrinks further on restart via a persisted per-repo cursor.
+    startup_merged_pr_scan_window: 72h
+    # rate_limit_floor_pct: once remaining/limit on the shared budget drops
+    # below this fraction, background scans (merged-PR scans, orphan-PR
+    # sweeps, reconciler evidence fetches) pause until headroom recovers.
+    # Issue pollers and active-PR CI watches are never gated — they're the
+    # highest-value consumer and must always get the reserve.
+    rate_limit_floor_pct: 0.15
+    # scan_stagger_interval: average delay between per-repo startup scans
+    # (jittered +/- 25%), so N repos' scans spread out over roughly
+    # N * scan_stagger_interval instead of all firing back-to-back at boot.
+    scan_stagger_interval: 3s
+
+    # Automatic release creation on PR merge (GH-3926).
+    release:
+      enabled: false
+      # Release cadence (GH-3989):
+      #   on_merge       (default) - cut a release for every merged PR.
+      #   manual         - never auto-release.
+      #   on_scope_close - hold merges belonging to an open epic (parent issue)
+      #                    or a shared "scope:"-prefixed label; standalone
+      #                    merges still release per-merge. The scope releases
+      #                    once when it completes (scope-close reconciler ships
+      #                    in a follow-up issue; this issue is config + hold
+      #                    semantics only - held work is fully reconstructable
+      #                    from GitHub in the meantime).
+      #   on_schedule    - hold every merge for a cron release train (see
+      #                    `schedule` below). At each tick, everything merged
+      #                    since the last tag is batched into one validated
+      #                    release (GH-3993). Restart across a tick still fires
+      #                    it exactly once (missed-tick recovery, bounded by
+      #                    `scope_lookback` below); a miss older than that
+      #                    window needs a manual re-trigger. DST transitions
+      #                    follow robfig/cron/v3's cron.WithLocation semantics
+      #                    (no special-casing). Urgent hotfix under
+      #                    `on_schedule`: everything still waits for the next
+      #                    tick by design - flip `trigger` to `on_merge`
+      #                    temporarily (config reload) if it can't wait.
+      #
+      # `on_scope_close`/`on_schedule` release notes (GH-3992): the aggregated
+      # scope body (headline, grouped Features/Fixes/Other with #PR + GH-issue
+      # links, breaking changes, What's New, compare footer) is only composed
+      # for `publish: api` or `publish: workflow` — `tag_only` never creates a
+      # release object, so there is nothing to attach notes to.
+      trigger: on_merge
+      # scope_label_prefix: "scope:"       # on_scope_close only; default "scope:"
+      # schedule: "0 21 * * FRI"           # on_schedule only; robfig/cron/v3 standard (5-field) syntax
+      # schedule_timezone: "Europe/Berlin" # on_schedule only; empty = daemon local time
+      # scope_lookback: 24h                # on_scope_close AND on_schedule; also bounds missed-tick recovery
+      version_strategy: conventional_commits
+      tag_prefix: "v"
+      generate_changelog: true
+      notify_on_release: true
+      # require_ci: wait for post-merge CI on the target branch before releasing.
+      # Gates every release path — the webhook-driven merge handler AND the
+      # polled external-merge/scan-recovery paths (GH-3994) — by routing through
+      # the same StagePostMergeCI wait; set false to release immediately on merge.
+      require_ci: true
+      # generate_summary prepends an LLM (Haiku) "## What's New" summary to the
+      # release body. Requires ANTHROPIC_API_KEY in the daemon's environment —
+      # unset means the summary step is silently skipped (releases still ship,
+      # just without it). Has no effect under `publish: tag_only` (GH-3992).
+      generate_summary: true
+      # Who actually publishes the GitHub Release once the tag is created:
+      #   workflow  (default when empty) - Pilot only creates the tag; the repo's
+      #             own tag-triggered CI (e.g. GoReleaser) publishes the release.
+      #             Preserves existing behavior byte-for-byte.
+      #   api       - Pilot publishes the GitHub Release itself via the API
+      #             immediately after tagging. Only use this on repos with NO
+      #             tag-triggered release workflow of their own (see the
+      #             per-project `release.publish: api` example under `projects:`
+      #             for the full warning on why this must not be combined with
+      #             GoReleaser).
+      #   tag_only  - the tag is created and nothing publishes a release; use
+      #             for repos with an intentionally manual release process.
+      publish: workflow
+      # Opt-in: also consider merged PRs whose head branch is NOT pilot/* for
+      # release tagging (GH-3928). Default false - zero behavior change; only
+      # pilot/* branches are scanned. When true, ScanRecentlyMergedPRs also
+      # picks up human-authored PRs merged into the environment's default
+      # branch. Whether a release is actually cut still depends entirely on
+      # conventional-commit hygiene: squash-merge means the PR TITLE becomes
+      # the commit subject, so a `feat: ...`/`fix: ...` title bumps a version
+      # and a non-conventional title (or `docs:`/`chore:`/`refactor:`) produces
+      # no release. Merge metrics, self-heal, and board sync are unaffected -
+      # those remain Pilot-PR-only regardless of this flag.
+      tag_human_merges: false
+
+    # Define named environment configurations
+    # Each environment can have different branch, approval, and CI settings
+    environments:
+      # Development environment: fast feedback, auto-merge
+      dev:
+        branch: develop
+        require_approval: false
+        ci_timeout: 5m
+        skip_post_merge_ci: true
+        post_merge:
+          action: "none"
+
+      # Staging environment: wait for CI, then auto-merge
+      staging:
+        branch: staging
+        require_approval: false
+        ci_timeout: 30m
+        skip_post_merge_ci: false
+        post_merge:
+          action: "none"
+
+      # Production environment: requires human approval
+      prod:
+        branch: main
+        require_approval: true
+        approval_source: "telegram"
+        approval_timeout: 1h
+        ci_timeout: 30m
+        skip_post_merge_ci: false
+        merge_method: "squash"
+        post_merge:
+          action: "tag"
+          # For webhook action:
+          # webhook_url: "https://example.com/deploy"
+          # webhook_secret: "${DEPLOY_WEBHOOK_SECRET}"
+
+    # Approval configuration (per-environment override possible)
+    github_review:
+      poll_interval: 30s
+
+    # CI Check Discovery (v0.34+)
+    ci_checks:
+      mode: auto                    # auto | manual (default: auto)
+      exclude:                      # Check names to ignore in auto mode
+        - "codecov/*"              # Glob patterns supported
+        - "*-optional"
+      # required: []                # Allowlist; when non-empty, scopes status/failure
+      #                              # attribution to exactly these checks even in auto
+      #                              # mode (GH-4307) — use this to shield against
+      #                              # unrelated scheduled/canary checks landing on the
+      #                              # same SHA instead of enumerating them in `exclude`.
+      #                              # Precedence (GH-4333): a non-empty `required` here
+      #                              # always wins. If empty, the deprecated top-level
+      #                              # `required_checks` is used as a fallback (with a
+      #                              # startup WARN). If both are empty, no allowlist is
+      #                              # active and ALL non-excluded checks gate CI status.
+      discovery_grace_period: 60s   # Wait for CI to start
+
+    # Test-evidence gate (GH-4329): escalate-only, same pattern as the
+    # scope-drift/size-floor gates above. Green CI proves a check concluded
+    # "success" — it does NOT prove tests actually ran. When enabled, autopilot
+    # fetches the completed test job's log for the merge SHA and holds
+    # auto-merge (requiring human approval + posts a PR comment) if it looks
+    # like CI verified nothing: zero tests ran, or the skip ratio exceeds
+    # max_skip_ratio, on a PR that touches production source.
+    # Default off — enable per-project once canaried (pilot repo + pilot-console first).
+    test_evidence:
+      enabled: false
+      min_tests: 1        # escalate if fewer than this many tests ran
+      max_skip_ratio: 0.5  # escalate if skipped/(run+skipped) exceeds this
+
+    # Cross-PR platform-outage breaker (GH-4791, TASK-458 part 1). The
+    # per-PR circuit breaker above is deliberately scoped to one PR at a
+    # time ("so one bad PR doesn't block others") and cannot see a
+    # platform-wide outage by construction — each affected PR looks like a
+    # normal individual failure. This breaker correlates CI-failure
+    # observations across PRs (and repos, when multiple are configured):
+    # when min_correlated_prs distinct PRs observe an infra-or-unknown-class
+    # CI failure within correlation_window, it opens and suppresses
+    # destructive CI-failure actions (auto-close, fix-issue creation,
+    # escalate-and-hold) — affected PRs simply stay parked and are
+    # re-examined on a later tick. It closes again after quiet_period
+    # elapses with no further infra/unknown-class failure. One process-wide
+    # breaker shared by every controller (like the rate-limit budget
+    # tracker), since an outage is not scoped to a single repo.
+    # Default off.
+    #
+    # GH-4792 (TASK-458 part 2) adds, on top of part 1's correlation/suppression:
+    #   - an advisory githubstatus.com corroboration probe fired once per open
+    #     transition (never gates open/close — status pages lag reality)
+    #   - pausing new-work admission while open (pause_admission)
+    #   - suppressing merges of already-green PRs while open (CI signal is
+    #     untrustworthy during a platform incident)
+    #   - re-driving PRs the breaker parked back into StageWaitingCI once it
+    #     closes, up to a capped number of re-adoption attempts
+    platform_breaker:
+      enabled: false
+      min_correlated_prs: 3   # distinct PRs observing infra/unknown failures to open the breaker
+      correlation_window: 15m # how far back distinct-PR observations count toward the threshold
+      quiet_period: 20m       # how long with no new infra/unknown failure before it closes again
+      probe_interval: 5m      # how often the periodic monitor re-checks close + re-drives held PRs
+                               # during a quiet spell with no CI activity anywhere to trigger it
+      pause_admission: true   # pause new-work admission (Dispatcher) while the breaker is open;
+                               # set false to keep dispatching new tasks even during a suspected
+                               # platform outage (merge suppression and PR-parking still apply)
+
+    # CI fix iteration cap (GH-1566): chained fix(ci) issues per PR before giving up.
+    # sequential mode closes the PR to unblock the queue; any other mode holds it open with pilot-needs-human, branch intact.
+    max_ci_fix_iterations: 3  # Set to 0 to disable the limit
+
+    # Review-feedback handling: auto-creates a revision issue on CHANGES_REQUESTED.
+    review_feedback:
+      enabled: true
+      # Revision iteration cap, same closure semantics as max_ci_fix_iterations above.
+      max_iterations: 3  # Set to 0 to disable the limit
+
 # Executor settings
 executor:
   type: "claude-code"          # "claude-code", "opencode", "anthropic-api", or "openai-api"
@@ -670,233 +897,6 @@ projects:
   #     owner: "qf-studio"
   #     repo: "pilot-canary-sandbox"
   #   canary: true
-
-# Autopilot settings
-autopilot:
-  enabled: false
-  # Default environment used when --env is not specified (default: stage)
-  default_environment: "stage"
-  # Global autopilot settings
-  auto_merge: true
-  merge_method: "squash"
-  ci_wait_timeout: 30m
-  ci_poll_interval: 30s
-  approval_source: "telegram"   # telegram, slack, or github-review
-
-  # GH-4391: shared GitHub rate-limit budget. The GitHub primary rate limit
-  # is pooled per authenticated user across every client/session that user
-  # holds, so a startup burst of wide scans across many repos can silently
-  # starve the issue pollers even though `gh api rate_limit` looks fine from
-  # a different token/session's view of the same pool. These three settings
-  # bound that burst; defaults match the incident-driven values below.
-  #
-  # startup_merged_pr_scan_window: lookback for the one-time boot catch-up
-  # sweep (self-heal + board write-back for PRs merged while the daemon was
-  # down). Down from a hardcoded 720h (30d) — a restart minutes after the
-  # last startup scan doesn't need to re-walk a month of history; it also
-  # shrinks further on restart via a persisted per-repo cursor.
-  startup_merged_pr_scan_window: 72h
-  # rate_limit_floor_pct: once remaining/limit on the shared budget drops
-  # below this fraction, background scans (merged-PR scans, orphan-PR
-  # sweeps, reconciler evidence fetches) pause until headroom recovers.
-  # Issue pollers and active-PR CI watches are never gated — they're the
-  # highest-value consumer and must always get the reserve.
-  rate_limit_floor_pct: 0.15
-  # scan_stagger_interval: average delay between per-repo startup scans
-  # (jittered +/- 25%), so N repos' scans spread out over roughly
-  # N * scan_stagger_interval instead of all firing back-to-back at boot.
-  scan_stagger_interval: 3s
-
-  # Automatic release creation on PR merge (GH-3926).
-  release:
-    enabled: false
-    # Release cadence (GH-3989):
-    #   on_merge       (default) - cut a release for every merged PR.
-    #   manual         - never auto-release.
-    #   on_scope_close - hold merges belonging to an open epic (parent issue)
-    #                    or a shared "scope:"-prefixed label; standalone
-    #                    merges still release per-merge. The scope releases
-    #                    once when it completes (scope-close reconciler ships
-    #                    in a follow-up issue; this issue is config + hold
-    #                    semantics only - held work is fully reconstructable
-    #                    from GitHub in the meantime).
-    #   on_schedule    - hold every merge for a cron release train (see
-    #                    `schedule` below). At each tick, everything merged
-    #                    since the last tag is batched into one validated
-    #                    release (GH-3993). Restart across a tick still fires
-    #                    it exactly once (missed-tick recovery, bounded by
-    #                    `scope_lookback` below); a miss older than that
-    #                    window needs a manual re-trigger. DST transitions
-    #                    follow robfig/cron/v3's cron.WithLocation semantics
-    #                    (no special-casing). Urgent hotfix under
-    #                    `on_schedule`: everything still waits for the next
-    #                    tick by design - flip `trigger` to `on_merge`
-    #                    temporarily (config reload) if it can't wait.
-    #
-    # `on_scope_close`/`on_schedule` release notes (GH-3992): the aggregated
-    # scope body (headline, grouped Features/Fixes/Other with #PR + GH-issue
-    # links, breaking changes, What's New, compare footer) is only composed
-    # for `publish: api` or `publish: workflow` — `tag_only` never creates a
-    # release object, so there is nothing to attach notes to.
-    trigger: on_merge
-    # scope_label_prefix: "scope:"       # on_scope_close only; default "scope:"
-    # schedule: "0 21 * * FRI"           # on_schedule only; robfig/cron/v3 standard (5-field) syntax
-    # schedule_timezone: "Europe/Berlin" # on_schedule only; empty = daemon local time
-    # scope_lookback: 24h                # on_scope_close AND on_schedule; also bounds missed-tick recovery
-    version_strategy: conventional_commits
-    tag_prefix: "v"
-    generate_changelog: true
-    notify_on_release: true
-    # require_ci: wait for post-merge CI on the target branch before releasing.
-    # Gates every release path — the webhook-driven merge handler AND the
-    # polled external-merge/scan-recovery paths (GH-3994) — by routing through
-    # the same StagePostMergeCI wait; set false to release immediately on merge.
-    require_ci: true
-    # generate_summary prepends an LLM (Haiku) "## What's New" summary to the
-    # release body. Requires ANTHROPIC_API_KEY in the daemon's environment —
-    # unset means the summary step is silently skipped (releases still ship,
-    # just without it). Has no effect under `publish: tag_only` (GH-3992).
-    generate_summary: true
-    # Who actually publishes the GitHub Release once the tag is created:
-    #   workflow  (default when empty) - Pilot only creates the tag; the repo's
-    #             own tag-triggered CI (e.g. GoReleaser) publishes the release.
-    #             Preserves existing behavior byte-for-byte.
-    #   api       - Pilot publishes the GitHub Release itself via the API
-    #             immediately after tagging. Only use this on repos with NO
-    #             tag-triggered release workflow of their own (see the
-    #             per-project `release.publish: api` example under `projects:`
-    #             for the full warning on why this must not be combined with
-    #             GoReleaser).
-    #   tag_only  - the tag is created and nothing publishes a release; use
-    #             for repos with an intentionally manual release process.
-    publish: workflow
-    # Opt-in: also consider merged PRs whose head branch is NOT pilot/* for
-    # release tagging (GH-3928). Default false - zero behavior change; only
-    # pilot/* branches are scanned. When true, ScanRecentlyMergedPRs also
-    # picks up human-authored PRs merged into the environment's default
-    # branch. Whether a release is actually cut still depends entirely on
-    # conventional-commit hygiene: squash-merge means the PR TITLE becomes
-    # the commit subject, so a `feat: ...`/`fix: ...` title bumps a version
-    # and a non-conventional title (or `docs:`/`chore:`/`refactor:`) produces
-    # no release. Merge metrics, self-heal, and board sync are unaffected -
-    # those remain Pilot-PR-only regardless of this flag.
-    tag_human_merges: false
-
-  # Define named environment configurations
-  # Each environment can have different branch, approval, and CI settings
-  environments:
-    # Development environment: fast feedback, auto-merge
-    dev:
-      branch: develop
-      require_approval: false
-      ci_timeout: 5m
-      skip_post_merge_ci: true
-      post_merge:
-        action: "none"
-
-    # Staging environment: wait for CI, then auto-merge
-    staging:
-      branch: staging
-      require_approval: false
-      ci_timeout: 30m
-      skip_post_merge_ci: false
-      post_merge:
-        action: "none"
-
-    # Production environment: requires human approval
-    prod:
-      branch: main
-      require_approval: true
-      approval_source: "telegram"
-      approval_timeout: 1h
-      ci_timeout: 30m
-      skip_post_merge_ci: false
-      merge_method: "squash"
-      post_merge:
-        action: "tag"
-        # For webhook action:
-        # webhook_url: "https://example.com/deploy"
-        # webhook_secret: "${DEPLOY_WEBHOOK_SECRET}"
-
-  # Approval configuration (per-environment override possible)
-  github_review:
-    poll_interval: 30s
-
-  # CI Check Discovery (v0.34+)
-  ci_checks:
-    mode: auto                    # auto | manual (default: auto)
-    exclude:                      # Check names to ignore in auto mode
-      - "codecov/*"              # Glob patterns supported
-      - "*-optional"
-    # required: []                # Allowlist; when non-empty, scopes status/failure
-    #                              # attribution to exactly these checks even in auto
-    #                              # mode (GH-4307) — use this to shield against
-    #                              # unrelated scheduled/canary checks landing on the
-    #                              # same SHA instead of enumerating them in `exclude`.
-    #                              # Precedence (GH-4333): a non-empty `required` here
-    #                              # always wins. If empty, the deprecated top-level
-    #                              # `required_checks` is used as a fallback (with a
-    #                              # startup WARN). If both are empty, no allowlist is
-    #                              # active and ALL non-excluded checks gate CI status.
-    discovery_grace_period: 60s   # Wait for CI to start
-
-  # Test-evidence gate (GH-4329): escalate-only, same pattern as the
-  # scope-drift/size-floor gates above. Green CI proves a check concluded
-  # "success" — it does NOT prove tests actually ran. When enabled, autopilot
-  # fetches the completed test job's log for the merge SHA and holds
-  # auto-merge (requiring human approval + posts a PR comment) if it looks
-  # like CI verified nothing: zero tests ran, or the skip ratio exceeds
-  # max_skip_ratio, on a PR that touches production source.
-  # Default off — enable per-project once canaried (pilot repo + pilot-console first).
-  test_evidence:
-    enabled: false
-    min_tests: 1        # escalate if fewer than this many tests ran
-    max_skip_ratio: 0.5  # escalate if skipped/(run+skipped) exceeds this
-
-  # Cross-PR platform-outage breaker (GH-4791, TASK-458 part 1). The
-  # per-PR circuit breaker above is deliberately scoped to one PR at a
-  # time ("so one bad PR doesn't block others") and cannot see a
-  # platform-wide outage by construction — each affected PR looks like a
-  # normal individual failure. This breaker correlates CI-failure
-  # observations across PRs (and repos, when multiple are configured):
-  # when min_correlated_prs distinct PRs observe an infra-or-unknown-class
-  # CI failure within correlation_window, it opens and suppresses
-  # destructive CI-failure actions (auto-close, fix-issue creation,
-  # escalate-and-hold) — affected PRs simply stay parked and are
-  # re-examined on a later tick. It closes again after quiet_period
-  # elapses with no further infra/unknown-class failure. One process-wide
-  # breaker shared by every controller (like the rate-limit budget
-  # tracker), since an outage is not scoped to a single repo.
-  # Default off.
-  #
-  # GH-4792 (TASK-458 part 2) adds, on top of part 1's correlation/suppression:
-  #   - an advisory githubstatus.com corroboration probe fired once per open
-  #     transition (never gates open/close — status pages lag reality)
-  #   - pausing new-work admission while open (pause_admission)
-  #   - suppressing merges of already-green PRs while open (CI signal is
-  #     untrustworthy during a platform incident)
-  #   - re-driving PRs the breaker parked back into StageWaitingCI once it
-  #     closes, up to a capped number of re-adoption attempts
-  platform_breaker:
-    enabled: false
-    min_correlated_prs: 3   # distinct PRs observing infra/unknown failures to open the breaker
-    correlation_window: 15m # how far back distinct-PR observations count toward the threshold
-    quiet_period: 20m       # how long with no new infra/unknown failure before it closes again
-    probe_interval: 5m      # how often the periodic monitor re-checks close + re-drives held PRs
-                             # during a quiet spell with no CI activity anywhere to trigger it
-    pause_admission: true   # pause new-work admission (Dispatcher) while the breaker is open;
-                             # set false to keep dispatching new tasks even during a suspected
-                             # platform outage (merge suppression and PR-parking still apply)
-
-  # CI fix iteration cap (GH-1566): chained fix(ci) issues per PR before giving up.
-  # sequential mode closes the PR to unblock the queue; any other mode holds it open with pilot-needs-human, branch intact.
-  max_ci_fix_iterations: 3  # Set to 0 to disable the limit
-
-  # Review-feedback handling: auto-creates a revision issue on CHANGES_REQUESTED.
-  review_feedback:
-    enabled: true
-    # Revision iteration cap, same closure semantics as max_ci_fix_iterations above.
-    max_iterations: 3  # Set to 0 to disable the limit
 
 # Dashboard settings
 dashboard:

--- a/docs/content/features/autopilot.mdx
+++ b/docs/content/features/autopilot.mdx
@@ -22,15 +22,16 @@ See [Autopilot Environments](/features/autopilot-environments) for detailed beha
 
 ```yaml
 # ~/.pilot/config.yaml
-autopilot:
-  enabled: true
-  environment: stage
-  auto_merge: true
-  require_ci: true
-  merge_delay: 5m  # Wait before merging (stage only)
-  protected_branches:
-    - main
-    - production
+orchestrator:
+  autopilot:
+    enabled: true
+    environment: stage
+    auto_merge: true
+    require_ci: true
+    merge_delay: 5m  # Wait before merging (stage only)
+    protected_branches:
+      - main
+      - production
 ```
 
 ## Usage
@@ -146,13 +147,14 @@ Auto-rebase avoids ~$8–15 per full re-execution for conflicts that are trivial
 
 ```yaml
 # ~/.pilot/config.yaml
-autopilot:
-  enabled: true
-  conflict_handling:
-    auto_rebase: true        # Enable auto-rebase via GitHub API (default: true)
-    close_on_failure: true   # Close PR if rebase fails (default: true)
-    requeue_on_failure: true # Re-queue issue for fresh execution (default: true)
-    max_rebase_attempts: 1   # Attempts before falling back to close (default: 1)
+orchestrator:
+  autopilot:
+    enabled: true
+    conflict_handling:
+      auto_rebase: true        # Enable auto-rebase via GitHub API (default: true)
+      close_on_failure: true   # Close PR if rebase fails (default: true)
+      requeue_on_failure: true # Re-queue issue for fresh execution (default: true)
+      max_rebase_attempts: 1   # Attempts before falling back to close (default: 1)
 ```
 
 Set `auto_rebase: false` to skip the rebase attempt and immediately close-and-requeue on any conflict. This is useful if your CI is fast and re-execution is cheaper than debugging merge artifacts.
@@ -182,15 +184,16 @@ Controls how many chained CI-fix issues autopilot will spawn for the same PR bef
 
 ```yaml
 # ~/.pilot/config.yaml
-autopilot:
-  max_ci_fix_iterations: 3  # Maximum CI fix cycles before giving up (default: 3)
+orchestrator:
+  autopilot:
+    max_ci_fix_iterations: 3  # Maximum CI fix cycles before giving up (default: 3)
 ```
 
-This is a CI-monitor safety guard, but the key itself is **not** nested under a separate `ci_monitor:` block — `internal/autopilot/types.go:144-147` places `MaxCIFixIterations` as a flat, top-level field on the `autopilot` config struct (`yaml:"max_ci_fix_iterations"`), a sibling of `max_failures` rather than a child of `review_feedback`-style sub-config.
+This is a CI-monitor safety guard, but the key itself is **not** nested under a separate `ci_monitor:` block — `autopilot.Config.MaxCIFixIterations` (`internal/autopilot/types.go`) is a flat, top-level field on the `autopilot` config struct (`yaml:"max_ci_fix_iterations"`), a sibling of `max_failures` rather than a child of `review_feedback`-style sub-config.
 
 | Guard | Description |
 |-------|-------------|
-| Iteration limit | Controlled by `max_ci_fix_iterations` (default: `3`, `internal/autopilot/types.go:144-147`). Closure semantics when the limit is reached depend on `orchestrator.execution.mode`: under `sequential`, the PR is closed to unblock the queue. Under any other mode (including the default `auto`), the PR is held open with the `pilot-needs-human` label and the branch left intact for manual continuation. |
+| Iteration limit | Controlled by `max_ci_fix_iterations` (default: `3`, `autopilot.Config.MaxCIFixIterations` in `internal/autopilot/types.go`). Closure semantics when the limit is reached depend on `orchestrator.execution.mode`: under `sequential`, the PR is closed to unblock the queue. Under any other mode (including the default `auto`), the PR is held open with the `pilot-needs-human` label and the branch left intact for manual continuation. |
 
 <Callout type="info">
   `max_ci_fix_iterations: N` produces exactly N fix issues for a given PR — the Nth fix PR's own CI failure hits the limit and gets no further fix cycle.
@@ -305,10 +308,11 @@ Review feedback works in both operational modes:
 
 ```yaml
 # ~/.pilot/config.yaml
-autopilot:
-  review_feedback:
-    enabled: true
-    max_iterations: 3  # Maximum revision cycles before giving up (default: 3)
+orchestrator:
+  autopilot:
+    review_feedback:
+      enabled: true
+      max_iterations: 3  # Maximum revision cycles before giving up (default: 3)
 ```
 
 ### Safety Guards

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -807,6 +807,17 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse config: %w", err)
 	}
 
+	// GH-5251: every documented autopilot YAML example nests the block
+	// under orchestrator.autopilot, but yaml.v3 silently drops unknown
+	// top-level keys — a config with a top-level `autopilot:` block (an
+	// easy copy-paste mistake, and the same footgun that once bound
+	// platform_breaker.enabled to nothing) loads with no error and no
+	// effect. Detect it and either lift it into orchestrator.autopilot
+	// or warn loudly that it's being ignored in favor of the nested block.
+	if err := liftTopLevelAutopilot(expanded, config); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+
 	// Expand paths
 	if config.Memory != nil {
 		config.Memory.Path = expandPath(config.Memory.Path)
@@ -844,6 +855,45 @@ func Load(path string) (*Config, error) {
 	applyLedgerStalenessThreshold(config)
 
 	return config, nil
+}
+
+// liftTopLevelAutopilot detects a documented-but-misplaced top-level
+// `autopilot:` block (GH-5251). yaml.Unmarshal into Config silently drops
+// it because Config has no top-level Autopilot field — the only field that
+// binds is orchestrator.autopilot. A probe-decode into a throwaway struct
+// with both shapes tells us whether a top-level block is present and
+// whether orchestrator.autopilot was also explicitly set in the same file.
+//
+//   - Top-level only: lift it into orchestrator.autopilot so the documented
+//     snippets (configs/pilot.example.yaml, docs/content/features/autopilot.mdx)
+//     work when copy-pasted verbatim, and warn so the user fixes the nesting.
+//   - Both present: the main Unmarshal above already merged the nested block
+//     into config.Orchestrator.Autopilot correctly; warn that the top-level
+//     duplicate is being ignored rather than silently overwriting it.
+//   - Neither/nested-only: nothing to do.
+func liftTopLevelAutopilot(expanded string, config *Config) error {
+	var probe struct {
+		Autopilot    *autopilot.Config `yaml:"autopilot"`
+		Orchestrator struct {
+			Autopilot *autopilot.Config `yaml:"autopilot"`
+		} `yaml:"orchestrator"`
+	}
+	if err := yaml.Unmarshal([]byte(expanded), &probe); err != nil {
+		return err
+	}
+	if probe.Autopilot == nil {
+		return nil
+	}
+	if probe.Orchestrator.Autopilot != nil {
+		log.Printf("WARNING: config: top-level `autopilot:` block is ignored because orchestrator.autopilot is also set in this file — remove the top-level block or merge its keys into orchestrator.autopilot")
+		return nil
+	}
+	log.Printf("DEPRECATED: config: top-level `autopilot:` block found — nest it under orchestrator.autopilot instead (see configs/pilot.example.yaml); loading it for now")
+	if config.Orchestrator == nil {
+		config.Orchestrator = &OrchestratorConfig{}
+	}
+	config.Orchestrator.Autopilot = probe.Autopilot
+	return nil
 }
 
 // applyLedgerStalenessThreshold wires config.Ledger.StalenessWarnAfter

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1788,6 +1788,89 @@ adapters:
 	}
 }
 
+// TestLoadWithTopLevelAutopilot covers GH-5251: every documented autopilot
+// YAML example (configs/pilot.example.yaml, docs/content/features/autopilot.mdx)
+// nests the block under orchestrator.autopilot, but yaml.v3 silently drops
+// unknown top-level keys — a config with a top-level `autopilot:` block used
+// to load with no error and no effect. Load must now lift it into
+// orchestrator.autopilot so the values actually take effect.
+func TestLoadWithTopLevelAutopilot(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+version: "1.0"
+autopilot:
+  enabled: true
+  max_ci_fix_iterations: 7
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(originalOutput)
+
+	config, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if config.Orchestrator == nil || config.Orchestrator.Autopilot == nil {
+		t.Fatal("Orchestrator.Autopilot is nil, want the top-level block lifted into it")
+	}
+	if !config.Orchestrator.Autopilot.Enabled {
+		t.Errorf("Orchestrator.Autopilot.Enabled = false, want true (lifted from top-level autopilot block)")
+	}
+	if config.Orchestrator.Autopilot.MaxCIFixIterations != 7 {
+		t.Errorf("Orchestrator.Autopilot.MaxCIFixIterations = %d, want 7 (lifted from top-level autopilot block)", config.Orchestrator.Autopilot.MaxCIFixIterations)
+	}
+	if !strings.Contains(logBuf.String(), "orchestrator.autopilot") {
+		t.Errorf("expected a warning log naming orchestrator.autopilot, got: %q", logBuf.String())
+	}
+}
+
+// TestLoadWithTopLevelAndNestedAutopilot covers the case where both a
+// top-level `autopilot:` block AND the correctly-nested orchestrator.autopilot
+// block are present in the same file (e.g. a partial migration). The nested
+// block must win — it's the one that actually binds — and the top-level
+// duplicate must be flagged as ignored rather than silently overwriting it.
+func TestLoadWithTopLevelAndNestedAutopilot(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+version: "1.0"
+autopilot:
+  max_ci_fix_iterations: 7
+orchestrator:
+  autopilot:
+    max_ci_fix_iterations: 2
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(originalOutput)
+
+	config, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if config.Orchestrator.Autopilot.MaxCIFixIterations != 2 {
+		t.Errorf("Orchestrator.Autopilot.MaxCIFixIterations = %d, want 2 (the nested block must win over the ignored top-level duplicate)", config.Orchestrator.Autopilot.MaxCIFixIterations)
+	}
+	if !strings.Contains(logBuf.String(), "is ignored") {
+		t.Errorf("expected a warning log noting the top-level block is ignored, got: %q", logBuf.String())
+	}
+}
+
 func TestLoadTeamConfig(t *testing.T) {
 	t.Run("team config from YAML", func(t *testing.T) {
 		tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5251.

Closes #5251

## Changes

GitHub Issue GH-5251: fix(config): documented top-level autopilot block is silently ignored — loader only reads orchestrator.autopilot

## Problem

Every documented top-level autopilot YAML example is silently ignored by the config loader.

Both `configs/pilot.example.yaml` (top-level autopilot block at ~line 675, including the max_ci_fix_iterations / review_feedback keys added at ~891-899 by PR#5245) and every YAML snippet in `docs/content/features/autopilot.mdx` (~lines 24, 148, 184, 308) document autopilot keys under a **top-level** autopilot block. The loader only reads the nested orchestrator.autopilot section (`internal/config/config.go` ~line 170); there is no top-level alias, no key-lifting in Load, and yaml.v3 silently drops unknown top-level keys.

Probe-verified during the PR#5245 post-merge review: a config with a top-level autopilot block setting max_ci_fix_iterations to 7 leaves the value at the default 3; the same keys nested under orchestrator load correctly.

Same footgun already bit production once: platform_breaker.enabled under a top-level autopilot block bound to nothing (2026-08-13 config note; the working key is nested under orchestrator).

## Why it has never bitten the founder box

Production enables autopilot via the --env flag path (`cmd/pilot/main.go` ~lines 597-600), not via a YAML autopilot block. Any external user copying the documented snippets into their pilot config file (config.yaml in the user's .pilot home directory) gets silently-ignored settings with no warning.

## Fix (either leg is acceptable; both is best)

1. **Docs/example leg (minimum):** re-nest every autopilot snippet in `configs/pilot.example.yaml` and `docs/content/features/autopilot.mdx` under orchestrator so copy-paste works.
2. **Loader leg (defense):** in Load, detect a top-level autopilot key and either lift it into orchestrator.autopilot (alias) or emit a loud startup warning naming the correct nesting. A generic unknown-top-level-key warning would catch the whole class.

## Acceptance

- Copying any documented autopilot snippet into the user config verbatim results in the values actually loading (probe: set max_ci_fix_iterations to 7, assert the controller sees 7), OR the daemon logs a startup warning naming the orchestrator.autopilot path.
- A regression test covers whichever leg ships (docs-lint or loader unit test).
- While editing `docs/content/features/autopilot.mdx`: replace the stale line-number citations for MaxCIFixIterations (they point at pre-PR#5244 positions in `internal/autopilot/types.go`) with symbol references.

## History

Refiled from #5246, which was NOT failing on its merits: the referenced-path gate held it 20 cycles over a backticked home-directory config path in the body (not a repo path → base-presence hold → escalation). Found during the post-merge review of PR#5245, which extended the pattern but did not create it.