### PR TITLE
GH-5252: fix(autopilot): owner-death re-arm of a superseded hand-off source never dispatches — demote the ledger row alongside the label strip

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -261,6 +261,16 @@ type EvalStore interface {
 	// orphan-running sweep (a fresh event means the execution is still
 	// actively progressing even if the Monitor set missed it). TASK-399/GH-4209.
 	ListExecutionEvents(executionID string) ([]*memory.Event, error)
+	// ReclassifySupersededForRearm demotes a status='superseded' row to
+	// 'failed' so HasTerminalCompletion stops treating it as terminal and the
+	// ordinary retry-generation grant resumes. GH-5249 introduced this for
+	// the poller re-arm probe (cmd/pilot/rearm_superseded.go); GH-5252 adds a
+	// second caller — rearmDeadOwnerSource — since the durable-claim
+	// fallback in reactToDeadFixIssue can re-arm a source whose latest
+	// terminal evidence is a superseded row, not a pilot-failed label. The
+	// underlying UPDATE is filtered on status='superseded', so calling this
+	// when no such row exists is a safe no-op.
+	ReclassifySupersededForRearm(taskID, projectPath, reason string) error
 }
 
 // ControllerOption is a functional option for Controller configuration.

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6285,6 +6285,9 @@ type mockEvalStore struct {
 	lastExcludeTaskIDs []string                   // last exclude set FindOrphanedRunningExecutions was called with
 	resolvedOrphans    []resolveOrphanCall        // ResolveOrphanedRunningExecution calls
 	executionEvents    map[string][]*memory.Event // ListExecutionEvents responses keyed by execution ID
+
+	// GH-5252: ReclassifySupersededForRearm call log for owner-death re-arm assertions.
+	reclassifiedSupersededForRearm []reclassifyCall
 }
 
 // resolveOrphanCall records one ResolveOrphanedRunningExecution invocation. TASK-399/GH-4209.
@@ -6400,6 +6403,12 @@ func (m *mockEvalStore) ResolveOrphanedRunningExecution(id, prURL string) error 
 // or nil (no heartbeat) for an unconfigured ID. TASK-399/GH-4209.
 func (m *mockEvalStore) ListExecutionEvents(executionID string) ([]*memory.Event, error) {
 	return m.executionEvents[executionID], nil
+}
+
+// ReclassifySupersededForRearm records the call for assertions. GH-5252.
+func (m *mockEvalStore) ReclassifySupersededForRearm(taskID, projectPath, reason string) error {
+	m.reclassifiedSupersededForRearm = append(m.reclassifiedSupersededForRearm, reclassifyCall{TaskID: taskID, ProjectPath: projectPath, Reason: reason})
+	return nil
 }
 
 // TestHandleMerged_ExtractsEvalTask verifies that handleMerged extracts and saves

--- a/internal/autopilot/owner_death.go
+++ b/internal/autopilot/owner_death.go
@@ -240,6 +240,25 @@ func (c *Controller) rearmDeadOwnerSource(ctx context.Context, source *github.Is
 	if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, source.Number, github.LabelSuperseded); err != nil {
 		c.log.Debug("owner-death: failed to remove pilot-superseded label (may not exist)", "issue", source.Number, "error", err)
 	}
+	// GH-5252: the label strip above is cosmetic only — HasTerminalCompletion
+	// reads the ledger, not labels. If this source's latest terminal evidence
+	// is a 'superseded' execution row (the durable-claim fallback above can
+	// reach a hand-off-designated source, not just a pilot-failed one), that
+	// row survives the SDK poller's retry-ready rung (InvalidateCompletion
+	// only deletes 'completed' rows) and keeps HasTerminalCompletion=true
+	// forever — the re-arm comment posts, the retry-budget label is
+	// consumed, and dispatch never fires. Demote it here exactly like the
+	// GH-5249 poller probe does (tryRearmSuperseded), instead of requiring a
+	// second, separate re-arm gesture the owner-death path never emits. The
+	// underlying UPDATE only touches status='superseded' rows, so this is a
+	// no-op when the terminal evidence was pilot-failed instead.
+	if c.evalStore != nil {
+		taskID := fmt.Sprintf("GH-%d", source.Number)
+		reclassifyReason := fmt.Sprintf("GH-5252: owner-death re-arm (%s)", reasonMsg)
+		if err := c.evalStore.ReclassifySupersededForRearm(taskID, c.projectPath, reclassifyReason); err != nil {
+			c.log.Warn("owner-death: failed to demote superseded ledger row for re-arm", "issue", source.Number, "error", err)
+		}
+	}
 	comment := fmt.Sprintf(
 		"\U0001F501 **Owner-death recovery**: %s. Re-armed for automatic retry (`%s` restored).",
 		reasonMsg, github.LabelRetryReady,

--- a/internal/autopilot/owner_death_test.go
+++ b/internal/autopilot/owner_death_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/testutil"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
@@ -287,6 +288,12 @@ func TestController_ReactToDeadFixIssue(t *testing.T) {
 			c := NewController(cfg, ghClient, nil, "owner", "repo")
 			sink := &fakeAlertSink{}
 			c.SetAlertsEngine(sink)
+			// GH-5252: wire an evalStore so rearmDeadOwnerSource's ledger
+			// demote call is observable — the pre-fix behavior only ever
+			// touched labels, leaving a superseded row (if any) terminal
+			// forever.
+			evalMock := &mockEvalStore{}
+			c.SetEvalStore(evalMock)
 
 			deadIssue := &github.Issue{Number: 200, State: github.StateClosed, Body: fixIssueBody}
 			c.reactToDeadFixIssue(context.Background(), deadIssue, "closed without shipping")
@@ -304,6 +311,16 @@ func TestController_ReactToDeadFixIssue(t *testing.T) {
 						t.Errorf("expected %q to be removed from source #100, calls=%v", label, srv.removeLabelCalls)
 					}
 				}
+				// GH-5252: rearm must also demote the ledger row for this
+				// source — not just strip labels — so a superseded terminal
+				// row (if any) stops blocking dispatch.
+				if len(evalMock.reclassifiedSupersededForRearm) != 1 {
+					t.Fatalf("expected exactly 1 ReclassifySupersededForRearm call, got %d: %v",
+						len(evalMock.reclassifiedSupersededForRearm), evalMock.reclassifiedSupersededForRearm)
+				}
+				if got := evalMock.reclassifiedSupersededForRearm[0].TaskID; got != "GH-100" {
+					t.Errorf("ReclassifySupersededForRearm task_id = %q, want %q", got, "GH-100")
+				}
 			case tt.wantEscalate:
 				if !srv.hasAddLabel(100, labelNeedsHuman) {
 					t.Errorf("expected %s to be added to source #100, calls=%v", labelNeedsHuman, srv.addLabelCalls)
@@ -314,12 +331,20 @@ func TestController_ReactToDeadFixIssue(t *testing.T) {
 				if len(sink.events) != 1 {
 					t.Errorf("expected exactly 1 alert, got %d", len(sink.events))
 				}
+				// GH-5252: no dual-arm — escalation must never demote the
+				// ledger row, only rearm does.
+				if len(evalMock.reclassifiedSupersededForRearm) != 0 {
+					t.Errorf("expected no ReclassifySupersededForRearm calls on escalation, got %v", evalMock.reclassifiedSupersededForRearm)
+				}
 			case tt.wantNoReaction:
 				if len(srv.addLabelCalls) != 0 {
 					t.Errorf("expected no label writes, got %v", srv.addLabelCalls)
 				}
 				if len(sink.events) != 0 {
 					t.Errorf("expected no alerts, got %d", len(sink.events))
+				}
+				if len(evalMock.reclassifiedSupersededForRearm) != 0 {
+					t.Errorf("expected no ReclassifySupersededForRearm calls, got %v", evalMock.reclassifiedSupersededForRearm)
 				}
 			}
 		})
@@ -454,5 +479,84 @@ func TestFeedbackLoop_CreateFailureIssue_DedupOwnerHealth(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestController_RearmDeadOwnerSource_DemotesSupersededLedgerRow is GH-5252's
+// end-to-end coverage: before this fix, rearmDeadOwnerSource only stripped
+// labels, so a source whose latest terminal evidence was a 'superseded'
+// execution row (reached via the GH-4852 durable-claim fallback designating
+// a hand-off, not a pilot-failed, source) stayed HasTerminalCompletion=true
+// forever — the re-arm comment posts and a retry-budget label is consumed,
+// but the SDK poller's dispatch chokepoint (which reads the ledger, not
+// labels) never admits it again. This asserts the ledger flip itself, not
+// just the label writes the existing table test (TestController_
+// ReactToDeadFixIssue) already covers.
+func TestController_RearmDeadOwnerSource_DemotesSupersededLedgerRow(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const projectPath = "/proj/pilot-gh5252"
+	taskID := "GH-100"
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-gh5252-superseded", TaskID: taskID, ProjectPath: projectPath,
+		Status: "superseded", Error: "GH-5247: healthy hand-off to fix issue #200",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	done, err := store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion (before re-arm): %v", err)
+	}
+	if !done {
+		t.Fatal("expected done=true before re-arm — the superseded row is terminal")
+	}
+
+	sourceIssue := &github.Issue{
+		Number: 100,
+		State:  github.StateOpen,
+		Labels: []github.Label{{Name: github.LabelFailed}, {Name: github.LabelSuperseded}},
+	}
+	srv := newOwnerDeathGHServer()
+	srv.issues[100] = sourceIssue
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, ts.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(projectPath))
+	c.SetAlertsEngine(&fakeAlertSink{})
+	c.SetEvalStore(store)
+
+	fixIssueBody := "Fixes CI failure.\n\nDepends on: #100\n\n<!-- autopilot-meta branch:pilot/GH-100 pr:7 iteration:1 -->"
+	deadIssue := &github.Issue{Number: 200, State: github.StateClosed, Body: fixIssueBody}
+	c.reactToDeadFixIssue(context.Background(), deadIssue, "closed without shipping")
+
+	if !srv.hasAddLabel(100, github.LabelRetryReady) {
+		t.Fatalf("expected pilot-retry-ready to be added to source #100, calls=%v", srv.addLabelCalls)
+	}
+
+	// The acceptance-critical assertion: the ledger, not just the labels,
+	// must reflect the re-arm — the next SDK poll's dispatch chokepoint
+	// reads HasTerminalCompletion, which never consults GitHub labels.
+	done, err = store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion (after re-arm): %v", err)
+	}
+	if done {
+		t.Fatal("expected done=false after owner-death re-arm — the superseded row must be demoted so the next poll dispatches this source")
+	}
+
+	exec, err := store.GetExecution("exec-gh5252-superseded")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status=failed after re-arm demote, got %q", exec.Status)
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5252.

Closes #5252

## Changes

GitHub Issue GH-5252: fix(autopilot): owner-death re-arm of a superseded hand-off source never dispatches — demote the ledger row alongside the label strip

## Problem

Follow-up from the PR#5250 post-merge review (verdict on the PR). PR#5250 correctly makes `superseded` ledger rows terminal so open `pilot-superseded` hand-off sources stop re-dispatching. But the owner-death recovery path it touched is now a silent dead-end:

1. A fix issue dies; `reactToDeadFixIssue` designates the hand-off source via the GH-4852 durable-claim fallback.
2. `rearmDeadOwnerSource` (`internal/autopilot/owner_death.go` ~225-244) adds `pilot-retry-ready` and strips `pilot-failed` + `pilot-superseded` — **but never demotes the superseded ledger row**. `ReclassifySupersededForRearm` has exactly one caller in the tree (the poller probe in `cmd/pilot/rearm_superseded.go`).
3. The SDK poller's retry-ready rung calls `InvalidateCompletion`, which deletes only completed rows — the superseded row survives → `HasTerminalCompletion` stays true.
4. The re-arm probe demands a labeled-with-trigger or reopened event strictly after the supersede; owner-death only emitted retry-ready/unlabel events on an already-open issue → no evidence → skipped forever. The dispatch chokepoint and `nextRetryGeneration` gate on the same widened predicate.

Result: the operator log says "Re-armed for automatic retry", a retry-budget label is consumed, and nothing ever runs. Pre-PR#5250 this path actually dispatched. It fails safe (no dual-arm; a manual `pilot` label-cycle un-wedges via the probe), but the recovery path is functionally broken.

## Fix

In `rearmDeadOwnerSource`, alongside the existing label strip, demote the superseded ledger row — call `ReclassifySupersededForRearm` via the controller's evalStore, mirroring what the poller probe does (demote to failed so the ordinary generation grant resumes). Alternative considered in review (teach the probe to accept the retry-ready event) is worse: it leaves the ledger claiming terminal while dispatch proceeds.

## Acceptance

- After owner-death re-arm of a hand-off source, `HasTerminalCompletion` returns false for it and the next poll dispatches it (test asserts the ledger flip, not just labels — the existing owner-death table test only checks label removal).
- The poller-probe re-arm path (`rearm_superseded.go`) is unchanged and still passes its 4 wiring tests.
- No dual-arm: the demote happens only for the designated source of a dead fix issue.
- Genuine terminal states (completed / no_op / canceled) untouched.

## Refs

- PR#5250 review verdict (finding 1) · #5249 (parent) · GH-4852 (durable-claim designation) · #5247 / PR#5248 (origin of open pilot-superseded sources)