### PR TITLE
GH-5255: fix(config): top-level autopilot lift discards all defaults — decode into the default-populated struct, not a zero struct

### DIFF
--- a/.agent/knowledge/memories/pitfalls/top-level-autopilot-yaml-binds-to-nothing.md
+++ b/.agent/knowledge/memories/pitfalls/top-level-autopilot-yaml-binds-to-nothing.md
@@ -6,16 +6,36 @@ type: pitfall
 
 # Top-level `autopilot:` binds to nothing; without `--env` autopilot never starts
 
-**Status (2026-08-27, GH-5251):** leg 1 (silent-drop) is fixed. `config.Load`
-now detects a top-level `autopilot:` block via `liftTopLevelAutopilot`
-(`internal/config/config.go`): if `orchestrator.autopilot` is absent it lifts
-the top-level block into it (with a `DEPRECATED:` log), and if both are
-present it logs a `WARNING:` that the top-level duplicate is ignored in favor
-of the nested block. `configs/pilot.example.yaml` and every snippet in
+**Status (2026-08-27, GH-5251; defaults-loss closed 2026-08-29, GH-5255):**
+leg 1 (silent-drop) is fixed. `config.Load` now detects a top-level
+`autopilot:` block via `liftTopLevelAutopilot` (`internal/config/config.go`):
+if `orchestrator.autopilot` is absent it lifts the top-level block into it
+(with a `DEPRECATED:` log), and if both are present it logs a `WARNING:`
+that the top-level duplicate is ignored in favor of the nested block.
+`configs/pilot.example.yaml` and every snippet in
 `docs/content/features/autopilot.mdx` were re-nested under `orchestrator:` —
 the dead top-level shape referenced in point 3 below no longer exists in
 either. This does not change the `enabled`-not-emitted (pilot-console
 renderer) or missing-`--env` legs below — those are separate mechanisms.
+
+The GH-5251 fix itself shipped a subtler regression (GH-5255, PR#5253
+post-merge review): the original `liftTopLevelAutopilot` decoded the
+top-level block into a **fresh zero-value** `*autopilot.Config` and replaced
+`config.Orchestrator.Autopilot` wholesale, discarding every field
+`DefaultConfig()` seeds on the nested path (`MaxCIFixIterations`,
+`MaxFailures`, `MaxMergeAttempts`, `MergeMethod`, `ReviewFeedback`, …) — a
+lifted `{enabled: true, auto_merge: true}` block ran with the CI-fix cap and
+per-PR circuit breaker both disabled (`0` reads as "no limit"/"trip
+immediately" depending on the comparison direction), silently recreating a
+subtler version of the exact bug GH-5251 was filed to kill. Fixed by probing
+presence with a raw `yaml.Node` (`node.IsZero()`) instead of decoding into
+`*autopilot.Config` directly, then calling `node.Decode(config.Orchestrator.Autopilot)`
+— decoding onto the pointer already populated by `DefaultConfig()`, which is
+exactly how the nested path gets its defaults via yaml.v3's merge-onto-struct
+semantics. **Lesson: decoding an optional/deprecated YAML shape into a fresh
+pointer and swapping it in is never equivalent to decoding onto the
+default-populated struct — even when the fresh-decode path "works" for the
+fields the test happens to set.**
 
 **What happened (2026-07-24 → 07-26):** the hosted canary tenant
 (`i-0decbc0dcf225cf18`) executed issues with real tool-use and opened green PRs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -864,6 +864,17 @@ func Load(path string) (*Config, error) {
 // with both shapes tells us whether a top-level block is present and
 // whether orchestrator.autopilot was also explicitly set in the same file.
 //
+// The top-level block is probed as a raw yaml.Node rather than decoded
+// straight into *autopilot.Config: decoding into a fresh pointer produces a
+// zero-value struct populated only with the keys the file happens to set,
+// discarding every default DefaultConfig() would otherwise seed (GH-5255).
+// Instead, once presence is confirmed, node.Decode is applied directly onto
+// config.Orchestrator.Autopilot — already populated by DefaultConfig() and,
+// in the nested-only case, further merged by the main Unmarshal above — so
+// yaml.v3 merges just the keys present in the top-level block onto that
+// struct and leaves every unset key at its default, matching the nested
+// path byte-for-byte.
+//
 //   - Top-level only: lift it into orchestrator.autopilot so the documented
 //     snippets (configs/pilot.example.yaml, docs/content/features/autopilot.mdx)
 //     work when copy-pasted verbatim, and warn so the user fixes the nesting.
@@ -873,7 +884,7 @@ func Load(path string) (*Config, error) {
 //   - Neither/nested-only: nothing to do.
 func liftTopLevelAutopilot(expanded string, config *Config) error {
 	var probe struct {
-		Autopilot    *autopilot.Config `yaml:"autopilot"`
+		Autopilot    yaml.Node `yaml:"autopilot"`
 		Orchestrator struct {
 			Autopilot *autopilot.Config `yaml:"autopilot"`
 		} `yaml:"orchestrator"`
@@ -881,7 +892,7 @@ func liftTopLevelAutopilot(expanded string, config *Config) error {
 	if err := yaml.Unmarshal([]byte(expanded), &probe); err != nil {
 		return err
 	}
-	if probe.Autopilot == nil {
+	if probe.Autopilot.IsZero() {
 		return nil
 	}
 	if probe.Orchestrator.Autopilot != nil {
@@ -892,7 +903,12 @@ func liftTopLevelAutopilot(expanded string, config *Config) error {
 	if config.Orchestrator == nil {
 		config.Orchestrator = &OrchestratorConfig{}
 	}
-	config.Orchestrator.Autopilot = probe.Autopilot
+	if config.Orchestrator.Autopilot == nil {
+		config.Orchestrator.Autopilot = autopilot.DefaultConfig()
+	}
+	if err := probe.Autopilot.Decode(config.Orchestrator.Autopilot); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1830,6 +1830,30 @@ autopilot:
 	if !strings.Contains(logBuf.String(), "orchestrator.autopilot") {
 		t.Errorf("expected a warning log naming orchestrator.autopilot, got: %q", logBuf.String())
 	}
+
+	// GH-5255: keys the top-level block leaves unset must retain the same
+	// defaults the nested orchestrator.autopilot path gets from
+	// DefaultConfig() — the lift must merge onto the default-populated
+	// struct, not replace it with a fresh zero-value one.
+	ap := config.Orchestrator.Autopilot
+	if ap.MaxFailures != 3 {
+		t.Errorf("Orchestrator.Autopilot.MaxFailures = %d, want 3 (default, unset by top-level block)", ap.MaxFailures)
+	}
+	if ap.MaxMergeAttempts != 5 {
+		t.Errorf("Orchestrator.Autopilot.MaxMergeAttempts = %d, want 5 (default, unset by top-level block)", ap.MaxMergeAttempts)
+	}
+	if ap.MergeMethod != "squash" {
+		t.Errorf("Orchestrator.Autopilot.MergeMethod = %q, want %q (default, unset by top-level block)", ap.MergeMethod, "squash")
+	}
+	if ap.ReviewFeedback == nil || !ap.ReviewFeedback.Enabled {
+		t.Errorf("Orchestrator.Autopilot.ReviewFeedback = %+v, want non-nil with Enabled=true (default, unset by top-level block)", ap.ReviewFeedback)
+	}
+	if !ap.NotifyOnFailure {
+		t.Errorf("Orchestrator.Autopilot.NotifyOnFailure = false, want true (default, unset by top-level block)")
+	}
+	if !ap.AutoCreateIssues {
+		t.Errorf("Orchestrator.Autopilot.AutoCreateIssues = false, want true (default, unset by top-level block)")
+	}
 }
 
 // TestLoadWithTopLevelAndNestedAutopilot covers the case where both a


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5255.

Closes #5255

## Changes

GitHub Issue GH-5255: fix(config): top-level autopilot lift discards all defaults — decode into the default-populated struct, not a zero struct

## Problem

Follow-up from the PR#5253 post-merge review (verdict on the PR). The new top-level-autopilot lift in `internal/config/config.go` (`liftTopLevelAutopilot`, ~874-897) decodes the deprecated top-level block into a **fresh zero-value** autopilot config and then replaces `config.Orchestrator.Autopilot` wholesale — discarding every default the nested path gets from `DefaultConfig()`.

Probe-verified: an identical two-key block (`enabled: true, auto_merge: true`) produces
- lifted: `MaxCIFixIterations=0 · MaxFailures=0 · MaxMergeAttempts=0 · MergeMethod="" · ReviewFeedback=nil · NotifyOnFailure=false · AutoCreateIssues=false`
- nested: `3 · 3 · 5 · "squash" · {enabled:true, max:3} · true · true`

Consequences on the lifted path: `MaxCIFixIterations=0` disables the CI-fix cap entirely (the GH-1566 unbounded fix-issue chain class — the limit branch gates on `> 0`); `MaxFailures=0` trips the per-PR breaker on the FIRST recorded failure; `MaxMergeAttempts=0` makes the first merge failure terminal; empty `merge_method` goes to the GitHub merge API; review feedback silently off. The `DEPRECATED … loading it for now` log line actively implies the two shapes are equivalent. This recreates, for exactly the users the lift was built to rescue, a subtler version of the silent-misconfiguration bug #5251 was filed to kill.

## Fix

In `liftTopLevelAutopilot`: detect presence of the top-level key via a `yaml.Node` probe, then `node.Decode(config.Orchestrator.Autopilot)` — decoding INTO the already-default-populated struct (yaml.v3 merges onto non-nil pointers, which is precisely how the nested path gets its defaults). Keep the existing precedence (nested wins when both present) and the DEPRECATED/WARNING logs.

## Acceptance

- A lifted top-level block behaves byte-identically to the same block nested under orchestrator: every unset key keeps its `DefaultConfig()` value. Extend `TestLoadWithTopLevelAutopilot` to assert an unset key survives (e.g. `MaxFailures==3`, `MergeMethod=="squash"`, `ReviewFeedback` non-nil).
- Both-present precedence and the two log lines unchanged (`TestLoadWithTopLevelAndNestedAutopilot` still passes).
- Nested-only configs untouched (nil-probe early return preserved).
- Lifted values still pass through `Validate()`.

## Optional same-PR sweeps (small, skip if they bloat the diff)

- Re-nest the 8 remaining top-level `autopilot:` snippets on other docs pages: `docs/content/integrations/github.mdx` (~210/248/271), `docs/content/deployment/local.mdx` (~67), `docs/content/features/epic-decomposition.mdx` (~219), `docs/content/deployment/docker-helm.mdx` (~311/387), `docs/content/deployment/kubernetes.mdx` (~187) — the helm/k8s ones are inside `config:` values blocks where the block renders top-level.
- File-or-fix the phantom documented keys that bind to no Go struct field even when nested: quick-start `merge_delay`, `protected_branches`, autopilot-level `require_ci`, and the `conflict_handling:` block in `docs/content/features/autopilot.mdx` (~151-157). If not fixed here, note it in the PR so it gets its own issue.

## Refs

- PR#5253 review verdict (findings 1, 5, 6) · #5251 (parent) · GH-1566 (runaway fix-chain class)

## Planned Steps (execute all in sequence)

- Step 1: **fix(config): decode top-level autopilot lift into default-populated struct** — In internal/config/config.go liftTopLevelAutopilot (~lines 874-897), replace the fresh-zero-struct decode with a yaml.Node presence probe followed by node.Decode(config.Orchestrator.Autopilot) so yaml.v3 merges the deprecated top-level block onto the pointer already populated by DefaultConfig(). Preserve the nil-probe early return, nested-wins precedence, the 'DEPRECATED … loading it for now' log, and the WARNING log.
- Step 2: **test(config): extend TestLoadWithTopLevelAutopilot for default retention** — In internal/config/config_test.go, extend TestLoadWithTopLevelAutopilot to assert that unset keys retain their defaults after lift (MaxCIFixIterations==3, MaxFailures==3, MaxMergeAttempts==5, MergeMethod=="squash", ReviewFeedback != nil && ReviewFeedback.Enabled, NotifyOnFailure==true, AutoCreateIssues==true) while explicitly-set keys still take effect.
- Step 3: **test(config): verify precedence and validation tests still pass** — Confirm TestLoadWithTopLevelAndNestedAutopilot still passes (both-present precedence + log lines) along with nested-only tests, and verify lifted values continue through Validate() cleanly.
- Step 4: **chore(config): exclude docs and phantom-key changes from scope** — Explicitly skip the optional docs re-nesting sweep and the phantom-key file-or-fix, since those are docs/content/** changes that belong in a follow-up issue to keep this PR focused on the config-loader bugfix only.
