### PR TITLE
GH-5257: feat(briefs): daily receipts digest — per-run cost receipt lines at configurable time (default 18:00)

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -5855,6 +5855,21 @@
         ],
         "confidence": 0.95,
         "created": "2026-08-30"
+      },
+      "sandbox-gofmt-corrupts-double-single-quotes": {
+        "type": "pitfall",
+        "summary": "The gofmt binary in the Pilot-executor sandbox silently rewrites two adjacent straight single quotes ('') inside a Go comment into one smart quote (\u201d) \u2014 root cause of the GH-5257/PR#5258 SQL-guard comment corruption. Never run go fmt/gofmt -w/make fmt near a comment quoting an empty-string SQL literal.",
+        "file": ".agent/knowledge/memories/pitfalls/sandbox-gofmt-corrupts-double-single-quotes.md",
+        "concepts": [
+          "tooling",
+          "gofmt",
+          "sandbox",
+          "go-toolchain",
+          "code-review",
+          "data-corruption"
+        ],
+        "confidence": 0.95,
+        "created": "2026-08-30"
       }
     }
   },
@@ -9741,8 +9756,8 @@
   },
   "last_updated": "2026-08-30T13:52:06.104808+00:00",
   "stats": {
-    "total_nodes": 494,
+    "total_nodes": 495,
     "total_edges": 408,
-    "memory_count": 258
+    "memory_count": 259
   }
 }

--- a/.agent/knowledge/memories/pitfalls/sandbox-gofmt-corrupts-double-single-quotes.md
+++ b/.agent/knowledge/memories/pitfalls/sandbox-gofmt-corrupts-double-single-quotes.md
@@ -1,0 +1,63 @@
+---
+name: sandbox-gofmt-corrupts-double-single-quotes
+description: The gofmt binary in the Pilot-executor sandbox silently rewrites two adjacent straight single quotes ('') inside a Go comment into one smart quote (”) — almost certainly the root cause of the GH-5257/PR#5258 SQL-guard comment corruption, and a landmine for any comment quoting an empty-string SQL literal
+type: pitfall
+---
+
+# Sandbox `gofmt` corrupts `''` → `”` inside comments — never run `go fmt`/`make fmt` near a doc comment quoting `''`
+
+**What happened (GH-5261, 2026-08-30):** PR#5258's review flagged that
+`SetApprovalDecision`'s doc comment in `internal/memory/store.go` had its
+`` `AND approval_decision = ''` `` guard-clause quote mangled into
+`` `AND approval_decision = ”` `` (U+201D RIGHT DOUBLE QUOTATION MARK). This
+looked like a manual typo or an editor autocorrect mistake. It isn't.
+
+**Root cause, reproduced directly:** the `gofmt` binary on this sandbox
+(`/usr/bin/gofmt` → `/etc/alternatives/gofmt`, go1.25.8 toolchain) rewrites
+two adjacent ASCII single quotes (`0x27 0x27`) inside a `//` comment into a
+single `U+201D` character when formatting. Minimal repro:
+
+```go
+package main
+
+// `AND approval_decision = ''` test comment
+func main() {}
+```
+
+Running `gofmt` on this file changes the comment to
+`` // `AND approval_decision = ”` test comment `` — verified via `xxd` on
+both the original and `gofmt`-piped output (bytes `27 27` → `e2 80 9d`).
+`go build`/`go test`/`go vet` do not invoke formatting and are unaffected;
+only `gofmt -w`, `go fmt ./...`, `goimports -w`, or `make fmt` touch this.
+
+## Fix (this issue)
+Manually restored the doc comment to `` `AND approval_decision = ''` `` in
+`internal/memory/store.go` (`SetApprovalDecision`) via a plain string edit,
+not via any formatting tool.
+
+## Recommended Approach
+- **Never run `go fmt`, `gofmt -w`, `goimports -w`, or `make fmt`** on a file
+  containing a comment that quotes an empty-string SQL literal (`''`) or any
+  other doubled-straight-quote sequence, in this sandbox — it will silently
+  re-corrupt the comment on the next pass. Verify with `gofmt -d <file> |
+  xxd` before trusting a "no diff" or applying a formatting pass near such
+  comments.
+- If a PR review ever again reports a smart-quote / curly-quote corruption in
+  a comment (`'` → `’`, `''`/`"` → `”`/`"`), suspect this tooling bug first,
+  not a manual edit — grep the file history for who/what ran `make fmt`
+  around the corruption's introduction.
+- Longer term this is an environment defect worth reporting/patching
+  upstream in this sandbox's toolchain image (gofmt should never alter
+  comment/string literal content). Until fixed, treat `''`-in-comments as a
+  known trap in this repo's Go files.
+
+## Related
+- GH-5257 / PR#5258 (receipts digest — where the corruption first appeared)
+- GH-5261 (this revision issue — root cause identified while restoring the
+  comment)
+- `internal/memory/store.go` (`SetApprovalDecision`)
+
+---
+**Captured**: 2026-08-30
+**Confidence**: 0.95
+**Concepts**: tooling, gofmt, sandbox, go-toolchain, code-review, data-corruption

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -304,6 +304,7 @@
 | Weekly briefs | ✅ | briefs | `pilot brief --weekly` | - | Manual trigger |
 | Slack delivery | ✅ | briefs | - | `orchestrator.daily_brief.channels` | - |
 | Metrics summary | ✅ | briefs | - | `orchestrator.daily_brief.content.include_metrics` | - |
+| Receipts digest | ✅ | briefs | - | `orchestrator.receipts_digest` | GH-5257: end-of-day Telegram-only per-execution cost lines (issue ref, diff size, duration, $cost) + day total. Own schedule/scheduler (`ReceiptsScheduler`), default 18:00 America/New_York; empty day sends nothing. Fixed `GetLastBriefSent` to filter by `brief_type` so it can't cross-contaminate catch-up with `daily_brief` on a shared channel |
 
 ## Cost Controls
 

--- a/.agent/tasks/gh-5257.md
+++ b/.agent/tasks/gh-5257.md
@@ -1,0 +1,138 @@
+# GH-5257
+
+**Created:** 2026-08-29
+
+## Problem
+
+GitHub Issue GH-5257: feat(briefs): daily receipts digest — per-run cost receipt lines at configurable time (default 18:00)
+
+# feat(briefs): daily receipts digest — per-run cost receipt lines at configurable time (default 18:00)
+
+📋 PLANNED 2026-08-29 — researched (briefs subsystem seam map complete), dispatching to Pilot.
+
+## Problem
+
+Pilot sends one scheduled daily brief (14:00 local via `orchestrator.daily_brief`,
+cron `0 8 * * *` America/New_York). There is no end-of-day **receipts digest**:
+one line per completed execution — issue/PR ref, diff size, duration, dollar
+cost — plus a day total. All the data already exists on `executions` rows; it's
+a formatting + second-schedule feature, not new plumbing.
+
+Blocking defect discovered during research: `GetLastBriefSent(channel)`
+(`internal/memory/store.go:5176-5194`) filters `brief_history` by channel only,
+not `brief_type`. Any second scheduled brief type on the same Telegram channel
+makes catch-up logic read the wrong brief's last-sent timestamp (false catch-up
+fires / false skips). Must be fixed as part of this task.
+
+## Design
+
+**Approach: sibling config block + lightweight fork of the scheduler idiom.**
+Do NOT generalize the existing `briefs.Scheduler` — it hardcodes
+`GenerateDaily()` (`scheduler.go:170`) and `BriefType: "daily"`
+(`scheduler.go:191`), and the digest content shape (flat per-execution list +
+total) doesn't match `briefs.Brief` (Completed/InProgress/Blocked sections).
+A ~150-line receipts scheduler reusing the same cron + timezone + catch-up
+pattern keeps the working daily brief untouched.
+
+### 1. Config (`internal/config/config.go`)
+
+- New `ReceiptsDigestConfig` struct mirroring `DailyBriefConfig`
+  (config.go:196-204) minus `Time` (deprecated field — don't carry it over)
+  and minus `Content`/`Filters` (digest has no content toggles v1):
+  `Enabled bool`, `Schedule string`, `Timezone string`,
+  `Channels []BriefChannelConfig` (reuse existing type, config.go:206-211).
+- Add `ReceiptsDigest *ReceiptsDigestConfig \`yaml:"receipts_digest"\`` to
+  `OrchestratorConfig` next to `DailyBrief` (config.go:168).
+- Defaults (config.go:565-584 block): `Enabled: false`,
+  `Schedule: "0 18 * * *"`, `Timezone: "America/New_York"` (match daily_brief
+  default), empty channels.
+- `configs/pilot.example.yaml`: add a documented `receipts_digest:` example
+  under `orchestrator:` (note: `daily_brief:` has no example block today —
+  greenfield; adding a `daily_brief:` example alongside is optional/welcome).
+
+### 2. Memory (`internal/memory/store.go`)
+
+- **Fix**: `GetLastBriefSent(channel string)` → add `briefType string` param,
+  `WHERE channel = ? AND brief_type = ?`. Update the single existing call site
+  (`internal/briefs/scheduler.go:213`) to pass `"daily"`. Existing
+  `brief_history` rows already carry `brief_type = "daily"` so no migration.
+- **New query** `GetExecutionsForReceipts(query BriefQuery)`: like
+  `GetExecutionsInPeriod` (store.go:2075-2125) but SELECT/Scan the full
+  receipt column set — add `estimated_cost_usd, files_changed, lines_added,
+  lines_removed, task_source_adapter, task_source_issue_id` (columns exist and
+  are populated via `internal/executor/lifecycle.go:330-332`; fuller-column
+  Scan pattern precedent: `GetQueuedTasksForProject`, store.go:2375-2380).
+  Terminal statuses only (completed + failed — failed runs still cost money;
+  mark them in the output). Exclude canary rows
+  (`COALESCE(is_canary,0)=0`, same as `GetBriefMetrics` store.go:2281).
+
+### 3. Briefs package (`internal/briefs/`)
+
+New file `receipts.go` (+ `receipts_test.go`):
+
+- `ReceiptsScheduler`: cron via `robfig/cron/v3`, timezone load with
+  UTC-fallback-and-warn (copy `scheduler.go:33-37`), catch-up on start using
+  the fixed `GetLastBriefSent(channel, "receipts")`, records sends via
+  `RecordBriefSent` with `BriefType: "receipts"`.
+- Generation: day window in configured timezone (two-places-load-tz shape per
+  `generator.go:165-168`), rows from `GetExecutionsForReceipts`.
+- **Empty day → skip send entirely** (no "0 runs" noise).
+- Telegram formatting (in `receipts.go` or `formatter_receipts.go`):
+  - Per-run line: `#5214 merged · +88 −15 · 14m · $2.75` — issue ref via the
+    established idiom (strip `GH-` prefix from TaskID, fall back to
+    `TaskSourceIssueID`, guard on `TaskSourceAdapter == "github"`;
+    `lifecycle.go:427-438`), fall back to task title when no issue number.
+    Failed runs marked (e.g. `✗ failed` instead of status).
+  - Total line: `N runs · +ΣA −ΣD · $Σ.ΣΣ`.
+  - Reuse `formatDuration` (`formatter.go:100-112`),
+    `escapeTelegramMarkdown` (`delivery.go:334-344`) on all dynamic strings,
+    and the parse-entity-error plain-text retry pattern
+    (`delivery.go:246-255, 349-354`).
+- Delivery: reuse `DeliveryService`/`TelegramSender` seam (`delivery.go:19-21`)
+  or accept the sender directly — whichever needs less surface; no new
+  adapter code (`telegramBriefAdapter`, `cmd/pilot/adapters.go:26-41`, wraps
+  `SendBriefMessage` already).
+
+### 4. Wiring (`cmd/pilot/main.go`)
+
+- After the `DailyBrief` block (main.go:3775-3836): read
+  `cfg.Orchestrator.ReceiptsDigest`, construct + `Start(ctx)` the receipts
+  scheduler. Store nil-check same as main.go:3805. Extracting a shared
+  `startBriefScheduler`-style helper to cut the ~60-line duplication is
+  welcome but optional — do not let it grow the diff into a refactor.
+
+## Acceptance criteria
+
+1. `orchestrator.receipts_digest.enabled: true` with default schedule sends a
+   Telegram digest at 18:00 configured-timezone: one line per terminal
+   execution that day (issue ref, +adds −dels, duration, $cost) + total line.
+2. Empty day sends nothing.
+3. `GetLastBriefSent` filters by `brief_type`; daily-brief catch-up and
+   receipts catch-up cannot cross-contaminate on a shared channel (test
+   covers: both types recorded on same channel, each reads its own).
+4. Canary executions excluded from digest rows and totals.
+5. Failed runs appear, marked, with their cost counted in the total.
+6. Existing daily brief behavior unchanged (its scheduler/generator/delivery
+   code paths untouched except the one `GetLastBriefSent` call-site arg).
+7. Table-driven tests: formatter (escaping, issue-ref fallback, failed marker,
+   totals), `GetExecutionsForReceipts` (column completeness, canary exclusion,
+   period boundaries), `GetLastBriefSent` type filter.
+8. `configs/pilot.example.yaml` documents `receipts_digest`.
+9. `make lint && make test` green.
+
+## Non-goals (v1)
+
+- Slack/email formatting for the digest (Telegram only; channels config shape
+  supports adding later).
+- `owner/repo` display — `Execution` has only `ProjectPath`, no repo-name
+  field; single-project deployments don't need it. Do not add columns.
+- Generalizing `briefs.Scheduler` into a multi-brief engine.
+- Per-run receipt on PR comments (separate future task).
+
+## Refs
+
+- Research: briefs seam map 2026-08-29 (session research agent; findings
+  embedded above with file:line anchors).
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -3835,6 +3835,50 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		}
 	}
 
+	// Start receipts digest scheduler if enabled (GH-5257): a second,
+	// independently-scheduled Telegram-only brief listing one line per
+	// terminal execution (issue ref, diff size, duration, cost) plus a day
+	// total. Sibling to the daily brief block above rather than sharing its
+	// Scheduler — see internal/briefs/receipts.go's doc comment.
+	var receiptsScheduler *briefs.ReceiptsScheduler
+	if cfg.Orchestrator.ReceiptsDigest != nil && cfg.Orchestrator.ReceiptsDigest.Enabled {
+		receiptsCfg := cfg.Orchestrator.ReceiptsDigest
+
+		receiptsConfig := &briefs.ReceiptsConfig{
+			Enabled:  receiptsCfg.Enabled,
+			Schedule: receiptsCfg.Schedule,
+			Timezone: receiptsCfg.Timezone,
+		}
+		for _, ch := range receiptsCfg.Channels {
+			receiptsConfig.Channels = append(receiptsConfig.Channels, briefs.ChannelConfig{
+				Type:       ch.Type,
+				Channel:    ch.Channel,
+				Recipients: ch.Recipients,
+			})
+		}
+
+		if store != nil {
+			var sender briefs.TelegramSender
+			if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled {
+				tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
+				sender = &telegramBriefAdapter{client: tgClient, messageThreadID: cfg.Adapters.Telegram.MessageThreadID}
+			}
+
+			receiptsScheduler = briefs.NewReceiptsScheduler(store, sender, receiptsConfig, slog.Default())
+			if err := receiptsScheduler.Start(ctx); err != nil {
+				logging.WithComponent("start").Warn("Failed to start receipts digest scheduler", slog.Any("error", err))
+				receiptsScheduler = nil
+			} else {
+				logging.WithComponent("start").Info("receipts digest scheduler started",
+					slog.String("schedule", receiptsCfg.Schedule),
+					slog.String("timezone", receiptsCfg.Timezone),
+				)
+			}
+		} else {
+			logging.WithComponent("start").Warn("Receipts digest scheduler requires memory store, skipping")
+		}
+	}
+
 	// Dashboard mode: run TUI and handle shutdown via TUI quit
 	if dashboardMode && program != nil {
 		fmt.Println("\n● starting tui dashboard...")
@@ -4143,6 +4187,9 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		if briefScheduler != nil {
 			briefScheduler.Stop()
 		}
+		if receiptsScheduler != nil {
+			receiptsScheduler.Stop()
+		}
 		return nil
 	}
 
@@ -4165,6 +4212,9 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	}
 	if briefScheduler != nil {
 		briefScheduler.Stop()
+	}
+	if receiptsScheduler != nil {
+		receiptsScheduler.Stop()
 	}
 
 	return nil

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -291,6 +291,18 @@ orchestrator:
     poll_interval: 30s         # How often to check PR status
     pr_timeout: 1h             # Max time to wait for PR merge
 
+  # Daily receipts digest (GH-5257): an end-of-day Telegram-only summary,
+  # one line per terminal execution that day — issue ref, diff size,
+  # duration, dollar cost — plus a day total. Independent schedule from any
+  # daily_brief block; an empty day sends nothing.
+  receipts_digest:
+    enabled: false
+    schedule: "0 18 * * *"     # 6 PM daily (cron syntax)
+    timezone: "America/New_York"
+    channels:
+      - type: "telegram"
+        channel: "@your_chat_id"
+
   # Autopilot settings
   autopilot:
     enabled: false

--- a/internal/briefs/receipts.go
+++ b/internal/briefs/receipts.go
@@ -1,0 +1,357 @@
+package briefs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/robfig/cron/v3"
+)
+
+// ReceiptsConfig holds configuration for the daily receipts digest (GH-5257):
+// one line per terminal execution (issue ref, diff size, duration, cost) plus
+// a day total, delivered to Telegram on its own schedule (default 18:00).
+type ReceiptsConfig struct {
+	Enabled  bool
+	Schedule string
+	Timezone string
+	Channels []ChannelConfig
+}
+
+// receiptsBriefType is the brief_type stamped on brief_history rows recorded
+// by the receipts digest, distinct from Scheduler's "daily" — see
+// GetLastBriefSent's brief_type filter (GH-5257).
+const receiptsBriefType = "receipts"
+
+// receiptsRepresentativeChannel is the channel name recorded/read for
+// catch-up bookkeeping, mirroring Scheduler.maybeCatchUp's use of "telegram"
+// as a representative channel since Telegram is the only delivery mechanism
+// the receipts digest supports in v1.
+const receiptsRepresentativeChannel = "telegram"
+
+// ReceiptsScheduler generates and delivers the daily receipts digest on a
+// cron schedule. It forks the cron + timezone + catch-up idiom from
+// Scheduler rather than generalizing it — Scheduler hardcodes
+// GenerateDaily()/BriefType "daily", and the digest's flat
+// per-execution-plus-total shape doesn't fit Brief's
+// Completed/InProgress/Blocked sections.
+type ReceiptsScheduler struct {
+	store   *memory.Store
+	sender  TelegramSender
+	config  *ReceiptsConfig
+	cron    *cron.Cron
+	mu      sync.Mutex
+	running bool
+	entryID cron.EntryID
+	logger  *slog.Logger
+}
+
+// NewReceiptsScheduler creates a new receipts digest scheduler. store is
+// required for catch-up and send-history bookkeeping; sender is required to
+// actually deliver the digest (nil is tolerated for tests that only exercise
+// scheduling/catch-up detection).
+func NewReceiptsScheduler(store *memory.Store, sender TelegramSender, config *ReceiptsConfig, logger *slog.Logger) *ReceiptsScheduler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	loc, err := time.LoadLocation(config.Timezone)
+	if err != nil {
+		logger.Warn("invalid timezone, using UTC", "timezone", config.Timezone, "error", err)
+		loc = time.UTC
+	}
+
+	return &ReceiptsScheduler{
+		store:  store,
+		sender: sender,
+		config: config,
+		cron:   cron.New(cron.WithLocation(loc)),
+		logger: logger,
+	}
+}
+
+// Start begins the scheduler.
+func (s *ReceiptsScheduler) Start(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.running {
+		return nil
+	}
+
+	if !s.config.Enabled {
+		s.logger.Info("receipts digest scheduler disabled")
+		return nil
+	}
+
+	entryID, err := s.cron.AddFunc(s.config.Schedule, func() {
+		// runDigest's error is already logged internally; the cron callback
+		// has no caller to propagate it to.
+		_ = s.runDigest(ctx)
+	})
+	if err != nil {
+		return err
+	}
+
+	s.entryID = entryID
+	s.cron.Start()
+	s.running = true
+
+	nextRun := s.cron.Entry(s.entryID).Next
+
+	s.logger.Info("receipts digest scheduler started",
+		"schedule", s.config.Schedule,
+		"timezone", s.config.Timezone,
+		"next_run", nextRun,
+	)
+
+	s.maybeCatchUp(ctx)
+
+	return nil
+}
+
+// Stop stops the scheduler.
+func (s *ReceiptsScheduler) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.running {
+		return
+	}
+
+	ctx := s.cron.Stop()
+	<-ctx.Done()
+	s.running = false
+	s.logger.Info("receipts digest scheduler stopped")
+}
+
+// IsRunning returns whether the scheduler is active.
+func (s *ReceiptsScheduler) IsRunning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.running
+}
+
+// RunNow triggers an immediate digest generation and delivery.
+func (s *ReceiptsScheduler) RunNow(ctx context.Context) error {
+	return s.runDigest(ctx)
+}
+
+// runDigest generates the day's receipts digest and delivers it to every
+// configured Telegram channel. An empty day (no terminal executions) skips
+// the send entirely — no "0 runs" noise.
+func (s *ReceiptsScheduler) runDigest(ctx context.Context) error {
+	s.logger.Info("generating receipts digest")
+
+	loc, err := time.LoadLocation(s.config.Timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	now := time.Now().In(loc)
+	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+
+	rows, err := s.store.GetExecutionsForReceipts(memory.BriefQuery{Start: start, End: now})
+	if err != nil {
+		s.logger.Error("failed to load executions for receipts digest", "error", err)
+		return err
+	}
+
+	if len(rows) == 0 {
+		s.logger.Info("receipts digest: no terminal executions today, skipping send")
+		return nil
+	}
+
+	text := formatReceiptsDigest(rows, now)
+
+	delivered := false
+	for _, channel := range s.config.Channels {
+		if channel.Type != "telegram" {
+			continue
+		}
+		if s.deliverTelegram(ctx, channel.Channel, text) {
+			delivered = true
+		}
+	}
+
+	if delivered && s.store != nil {
+		record := &memory.BriefRecord{
+			SentAt:    time.Now(),
+			Channel:   receiptsRepresentativeChannel,
+			BriefType: receiptsBriefType,
+		}
+		if err := s.store.RecordBriefSent(record); err != nil {
+			s.logger.Warn("failed to record receipts digest sent", "error", err)
+		}
+	}
+
+	return nil
+}
+
+// deliverTelegram sends text to chatID, retrying as plain text if Markdown
+// entity parsing fails (mirrors DeliveryService.deliverTelegram). Returns
+// whether delivery succeeded.
+func (s *ReceiptsScheduler) deliverTelegram(ctx context.Context, chatID, text string) bool {
+	if s.sender == nil {
+		s.logger.Warn("receipts digest: telegram sender not configured")
+		return false
+	}
+
+	_, err := s.sender.SendBriefMessage(ctx, chatID, text, "Markdown")
+	if err != nil && isTelegramParseEntityError(err) {
+		s.logger.Warn("receipts digest: markdown parse failed, retrying as plain text",
+			"chat_id", chatID,
+			"error", err,
+		)
+		_, err = s.sender.SendBriefMessage(ctx, chatID, text, "")
+	}
+	if err != nil {
+		s.logger.Error("failed to deliver receipts digest", "chat_id", chatID, "error", err)
+		return false
+	}
+
+	s.logger.Info("receipts digest delivered", "chat_id", chatID)
+	return true
+}
+
+// maybeCatchUp checks if a scheduled digest was missed and fires one if
+// needed — the same detection idiom as Scheduler.maybeCatchUp, but reading
+// GetLastBriefSent's own "receipts" brief_type so it can never be fooled by
+// the daily brief's send history on a shared channel (GH-5257).
+func (s *ReceiptsScheduler) maybeCatchUp(ctx context.Context) {
+	if s.store == nil {
+		s.logger.Info("receipts catch-up skipped: no store configured")
+		return
+	}
+
+	lastRecord, err := s.store.GetLastBriefSent(receiptsRepresentativeChannel, receiptsBriefType)
+	if err != nil {
+		s.logger.Warn("receipts catch-up: failed to get last digest sent", "error", err)
+		return
+	}
+
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	schedule, err := parser.Parse(s.config.Schedule)
+	if err != nil {
+		s.logger.Warn("receipts catch-up: failed to parse schedule", "schedule", s.config.Schedule, "error", err)
+		return
+	}
+
+	now := time.Now()
+	loc, _ := time.LoadLocation(s.config.Timezone)
+	if loc == nil {
+		loc = time.UTC
+	}
+	nowInTz := now.In(loc)
+
+	checkTime := nowInTz.Add(-48 * time.Hour)
+	var prevScheduled time.Time
+	for {
+		nextRun := schedule.Next(checkTime)
+		if nextRun.After(nowInTz) {
+			break
+		}
+		prevScheduled = nextRun
+		checkTime = nextRun
+	}
+
+	if prevScheduled.IsZero() {
+		s.logger.Info("receipts catch-up: no previous scheduled time found")
+		return
+	}
+
+	if lastRecord == nil || lastRecord.SentAt.Before(prevScheduled) {
+		lastSentStr := "never"
+		if lastRecord != nil {
+			lastSentStr = lastRecord.SentAt.Format(time.RFC3339)
+		}
+		s.logger.Info("receipts catch-up: missed digest detected, firing now",
+			"last_sent", lastSentStr,
+			"prev_scheduled", prevScheduled.Format(time.RFC3339),
+		)
+		if err := s.runDigest(ctx); err != nil {
+			s.logger.Warn("receipts catch-up: run failed", "error", err)
+		}
+	} else {
+		s.logger.Info("receipts catch-up: no missed digest",
+			"last_sent", lastRecord.SentAt.Format(time.RFC3339),
+			"prev_scheduled", prevScheduled.Format(time.RFC3339),
+		)
+	}
+}
+
+// receiptIssueRef returns the display ref for a receipt line — the GitHub
+// issue number (with the "GH-" TaskID prefix stripped, or TaskSourceIssueID
+// when set) when the execution came from GitHub, otherwise the task title,
+// falling back to the raw TaskID. Mirrors the established idiom in
+// executor/lifecycle.go's stripInProgressLabelOnTerminalFailure.
+func receiptIssueRef(exec *memory.Execution) string {
+	if exec.TaskSourceAdapter == "github" {
+		issueNum := strings.TrimPrefix(exec.TaskID, "GH-")
+		if exec.TaskSourceIssueID != "" {
+			issueNum = exec.TaskSourceIssueID
+		}
+		if issueNum != "" {
+			return "#" + issueNum
+		}
+	}
+	if exec.TaskTitle != "" {
+		return exec.TaskTitle
+	}
+	return exec.TaskID
+}
+
+// formatReceiptLine formats a single execution's receipt line, e.g.
+// "#5214 · +88 −15 · 14m · $2.75" for a completed run, or
+// "#5214 ✗ failed · +88 −15 · 14m · $2.75" for a failed one.
+func formatReceiptLine(exec *memory.Execution) string {
+	ref := escapeTelegramMarkdown(receiptIssueRef(exec))
+
+	status := ""
+	if exec.Status == "failed" {
+		status = " ✗ failed"
+	}
+
+	return fmt.Sprintf("%s%s · +%d −%d · %s · $%.2f",
+		ref, status, exec.LinesAdded, exec.LinesRemoved, formatDuration(exec.DurationMs), exec.EstimatedCostUSD)
+}
+
+// receiptsTotals sums the diff size and cost across every row for the day
+// total line.
+func receiptsTotals(rows []*memory.Execution) (linesAdded, linesRemoved int, costUSD float64) {
+	for _, exec := range rows {
+		linesAdded += exec.LinesAdded
+		linesRemoved += exec.LinesRemoved
+		costUSD += exec.EstimatedCostUSD
+	}
+	return linesAdded, linesRemoved, costUSD
+}
+
+// formatReceiptsTotal formats the day total line, e.g.
+// "3 runs · +140 −42 · $6.30".
+func formatReceiptsTotal(rows []*memory.Execution) string {
+	linesAdded, linesRemoved, costUSD := receiptsTotals(rows)
+	return fmt.Sprintf("%d runs · +%d −%d · $%.2f", len(rows), linesAdded, linesRemoved, costUSD)
+}
+
+// formatReceiptsDigest formats the full Telegram digest message: a header,
+// one line per terminal execution, and a day total line.
+func formatReceiptsDigest(rows []*memory.Execution, day time.Time) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("🧾 *Receipts — %s*\n", day.Format("Jan 2, 2006")))
+	sb.WriteString("━━━━━━━━━━━━━━━━━━━━━\n")
+
+	for _, exec := range rows {
+		sb.WriteString(formatReceiptLine(exec))
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("*Total:* %s", formatReceiptsTotal(rows)))
+
+	return sb.String()
+}

--- a/internal/briefs/receipts.go
+++ b/internal/briefs/receipts.go
@@ -342,7 +342,7 @@ func formatReceiptsTotal(rows []*memory.Execution) string {
 func formatReceiptsDigest(rows []*memory.Execution, day time.Time) string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("🧾 *Receipts — %s*\n", day.Format("Jan 2, 2006")))
+	fmt.Fprintf(&sb, "🧾 *Receipts — %s*\n", day.Format("Jan 2, 2006"))
 	sb.WriteString("━━━━━━━━━━━━━━━━━━━━━\n")
 
 	for _, exec := range rows {
@@ -351,7 +351,7 @@ func formatReceiptsDigest(rows []*memory.Execution, day time.Time) string {
 	}
 
 	sb.WriteString("\n")
-	sb.WriteString(fmt.Sprintf("*Total:* %s", formatReceiptsTotal(rows)))
+	fmt.Fprintf(&sb, "*Total:* %s", formatReceiptsTotal(rows))
 
 	return sb.String()
 }

--- a/internal/briefs/receipts.go
+++ b/internal/briefs/receipts.go
@@ -141,9 +141,16 @@ func (s *ReceiptsScheduler) RunNow(ctx context.Context) error {
 	return s.runDigest(ctx)
 }
 
-// runDigest generates the day's receipts digest and delivers it to every
-// configured Telegram channel. An empty day (no terminal executions) skips
-// the send entirely — no "0 runs" noise.
+// runDigest generates the receipts digest for every terminal execution
+// completed since the last digest was sent, and delivers it to every
+// configured Telegram channel. Windowing on the last-sent digest (rather than
+// a fixed calendar day) is deliberate (GH-5261 / PR#5258 review): a run
+// started before 18:00 but still in flight at digest time — or any run
+// created after 18:00 — would otherwise sit outside every digest's
+// created_at-scoped window and never get receipted. Keying the window on
+// completed_at and resuming exactly where the last digest left off
+// guarantees every terminal execution is receipted exactly once. An empty
+// window (no terminal executions) skips the send entirely — no "0 runs" noise.
 func (s *ReceiptsScheduler) runDigest(ctx context.Context) error {
 	s.logger.Info("generating receipts digest")
 
@@ -152,7 +159,16 @@ func (s *ReceiptsScheduler) runDigest(ctx context.Context) error {
 		loc = time.UTC
 	}
 	now := time.Now().In(loc)
-	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+
+	start := now.Add(-24 * time.Hour)
+	if s.store != nil {
+		lastRecord, err := s.store.GetLastBriefSent(receiptsRepresentativeChannel, receiptsBriefType)
+		if err != nil {
+			s.logger.Warn("receipts digest: failed to get last digest sent, falling back to 24h window", "error", err)
+		} else if lastRecord != nil {
+			start = lastRecord.SentAt.In(loc)
+		}
+	}
 
 	rows, err := s.store.GetExecutionsForReceipts(memory.BriefQuery{Start: start, End: now})
 	if err != nil {
@@ -161,7 +177,7 @@ func (s *ReceiptsScheduler) runDigest(ctx context.Context) error {
 	}
 
 	if len(rows) == 0 {
-		s.logger.Info("receipts digest: no terminal executions today, skipping send")
+		s.logger.Info("receipts digest: no terminal executions since last digest, skipping send")
 		return nil
 	}
 
@@ -337,21 +353,30 @@ func formatReceiptsTotal(rows []*memory.Execution) string {
 	return fmt.Sprintf("%d runs · +%d −%d · $%.2f", len(rows), linesAdded, linesRemoved, costUSD)
 }
 
+// maxReceiptsDigestLen caps the per-run list so the digest stays comfortably
+// under Telegram's 4096-char message limit; the total line always reflects
+// every row regardless of how much of the list got truncated.
+const maxReceiptsDigestLen = 3900
+
 // formatReceiptsDigest formats the full Telegram digest message: a header,
-// one line per terminal execution, and a day total line.
+// one line per terminal execution, and a day total line. If the per-run list
+// would push the message past maxReceiptsDigestLen, it's truncated with a
+// final "… +N more runs" line — the total line (computed over every row, not
+// just the shown ones) is always included in full.
 func formatReceiptsDigest(rows []*memory.Execution, day time.Time) string {
-	var sb strings.Builder
+	header := fmt.Sprintf("🧾 *Receipts — %s*\n━━━━━━━━━━━━━━━━━━━━━\n", day.Format("Jan 2, 2006"))
+	totalLine := fmt.Sprintf("\n*Total:* %s", formatReceiptsTotal(rows))
 
-	fmt.Fprintf(&sb, "🧾 *Receipts — %s*\n", day.Format("Jan 2, 2006"))
-	sb.WriteString("━━━━━━━━━━━━━━━━━━━━━\n")
-
-	for _, exec := range rows {
-		sb.WriteString(formatReceiptLine(exec))
-		sb.WriteString("\n")
+	var lines strings.Builder
+	for i, exec := range rows {
+		line := formatReceiptLine(exec) + "\n"
+		budgetExceeded := len(header)+lines.Len()+len(line)+len(totalLine) > maxReceiptsDigestLen
+		if budgetExceeded && i > 0 {
+			fmt.Fprintf(&lines, "… +%d more runs\n", len(rows)-i)
+			break
+		}
+		lines.WriteString(line)
 	}
 
-	sb.WriteString("\n")
-	fmt.Fprintf(&sb, "*Total:* %s", formatReceiptsTotal(rows))
-
-	return sb.String()
+	return header + lines.String() + totalLine
 }

--- a/internal/briefs/receipts_test.go
+++ b/internal/briefs/receipts_test.go
@@ -1,0 +1,277 @@
+package briefs
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+func TestReceiptIssueRef(t *testing.T) {
+	tests := []struct {
+		name string
+		exec *memory.Execution
+		want string
+	}{
+		{
+			name: "github execution strips GH- prefix from TaskID",
+			exec: &memory.Execution{TaskID: "GH-5214", TaskSourceAdapter: "github"},
+			want: "#5214",
+		},
+		{
+			name: "github execution prefers TaskSourceIssueID over TaskID",
+			exec: &memory.Execution{TaskID: "GH-5214", TaskSourceAdapter: "github", TaskSourceIssueID: "5299"},
+			want: "#5299",
+		},
+		{
+			name: "non-github execution falls back to task title",
+			exec: &memory.Execution{TaskID: "local-1", TaskSourceAdapter: "linear", TaskTitle: "Fix the thing"},
+			want: "Fix the thing",
+		},
+		{
+			name: "github adapter but empty issue number falls back to title",
+			exec: &memory.Execution{TaskID: "GH-", TaskSourceAdapter: "github", TaskTitle: "Untitled run"},
+			want: "Untitled run",
+		},
+		{
+			name: "no adapter, no title falls back to raw TaskID",
+			exec: &memory.Execution{TaskID: "adhoc-42"},
+			want: "adhoc-42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := receiptIssueRef(tt.exec); got != tt.want {
+				t.Errorf("receiptIssueRef() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatReceiptLine(t *testing.T) {
+	tests := []struct {
+		name       string
+		exec       *memory.Execution
+		wantSubstr []string
+		notWant    string
+	}{
+		{
+			name: "completed run has no failed marker",
+			exec: &memory.Execution{
+				TaskID: "GH-5214", TaskSourceAdapter: "github", Status: "completed",
+				LinesAdded: 88, LinesRemoved: 15, DurationMs: 14 * 60 * 1000, EstimatedCostUSD: 2.75,
+			},
+			wantSubstr: []string{"#5214", "+88 −15", "14m", "$2.75"},
+			notWant:    "failed",
+		},
+		{
+			name: "failed run is marked",
+			exec: &memory.Execution{
+				TaskID: "GH-5215", TaskSourceAdapter: "github", Status: "failed",
+				LinesAdded: 3, LinesRemoved: 1, DurationMs: 30 * 1000, EstimatedCostUSD: 0.42,
+			},
+			wantSubstr: []string{"#5215", "✗ failed", "+3 −1", "30s", "$0.42"},
+		},
+		{
+			name: "dynamic title text is markdown-escaped",
+			exec: &memory.Execution{
+				TaskID: "local-1", TaskSourceAdapter: "linear", TaskTitle: "fix_the_bug [urgent]", Status: "completed",
+				LinesAdded: 1, LinesRemoved: 1, DurationMs: 1000, EstimatedCostUSD: 0.01,
+			},
+			wantSubstr: []string{`fix\_the\_bug \[urgent]`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatReceiptLine(tt.exec)
+			for _, want := range tt.wantSubstr {
+				if !strings.Contains(got, want) {
+					t.Errorf("formatReceiptLine() = %q, want substring %q", got, want)
+				}
+			}
+			if tt.notWant != "" && strings.Contains(got, tt.notWant) {
+				t.Errorf("formatReceiptLine() = %q, did not want substring %q", got, tt.notWant)
+			}
+		})
+	}
+}
+
+func TestFormatReceiptsTotal(t *testing.T) {
+	tests := []struct {
+		name string
+		rows []*memory.Execution
+		want string
+	}{
+		{
+			name: "no rows",
+			rows: nil,
+			want: "0 runs · +0 −0 · $0.00",
+		},
+		{
+			name: "sums across completed and failed rows",
+			rows: []*memory.Execution{
+				{Status: "completed", LinesAdded: 88, LinesRemoved: 15, EstimatedCostUSD: 2.75},
+				{Status: "failed", LinesAdded: 3, LinesRemoved: 1, EstimatedCostUSD: 0.42},
+			},
+			want: "2 runs · +91 −16 · $3.17",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatReceiptsTotal(tt.rows); got != tt.want {
+				t.Errorf("formatReceiptsTotal() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatReceiptsDigest(t *testing.T) {
+	rows := []*memory.Execution{
+		{TaskID: "GH-5214", TaskSourceAdapter: "github", Status: "completed", LinesAdded: 88, LinesRemoved: 15, DurationMs: 14 * 60 * 1000, EstimatedCostUSD: 2.75},
+		{TaskID: "GH-5215", TaskSourceAdapter: "github", Status: "failed", LinesAdded: 3, LinesRemoved: 1, DurationMs: 30 * 1000, EstimatedCostUSD: 0.42},
+	}
+	day := time.Date(2026, 8, 29, 18, 0, 0, 0, time.UTC)
+
+	got := formatReceiptsDigest(rows, day)
+
+	for _, want := range []string{"Aug 29, 2026", "#5214", "#5215", "✗ failed", "*Total:* 2 runs · +91 −16 · $3.17"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatReceiptsDigest() missing %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestNewReceiptsScheduler(t *testing.T) {
+	store, cleanup := setupSchedulerTestStore(t)
+	defer cleanup()
+
+	tests := []struct {
+		name   string
+		config *ReceiptsConfig
+		logger *slog.Logger
+		wantTz string
+	}{
+		{
+			name:   "valid timezone",
+			config: &ReceiptsConfig{Enabled: true, Schedule: "0 18 * * *", Timezone: "America/New_York"},
+			wantTz: "America/New_York",
+		},
+		{
+			name:   "invalid timezone falls back to UTC",
+			config: &ReceiptsConfig{Enabled: true, Schedule: "0 18 * * *", Timezone: "Invalid/Timezone"},
+			logger: slog.Default(),
+			wantTz: "UTC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewReceiptsScheduler(store, nil, tt.config, tt.logger)
+			if s == nil {
+				t.Fatal("expected scheduler, got nil")
+			}
+			if s.cron == nil {
+				t.Fatal("expected cron instance, got nil")
+			}
+		})
+	}
+}
+
+func TestReceiptsSchedulerRunNow_EmptyDaySkipsSend(t *testing.T) {
+	store, cleanup := setupSchedulerTestStore(t)
+	defer cleanup()
+
+	sender := &mockTelegramSender{}
+	config := &ReceiptsConfig{
+		Enabled:  true,
+		Schedule: "0 18 * * *",
+		Timezone: "UTC",
+		Channels: []ChannelConfig{{Type: "telegram", Channel: "@test"}},
+	}
+	scheduler := NewReceiptsScheduler(store, sender, config, nil)
+
+	if err := scheduler.RunNow(context.Background()); err != nil {
+		t.Fatalf("RunNow failed: %v", err)
+	}
+
+	if len(sender.calls) != 0 {
+		t.Errorf("expected no send on empty day, got %d calls", len(sender.calls))
+	}
+
+	record, err := store.GetLastBriefSent(receiptsRepresentativeChannel, receiptsBriefType)
+	if err != nil {
+		t.Fatalf("GetLastBriefSent: %v", err)
+	}
+	if record != nil {
+		t.Errorf("expected no brief_history record on empty day, got %+v", record)
+	}
+}
+
+func TestReceiptsSchedulerRunNow_DeliversAndRecordsOwnBriefType(t *testing.T) {
+	store, cleanup := setupSchedulerTestStore(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	if err := store.SaveExecution(&memory.Execution{
+		ID:                "exec-1",
+		TaskID:            "GH-5214",
+		ProjectPath:       "/tmp/proj",
+		Status:            "completed",
+		CreatedAt:         now,
+		LinesAdded:        88,
+		LinesRemoved:      15,
+		EstimatedCostUSD:  2.75,
+		TaskSourceAdapter: "github",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	// A daily-brief record on the same channel, timestamped after the
+	// receipts send will happen, must not be read back by the receipts
+	// scheduler's own catch-up/history lookup (GH-5257 cross-contamination
+	// guard).
+	if err := store.RecordBriefSent(&memory.BriefRecord{
+		SentAt:    time.Now().Add(1 * time.Hour),
+		Channel:   receiptsRepresentativeChannel,
+		BriefType: "daily",
+	}); err != nil {
+		t.Fatalf("RecordBriefSent (daily): %v", err)
+	}
+
+	sender := &mockTelegramSender{}
+	config := &ReceiptsConfig{
+		Enabled:  true,
+		Schedule: "0 18 * * *",
+		Timezone: "UTC",
+		Channels: []ChannelConfig{{Type: "telegram", Channel: "@test"}},
+	}
+	scheduler := NewReceiptsScheduler(store, sender, config, nil)
+
+	if err := scheduler.RunNow(context.Background()); err != nil {
+		t.Fatalf("RunNow failed: %v", err)
+	}
+
+	if len(sender.calls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(sender.calls))
+	}
+	if !strings.Contains(sender.calls[0].text, "#5214") {
+		t.Errorf("expected digest text to mention #5214, got: %s", sender.calls[0].text)
+	}
+
+	record, err := store.GetLastBriefSent(receiptsRepresentativeChannel, receiptsBriefType)
+	if err != nil {
+		t.Fatalf("GetLastBriefSent: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected a receipts brief_history record after delivery, got nil")
+	}
+	if record.BriefType != receiptsBriefType {
+		t.Errorf("BriefType = %q, want %q", record.BriefType, receiptsBriefType)
+	}
+}

--- a/internal/briefs/receipts_test.go
+++ b/internal/briefs/receipts_test.go
@@ -2,6 +2,7 @@ package briefs
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -147,6 +148,34 @@ func TestFormatReceiptsDigest(t *testing.T) {
 	}
 }
 
+// TestFormatReceiptsDigest_TruncatesLongList is the optional Telegram
+// 4096-char guard: a per-run list long enough to blow the digest past
+// maxReceiptsDigestLen is truncated with a "… +N more runs" line, and the
+// total line still reflects every row, not just the ones shown.
+func TestFormatReceiptsDigest_TruncatesLongList(t *testing.T) {
+	var rows []*memory.Execution
+	for i := 0; i < 200; i++ {
+		rows = append(rows, &memory.Execution{
+			TaskID: fmt.Sprintf("GH-%d", 5000+i), TaskSourceAdapter: "github",
+			Status: "completed", LinesAdded: 10, LinesRemoved: 2,
+			DurationMs: 60000, EstimatedCostUSD: 1.00,
+		})
+	}
+	day := time.Date(2026, 8, 29, 18, 0, 0, 0, time.UTC)
+
+	got := formatReceiptsDigest(rows, day)
+
+	if len(got) > 4096 {
+		t.Errorf("formatReceiptsDigest() length = %d, must stay under Telegram's 4096 limit", len(got))
+	}
+	if !strings.Contains(got, "more runs") {
+		t.Errorf("expected a truncation marker in a 200-row digest, got:\n%s", got)
+	}
+	if !strings.Contains(got, "*Total:* 200 runs · +2000 −400 · $200.00") {
+		t.Errorf("expected total to reflect all 200 rows regardless of truncation, got:\n%s", got)
+	}
+}
+
 func TestNewReceiptsScheduler(t *testing.T) {
 	store, cleanup := setupSchedulerTestStore(t)
 	defer cleanup()
@@ -224,6 +253,7 @@ func TestReceiptsSchedulerRunNow_DeliversAndRecordsOwnBriefType(t *testing.T) {
 		ProjectPath:       "/tmp/proj",
 		Status:            "completed",
 		CreatedAt:         now,
+		CompletedAt:       &now,
 		LinesAdded:        88,
 		LinesRemoved:      15,
 		EstimatedCostUSD:  2.75,
@@ -273,5 +303,96 @@ func TestReceiptsSchedulerRunNow_DeliversAndRecordsOwnBriefType(t *testing.T) {
 	}
 	if record.BriefType != receiptsBriefType {
 		t.Errorf("BriefType = %q, want %q", record.BriefType, receiptsBriefType)
+	}
+}
+
+// TestReceiptsSchedulerRunNow_InFlightRunAppearsInNextDigest is GH-5261
+// (PR#5258 review): a run still "running" at one digest's send time must be
+// receipted in the NEXT digest once it completes — never dropped, and never
+// receipted twice. Windowing on completed_at since the last digest sent
+// (rather than a fixed calendar day keyed on created_at) is what makes this
+// possible.
+func TestReceiptsSchedulerRunNow_InFlightRunAppearsInNextDigest(t *testing.T) {
+	store, cleanup := setupSchedulerTestStore(t)
+	defer cleanup()
+
+	// exec-early: created and completed well before the first digest fires —
+	// must appear in digest 1 and never again.
+	early := time.Now().Add(-2 * time.Hour)
+	if err := store.SaveExecution(&memory.Execution{
+		ID:                "exec-early",
+		TaskID:            "GH-5300",
+		ProjectPath:       "/tmp/proj",
+		Status:            "completed",
+		CreatedAt:         early,
+		CompletedAt:       &early,
+		EstimatedCostUSD:  1.00,
+		TaskSourceAdapter: "github",
+	}); err != nil {
+		t.Fatalf("SaveExecution (early): %v", err)
+	}
+
+	// exec-inflight: created before the first digest but still "running" at
+	// that point — must be excluded from digest 1 and included in digest 2
+	// once it completes.
+	startedBeforeDigest1 := time.Now().Add(-90 * time.Minute)
+	if err := store.SaveExecution(&memory.Execution{
+		ID:                "exec-inflight",
+		TaskID:            "GH-5301",
+		ProjectPath:       "/tmp/proj",
+		Status:            "running",
+		CreatedAt:         startedBeforeDigest1,
+		EstimatedCostUSD:  0,
+		TaskSourceAdapter: "github",
+	}); err != nil {
+		t.Fatalf("SaveExecution (inflight): %v", err)
+	}
+
+	sender := &mockTelegramSender{}
+	config := &ReceiptsConfig{
+		Enabled:  true,
+		Schedule: "0 18 * * *",
+		Timezone: "UTC",
+		Channels: []ChannelConfig{{Type: "telegram", Channel: "@test"}},
+	}
+	scheduler := NewReceiptsScheduler(store, sender, config, nil)
+
+	// Digest 1: only exec-early is terminal.
+	if err := scheduler.RunNow(context.Background()); err != nil {
+		t.Fatalf("RunNow (digest 1) failed: %v", err)
+	}
+	if len(sender.calls) != 1 {
+		t.Fatalf("expected 1 send after digest 1, got %d", len(sender.calls))
+	}
+	if !strings.Contains(sender.calls[0].text, "#5300") {
+		t.Errorf("digest 1 should mention #5300, got: %s", sender.calls[0].text)
+	}
+	if strings.Contains(sender.calls[0].text, "#5301") {
+		t.Errorf("digest 1 must NOT mention still-running #5301, got: %s", sender.calls[0].text)
+	}
+
+	// exec-inflight finishes after digest 1 fired. The sleep guarantees
+	// completed_at (CURRENT_TIMESTAMP, second precision) lands in a distinct
+	// second from digest 1's brief_history SentAt (sub-second Go precision),
+	// avoiding a same-second boundary flake in the completed_at >= start
+	// comparison.
+	time.Sleep(1100 * time.Millisecond)
+	if err := store.MarkExecutionCompleted("exec-inflight", "", "", 1000); err != nil {
+		t.Fatalf("MarkExecutionCompleted: %v", err)
+	}
+
+	// Digest 2: exec-inflight must now appear, and exec-early must NOT
+	// reappear (already receipted in digest 1).
+	if err := scheduler.RunNow(context.Background()); err != nil {
+		t.Fatalf("RunNow (digest 2) failed: %v", err)
+	}
+	if len(sender.calls) != 2 {
+		t.Fatalf("expected 2 sends after digest 2, got %d", len(sender.calls))
+	}
+	if !strings.Contains(sender.calls[1].text, "#5301") {
+		t.Errorf("digest 2 should mention now-completed #5301, got: %s", sender.calls[1].text)
+	}
+	if strings.Contains(sender.calls[1].text, "#5300") {
+		t.Errorf("digest 2 must NOT re-mention already-receipted #5300, got: %s", sender.calls[1].text)
 	}
 }

--- a/internal/briefs/scheduler.go
+++ b/internal/briefs/scheduler.go
@@ -210,7 +210,7 @@ func (s *Scheduler) maybeCatchUp(ctx context.Context) {
 
 	// Get the most recent brief sent for any channel
 	// We use "telegram" as a representative channel since it's the primary delivery mechanism
-	lastRecord, err := s.store.GetLastBriefSent("telegram")
+	lastRecord, err := s.store.GetLastBriefSent("telegram", "daily")
 	if err != nil {
 		s.logger.Warn("catch-up: failed to get last brief sent", "error", err)
 		return

--- a/internal/briefs/scheduler_test.go
+++ b/internal/briefs/scheduler_test.go
@@ -596,7 +596,7 @@ func TestSchedulerRunNowRecordsToHistory(t *testing.T) {
 	ctx := context.Background()
 
 	// Verify no brief history initially
-	lastRecord, err := store.GetLastBriefSent("telegram")
+	lastRecord, err := store.GetLastBriefSent("telegram", "daily")
 	if err != nil {
 		t.Fatalf("GetLastBriefSent failed: %v", err)
 	}
@@ -619,7 +619,7 @@ func TestSchedulerRunNowRecordsToHistory(t *testing.T) {
 	// But the important part is that if it had succeeded, it would have been recorded
 	if results[0].Success {
 		// If delivery succeeded (shouldn't in this test setup), verify it was recorded
-		lastRecord, err = store.GetLastBriefSent("telegram")
+		lastRecord, err = store.GetLastBriefSent("telegram", "daily")
 		if err != nil {
 			t.Fatalf("GetLastBriefSent failed after successful delivery: %v", err)
 		}
@@ -634,7 +634,7 @@ func TestSchedulerRunNowRecordsToHistory(t *testing.T) {
 		}
 	} else {
 		// Delivery failed (expected), so no record should be written
-		lastRecord, err = store.GetLastBriefSent("telegram")
+		lastRecord, err = store.GetLastBriefSent("telegram", "daily")
 		if err != nil {
 			t.Fatalf("GetLastBriefSent failed: %v", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,8 +166,15 @@ type OrchestratorConfig struct {
 	Model         string            `yaml:"model"`
 	MaxConcurrent int               `yaml:"max_concurrent"`
 	DailyBrief    *DailyBriefConfig `yaml:"daily_brief"`
-	Execution     *ExecutionConfig  `yaml:"execution"`
-	Autopilot     *autopilot.Config `yaml:"autopilot"`
+	// ReceiptsDigest configures the end-of-day per-run cost receipts digest
+	// (GH-5257) — a second, independently-scheduled Telegram brief listing one
+	// line per terminal execution (issue ref, diff size, duration, cost) plus
+	// a day total. Sibling to DailyBrief rather than a generalization of it:
+	// the digest's flat per-execution shape doesn't match Brief's
+	// Completed/InProgress/Blocked sections.
+	ReceiptsDigest *ReceiptsDigestConfig `yaml:"receipts_digest"`
+	Execution      *ExecutionConfig      `yaml:"execution"`
+	Autopilot      *autopilot.Config     `yaml:"autopilot"`
 }
 
 // ExecutionConfig holds settings for task execution mode.
@@ -201,6 +208,18 @@ type DailyBriefConfig struct {
 	Channels []BriefChannelConfig `yaml:"channels"`
 	Content  BriefContentConfig   `yaml:"content"`
 	Filters  BriefFilterConfig    `yaml:"filters"`
+}
+
+// ReceiptsDigestConfig holds settings for the daily receipts digest (GH-5257):
+// an end-of-day Telegram-only summary of per-execution cost receipts, on its
+// own schedule independent of DailyBriefConfig. No Time field (that's a
+// deprecated leftover on DailyBriefConfig) and no Content/Filters — the
+// digest has no content toggles in v1.
+type ReceiptsDigestConfig struct {
+	Enabled  bool                 `yaml:"enabled"`
+	Schedule string               `yaml:"schedule"` // Cron syntax: "0 18 * * *"
+	Timezone string               `yaml:"timezone"`
+	Channels []BriefChannelConfig `yaml:"channels"`
 }
 
 // BriefChannelConfig defines a delivery channel for daily briefs (Slack or email).
@@ -578,6 +597,12 @@ func DefaultConfig() *Config {
 				Filters: BriefFilterConfig{
 					Projects: []string{},
 				},
+			},
+			ReceiptsDigest: &ReceiptsDigestConfig{
+				Enabled:  false,
+				Schedule: "0 18 * * *", // 6 PM daily
+				Timezone: "America/New_York",
+				Channels: []BriefChannelConfig{},
 			},
 			Execution: DefaultExecutionConfig(),
 			Autopilot: autopilot.DefaultConfig(),

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1765,7 +1765,7 @@ var ErrApprovalAlreadyDecided = errors.New("approval already decided")
 // SetApprovalDecision records an approval decision on the execution linked to requestID.
 // It sets approval_decision, approval_decision_at, and approval_decision_by on the row
 // whose approval_request_id matches. The UPDATE is guarded by
-// `AND approval_decision = ''` so two racing callers (e.g. a POST racing a
+// `AND approval_decision = ”` so two racing callers (e.g. a POST racing a
 // Telegram/Slack button tap, or two concurrent POSTs) can never both win: only
 // the first writer's UPDATE matches a row, the second affects zero rows and
 // gets ErrApprovalAlreadyDecided rather than silently overwriting the first
@@ -2121,6 +2121,53 @@ func (s *Store) GetExecutionsInPeriod(query BriefQuery) ([]*Execution, error) {
 		executions = append(executions, &exec)
 	}
 
+	return executions, rows.Err()
+}
+
+// GetExecutionsForReceipts retrieves terminal (completed or failed) executions
+// within the specified time period for the daily receipts digest (GH-5257).
+// Unlike GetExecutionsInPeriod, it selects the full executionDetailColumns
+// set so callers can read cost/diff-size/source-issue fields, and it
+// excludes canary rows (COALESCE(is_canary,0)=0, matching GetBriefMetrics)
+// so synthetic sandbox runs never contaminate the digest or its totals.
+// Failed rows are included deliberately — a failed run still spent money and
+// the digest marks it as such rather than hiding its cost from the total.
+func (s *Store) GetExecutionsForReceipts(query BriefQuery) ([]*Execution, error) {
+	var args []interface{}
+	whereClause := "WHERE created_at >= ? AND created_at < ? AND status IN ('completed', 'failed') AND COALESCE(is_canary, 0) = 0"
+	args = append(args, query.Start, query.End)
+
+	if len(query.Projects) > 0 {
+		placeholders := ""
+		for i, p := range query.Projects {
+			if i > 0 {
+				placeholders += ","
+			}
+			placeholders += "?"
+			args = append(args, p)
+		}
+		whereClause += " AND project_path IN (" + placeholders + ")"
+	}
+
+	rows, err := s.db.Query(`
+		SELECT `+executionDetailColumns+`
+		FROM executions
+		`+whereClause+`
+		ORDER BY created_at ASC
+	`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var executions []*Execution
+	for rows.Next() {
+		exec, err := scanExecutionDetail(rows)
+		if err != nil {
+			return nil, err
+		}
+		executions = append(executions, exec)
+	}
 	return executions, rows.Err()
 }
 
@@ -5171,16 +5218,21 @@ func (s *Store) GetLogsByExecutionID(executionID string, limit int) ([]*LogEntry
 	return entries, nil
 }
 
-// GetLastBriefSent returns the most recent brief record for a given channel.
-// Returns nil if no brief has been sent to the channel.
-func (s *Store) GetLastBriefSent(channel string) (*BriefRecord, error) {
+// GetLastBriefSent returns the most recent brief record for a given channel
+// and brief type. Returns nil if no matching brief has been sent.
+//
+// GH-5257: briefType is a required filter, not just channel — brief_history
+// rows from a second scheduled brief type (e.g. "receipts") on the same
+// Telegram channel would otherwise satisfy a channel-only lookup and corrupt
+// the other brief type's catch-up logic (false catch-up fires / false skips).
+func (s *Store) GetLastBriefSent(channel, briefType string) (*BriefRecord, error) {
 	row := s.db.QueryRow(`
 		SELECT id, sent_at, channel, brief_type, COALESCE(recipient, '')
 		FROM brief_history
-		WHERE channel = ?
+		WHERE channel = ? AND brief_type = ?
 		ORDER BY sent_at DESC
 		LIMIT 1
-	`, channel)
+	`, channel, briefType)
 
 	var record BriefRecord
 	err := row.Scan(&record.ID, &record.SentAt, &record.Channel, &record.BriefType, &record.Recipient)

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1765,7 +1765,7 @@ var ErrApprovalAlreadyDecided = errors.New("approval already decided")
 // SetApprovalDecision records an approval decision on the execution linked to requestID.
 // It sets approval_decision, approval_decision_at, and approval_decision_by on the row
 // whose approval_request_id matches. The UPDATE is guarded by
-// `AND approval_decision = ”` so two racing callers (e.g. a POST racing a
+// `AND approval_decision = ''` so two racing callers (e.g. a POST racing a
 // Telegram/Slack button tap, or two concurrent POSTs) can never both win: only
 // the first writer's UPDATE matches a row, the second affects zero rows and
 // gets ErrApprovalAlreadyDecided rather than silently overwriting the first
@@ -2125,16 +2125,21 @@ func (s *Store) GetExecutionsInPeriod(query BriefQuery) ([]*Execution, error) {
 }
 
 // GetExecutionsForReceipts retrieves terminal (completed or failed) executions
-// within the specified time period for the daily receipts digest (GH-5257).
-// Unlike GetExecutionsInPeriod, it selects the full executionDetailColumns
-// set so callers can read cost/diff-size/source-issue fields, and it
-// excludes canary rows (COALESCE(is_canary,0)=0, matching GetBriefMetrics)
-// so synthetic sandbox runs never contaminate the digest or its totals.
-// Failed rows are included deliberately — a failed run still spent money and
-// the digest marks it as such rather than hiding its cost from the total.
+// whose completed_at falls within the specified time period, for the daily
+// receipts digest (GH-5257 / GH-5261). It windows on completed_at rather than
+// created_at deliberately: a run's cost is only knowable once it finishes, and
+// windowing on created_at let a run started before a digest boundary but
+// finishing after it (still "running" at digest time) fall permanently outside
+// every digest's window (GH-5261 / PR#5258 review). Unlike GetExecutionsInPeriod,
+// it selects the full executionDetailColumns set so callers can read
+// cost/diff-size/source-issue fields, and it excludes canary rows
+// (COALESCE(is_canary,0)=0, matching GetBriefMetrics) so synthetic sandbox runs
+// never contaminate the digest or its totals. Failed rows are included
+// deliberately — a failed run still spent money and the digest marks it as such
+// rather than hiding its cost from the total.
 func (s *Store) GetExecutionsForReceipts(query BriefQuery) ([]*Execution, error) {
 	var args []interface{}
-	whereClause := "WHERE created_at >= ? AND created_at < ? AND status IN ('completed', 'failed') AND COALESCE(is_canary, 0) = 0"
+	whereClause := "WHERE completed_at >= ? AND completed_at < ? AND status IN ('completed', 'failed') AND COALESCE(is_canary, 0) = 0"
 	args = append(args, query.Start, query.End)
 
 	if len(query.Projects) > 0 {
@@ -2153,7 +2158,7 @@ func (s *Store) GetExecutionsForReceipts(query BriefQuery) ([]*Execution, error)
 		SELECT `+executionDetailColumns+`
 		FROM executions
 		`+whereClause+`
-		ORDER BY created_at ASC
+		ORDER BY completed_at ASC
 	`, args...)
 	if err != nil {
 		return nil, err

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1667,6 +1667,111 @@ func TestGetExecutionsInPeriod(t *testing.T) {
 	}
 }
 
+// TestGetExecutionsForReceipts covers GH-5257's receipts digest query:
+// full column completeness (cost/diff-size/source-issue fields), terminal
+// status filtering, canary exclusion, and period boundaries.
+func TestGetExecutionsForReceipts(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now()
+
+	execs := []*Execution{
+		{
+			ID: "receipt-completed", TaskID: "GH-5214", ProjectPath: "/p", Status: "completed",
+			CreatedAt: now, DurationMs: 840000, EstimatedCostUSD: 2.75,
+			FilesChanged: 4, LinesAdded: 88, LinesRemoved: 15,
+			TaskSourceAdapter: "github", TaskSourceIssueID: "5214",
+		},
+		{
+			ID: "receipt-failed", TaskID: "GH-5215", ProjectPath: "/p", Status: "failed",
+			CreatedAt: now, DurationMs: 30000, EstimatedCostUSD: 0.42,
+			FilesChanged: 1, LinesAdded: 3, LinesRemoved: 1,
+			TaskSourceAdapter: "github", TaskSourceIssueID: "5215",
+		},
+		{
+			// Non-terminal: must be excluded.
+			ID: "receipt-running", TaskID: "GH-5216", ProjectPath: "/p", Status: "running",
+			CreatedAt: now, EstimatedCostUSD: 0.10,
+		},
+		{
+			// Canary: must be excluded even though terminal and in-period.
+			ID: "receipt-canary", TaskID: "GH-5217", ProjectPath: "/p", Status: "completed",
+			CreatedAt: now, EstimatedCostUSD: 1.00, IsCanary: true,
+		},
+		{
+			// Outside the period: must be excluded.
+			ID: "receipt-yesterday", TaskID: "GH-5218", ProjectPath: "/p", Status: "completed",
+			CreatedAt: now.Add(-48 * time.Hour), EstimatedCostUSD: 5.00,
+		},
+	}
+	for _, e := range execs {
+		if err := store.SaveExecution(e); err != nil {
+			t.Fatalf("SaveExecution %s: %v", e.ID, err)
+		}
+	}
+
+	query := BriefQuery{
+		Start: now.Add(-1 * time.Hour),
+		End:   now.Add(1 * time.Hour),
+	}
+
+	rows, err := store.GetExecutionsForReceipts(query)
+	if err != nil {
+		t.Fatalf("GetExecutionsForReceipts: %v", err)
+	}
+
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows (completed + failed, excluding running/canary/out-of-period), got %d", len(rows))
+	}
+
+	byID := map[string]*Execution{}
+	for _, r := range rows {
+		byID[r.ID] = r
+	}
+
+	if _, ok := byID["receipt-running"]; ok {
+		t.Error("expected running execution to be excluded")
+	}
+	if _, ok := byID["receipt-canary"]; ok {
+		t.Error("expected canary execution to be excluded")
+	}
+	if _, ok := byID["receipt-yesterday"]; ok {
+		t.Error("expected out-of-period execution to be excluded")
+	}
+
+	completed, ok := byID["receipt-completed"]
+	if !ok {
+		t.Fatal("expected receipt-completed row")
+	}
+	if completed.EstimatedCostUSD != 2.75 {
+		t.Errorf("EstimatedCostUSD = %v, want 2.75", completed.EstimatedCostUSD)
+	}
+	if completed.LinesAdded != 88 || completed.LinesRemoved != 15 {
+		t.Errorf("LinesAdded/LinesRemoved = %d/%d, want 88/15", completed.LinesAdded, completed.LinesRemoved)
+	}
+	if completed.FilesChanged != 4 {
+		t.Errorf("FilesChanged = %d, want 4", completed.FilesChanged)
+	}
+	if completed.TaskSourceAdapter != "github" || completed.TaskSourceIssueID != "5214" {
+		t.Errorf("TaskSourceAdapter/TaskSourceIssueID = %q/%q, want github/5214", completed.TaskSourceAdapter, completed.TaskSourceIssueID)
+	}
+
+	failed, ok := byID["receipt-failed"]
+	if !ok {
+		t.Fatal("expected receipt-failed row")
+	}
+	if failed.Status != "failed" {
+		t.Errorf("Status = %q, want failed", failed.Status)
+	}
+	if failed.EstimatedCostUSD != 0.42 {
+		t.Errorf("EstimatedCostUSD = %v, want 0.42 (failed runs still cost money)", failed.EstimatedCostUSD)
+	}
+}
+
 func TestGetBriefMetrics(t *testing.T) {
 	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
 	defer func() { _ = os.RemoveAll(tmpDir) }()
@@ -2790,15 +2895,17 @@ func TestBriefHistory(t *testing.T) {
 		name          string
 		setup         func(*Store)
 		channel       string
+		queryType     string
 		wantNil       bool
 		wantBriefType string
 		wantRecipient string
 	}{
 		{
-			name:    "empty table returns nil",
-			setup:   func(s *Store) {},
-			channel: "telegram",
-			wantNil: true,
+			name:      "empty table returns nil",
+			setup:     func(s *Store) {},
+			channel:   "telegram",
+			queryType: "daily",
+			wantNil:   true,
 		},
 		{
 			name: "single insert returns that record",
@@ -2811,6 +2918,7 @@ func TestBriefHistory(t *testing.T) {
 				})
 			},
 			channel:       "telegram",
+			queryType:     "daily",
 			wantNil:       false,
 			wantBriefType: "daily",
 			wantRecipient: "user123",
@@ -2825,7 +2933,8 @@ func TestBriefHistory(t *testing.T) {
 					BriefType: "daily",
 					Recipient: "old-user",
 				})
-				// Insert newer record
+				// Insert newer record of a different brief type — must not
+				// be picked up by a "daily" query (GH-5257).
 				_ = s.RecordBriefSent(&BriefRecord{
 					SentAt:    time.Now().Add(-1 * time.Hour),
 					Channel:   "slack",
@@ -2841,6 +2950,7 @@ func TestBriefHistory(t *testing.T) {
 				})
 			},
 			channel:       "slack",
+			queryType:     "daily",
 			wantNil:       false,
 			wantBriefType: "daily",
 			wantRecipient: "latest-user",
@@ -2862,6 +2972,7 @@ func TestBriefHistory(t *testing.T) {
 				})
 			},
 			channel:       "telegram",
+			queryType:     "daily",
 			wantNil:       false,
 			wantBriefType: "daily",
 			wantRecipient: "tg-user",
@@ -2875,8 +2986,58 @@ func TestBriefHistory(t *testing.T) {
 					BriefType: "daily",
 				})
 			},
-			channel: "email",
-			wantNil: true,
+			channel:   "email",
+			queryType: "daily",
+			wantNil:   true,
+		},
+		{
+			// GH-5257: two brief types sharing a channel must not
+			// cross-contaminate — a "receipts" digest sent more recently on
+			// the same Telegram channel must not shadow the "daily" brief's
+			// own last-sent record (and vice versa), or catch-up logic for
+			// one brief type would fire/skip based on the other's history.
+			name: "filters by brief_type on shared channel",
+			setup: func(s *Store) {
+				_ = s.RecordBriefSent(&BriefRecord{
+					SentAt:    time.Now().Add(-1 * time.Hour),
+					Channel:   "telegram",
+					BriefType: "daily",
+					Recipient: "daily-recipient",
+				})
+				_ = s.RecordBriefSent(&BriefRecord{
+					SentAt:    time.Now(),
+					Channel:   "telegram",
+					BriefType: "receipts",
+					Recipient: "receipts-recipient",
+				})
+			},
+			channel:       "telegram",
+			queryType:     "daily",
+			wantNil:       false,
+			wantBriefType: "daily",
+			wantRecipient: "daily-recipient",
+		},
+		{
+			name: "reads its own type when the other type is older",
+			setup: func(s *Store) {
+				_ = s.RecordBriefSent(&BriefRecord{
+					SentAt:    time.Now().Add(-1 * time.Hour),
+					Channel:   "telegram",
+					BriefType: "daily",
+					Recipient: "daily-recipient",
+				})
+				_ = s.RecordBriefSent(&BriefRecord{
+					SentAt:    time.Now(),
+					Channel:   "telegram",
+					BriefType: "receipts",
+					Recipient: "receipts-recipient",
+				})
+			},
+			channel:       "telegram",
+			queryType:     "receipts",
+			wantNil:       false,
+			wantBriefType: "receipts",
+			wantRecipient: "receipts-recipient",
 		},
 	}
 
@@ -2891,7 +3052,7 @@ func TestBriefHistory(t *testing.T) {
 
 			tt.setup(store)
 
-			record, err := store.GetLastBriefSent(tt.channel)
+			record, err := store.GetLastBriefSent(tt.channel, tt.queryType)
 			if err != nil {
 				t.Fatalf("GetLastBriefSent: %v", err)
 			}

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1670,6 +1670,9 @@ func TestGetExecutionsInPeriod(t *testing.T) {
 // TestGetExecutionsForReceipts covers GH-5257's receipts digest query:
 // full column completeness (cost/diff-size/source-issue fields), terminal
 // status filtering, canary exclusion, and period boundaries.
+// TestGetExecutionsForReceipts is GH-5261 (PR#5258 review): the receipts
+// digest window is keyed on completed_at, not created_at, so an in-flight
+// run at digest time still gets receipted once it finishes.
 func TestGetExecutionsForReceipts(t *testing.T) {
 	store, err := NewStore(t.TempDir())
 	if err != nil {
@@ -1678,34 +1681,46 @@ func TestGetExecutionsForReceipts(t *testing.T) {
 	defer func() { _ = store.Close() }()
 
 	now := time.Now()
+	inWindow := now
+	outOfWindow := now.Add(-48 * time.Hour)
 
 	execs := []*Execution{
 		{
 			ID: "receipt-completed", TaskID: "GH-5214", ProjectPath: "/p", Status: "completed",
-			CreatedAt: now, DurationMs: 840000, EstimatedCostUSD: 2.75,
+			CreatedAt: now, CompletedAt: &inWindow, DurationMs: 840000, EstimatedCostUSD: 2.75,
 			FilesChanged: 4, LinesAdded: 88, LinesRemoved: 15,
 			TaskSourceAdapter: "github", TaskSourceIssueID: "5214",
 		},
 		{
 			ID: "receipt-failed", TaskID: "GH-5215", ProjectPath: "/p", Status: "failed",
-			CreatedAt: now, DurationMs: 30000, EstimatedCostUSD: 0.42,
+			CreatedAt: now, CompletedAt: &inWindow, DurationMs: 30000, EstimatedCostUSD: 0.42,
 			FilesChanged: 1, LinesAdded: 3, LinesRemoved: 1,
 			TaskSourceAdapter: "github", TaskSourceIssueID: "5215",
 		},
 		{
-			// Non-terminal: must be excluded.
+			// Non-terminal (no CompletedAt yet): must be excluded.
 			ID: "receipt-running", TaskID: "GH-5216", ProjectPath: "/p", Status: "running",
 			CreatedAt: now, EstimatedCostUSD: 0.10,
 		},
 		{
 			// Canary: must be excluded even though terminal and in-period.
 			ID: "receipt-canary", TaskID: "GH-5217", ProjectPath: "/p", Status: "completed",
-			CreatedAt: now, EstimatedCostUSD: 1.00, IsCanary: true,
+			CreatedAt: now, CompletedAt: &inWindow, EstimatedCostUSD: 1.00, IsCanary: true,
 		},
 		{
-			// Outside the period: must be excluded.
+			// Completed outside the period: must be excluded.
 			ID: "receipt-yesterday", TaskID: "GH-5218", ProjectPath: "/p", Status: "completed",
-			CreatedAt: now.Add(-48 * time.Hour), EstimatedCostUSD: 5.00,
+			CreatedAt: outOfWindow, CompletedAt: &outOfWindow, EstimatedCostUSD: 5.00,
+		},
+		{
+			// GH-5261: created well before the window opened (e.g. started
+			// before the previous digest ran) but finished inside the
+			// window — must be included. This is the "in-flight at digest
+			// time" case the created_at-keyed window used to drop forever.
+			ID: "receipt-in-flight-at-digest", TaskID: "GH-5219", ProjectPath: "/p", Status: "completed",
+			CreatedAt: outOfWindow, CompletedAt: &inWindow, EstimatedCostUSD: 3.30,
+			LinesAdded: 20, LinesRemoved: 5,
+			TaskSourceAdapter: "github", TaskSourceIssueID: "5219",
 		},
 	}
 	for _, e := range execs {
@@ -1724,8 +1739,8 @@ func TestGetExecutionsForReceipts(t *testing.T) {
 		t.Fatalf("GetExecutionsForReceipts: %v", err)
 	}
 
-	if len(rows) != 2 {
-		t.Fatalf("expected 2 rows (completed + failed, excluding running/canary/out-of-period), got %d", len(rows))
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows (completed + failed + in-flight-at-digest, excluding running/canary/out-of-period), got %d", len(rows))
 	}
 
 	byID := map[string]*Execution{}
@@ -1769,6 +1784,14 @@ func TestGetExecutionsForReceipts(t *testing.T) {
 	}
 	if failed.EstimatedCostUSD != 0.42 {
 		t.Errorf("EstimatedCostUSD = %v, want 0.42 (failed runs still cost money)", failed.EstimatedCostUSD)
+	}
+
+	inFlight, ok := byID["receipt-in-flight-at-digest"]
+	if !ok {
+		t.Fatal("expected receipt-in-flight-at-digest row (created before window, completed inside it)")
+	}
+	if inFlight.EstimatedCostUSD != 3.30 {
+		t.Errorf("EstimatedCostUSD = %v, want 3.30", inFlight.EstimatedCostUSD)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5257.

Closes #5257

## Changes

GitHub Issue GH-5257: feat(briefs): daily receipts digest — per-run cost receipt lines at configurable time (default 18:00)

# feat(briefs): daily receipts digest — per-run cost receipt lines at configurable time (default 18:00)

📋 PLANNED 2026-08-29 — researched (briefs subsystem seam map complete), dispatching to Pilot.

## Problem

Pilot sends one scheduled daily brief (14:00 local via `orchestrator.daily_brief`,
cron `0 8 * * *` America/New_York). There is no end-of-day **receipts digest**:
one line per completed execution — issue/PR ref, diff size, duration, dollar
cost — plus a day total. All the data already exists on `executions` rows; it's
a formatting + second-schedule feature, not new plumbing.

Blocking defect discovered during research: `GetLastBriefSent(channel)`
(`internal/memory/store.go:5176-5194`) filters `brief_history` by channel only,
not `brief_type`. Any second scheduled brief type on the same Telegram channel
makes catch-up logic read the wrong brief's last-sent timestamp (false catch-up
fires / false skips). Must be fixed as part of this task.

## Design

**Approach: sibling config block + lightweight fork of the scheduler idiom.**
Do NOT generalize the existing `briefs.Scheduler` — it hardcodes
`GenerateDaily()` (`scheduler.go:170`) and `BriefType: "daily"`
(`scheduler.go:191`), and the digest content shape (flat per-execution list +
total) doesn't match `briefs.Brief` (Completed/InProgress/Blocked sections).
A ~150-line receipts scheduler reusing the same cron + timezone + catch-up
pattern keeps the working daily brief untouched.

### 1. Config (`internal/config/config.go`)

- New `ReceiptsDigestConfig` struct mirroring `DailyBriefConfig`
  (config.go:196-204) minus `Time` (deprecated field — don't carry it over)
  and minus `Content`/`Filters` (digest has no content toggles v1):
  `Enabled bool`, `Schedule string`, `Timezone string`,
  `Channels []BriefChannelConfig` (reuse existing type, config.go:206-211).
- Add `ReceiptsDigest *ReceiptsDigestConfig \`yaml:"receipts_digest"\`` to
  `OrchestratorConfig` next to `DailyBrief` (config.go:168).
- Defaults (config.go:565-584 block): `Enabled: false`,
  `Schedule: "0 18 * * *"`, `Timezone: "America/New_York"` (match daily_brief
  default), empty channels.
- `configs/pilot.example.yaml`: add a documented `receipts_digest:` example
  under `orchestrator:` (note: `daily_brief:` has no example block today —
  greenfield; adding a `daily_brief:` example alongside is optional/welcome).

### 2. Memory (`internal/memory/store.go`)

- **Fix**: `GetLastBriefSent(channel string)` → add `briefType string` param,
  `WHERE channel = ? AND brief_type = ?`. Update the single existing call site
  (`internal/briefs/scheduler.go:213`) to pass `"daily"`. Existing
  `brief_history` rows already carry `brief_type = "daily"` so no migration.
- **New query** `GetExecutionsForReceipts(query BriefQuery)`: like
  `GetExecutionsInPeriod` (store.go:2075-2125) but SELECT/Scan the full
  receipt column set — add `estimated_cost_usd, files_changed, lines_added,
  lines_removed, task_source_adapter, task_source_issue_id` (columns exist and
  are populated via `internal/executor/lifecycle.go:330-332`; fuller-column
  Scan pattern precedent: `GetQueuedTasksForProject`, store.go:2375-2380).
  Terminal statuses only (completed + failed — failed runs still cost money;
  mark them in the output). Exclude canary rows
  (`COALESCE(is_canary,0)=0`, same as `GetBriefMetrics` store.go:2281).

### 3. Briefs package (`internal/briefs/`)

New file `receipts.go` (+ `receipts_test.go`):

- `ReceiptsScheduler`: cron via `robfig/cron/v3`, timezone load with
  UTC-fallback-and-warn (copy `scheduler.go:33-37`), catch-up on start using
  the fixed `GetLastBriefSent(channel, "receipts")`, records sends via
  `RecordBriefSent` with `BriefType: "receipts"`.
- Generation: day window in configured timezone (two-places-load-tz shape per
  `generator.go:165-168`), rows from `GetExecutionsForReceipts`.
- **Empty day → skip send entirely** (no "0 runs" noise).
- Telegram formatting (in `receipts.go` or `formatter_receipts.go`):
  - Per-run line: `#5214 merged · +88 −15 · 14m · $2.75` — issue ref via the
    established idiom (strip `GH-` prefix from TaskID, fall back to
    `TaskSourceIssueID`, guard on `TaskSourceAdapter == "github"`;
    `lifecycle.go:427-438`), fall back to task title when no issue number.
    Failed runs marked (e.g. `✗ failed` instead of status).
  - Total line: `N runs · +ΣA −ΣD · $Σ.ΣΣ`.
  - Reuse `formatDuration` (`formatter.go:100-112`),
    `escapeTelegramMarkdown` (`delivery.go:334-344`) on all dynamic strings,
    and the parse-entity-error plain-text retry pattern
    (`delivery.go:246-255, 349-354`).
- Delivery: reuse `DeliveryService`/`TelegramSender` seam (`delivery.go:19-21`)
  or accept the sender directly — whichever needs less surface; no new
  adapter code (`telegramBriefAdapter`, `cmd/pilot/adapters.go:26-41`, wraps
  `SendBriefMessage` already).

### 4. Wiring (`cmd/pilot/main.go`)

- After the `DailyBrief` block (main.go:3775-3836): read
  `cfg.Orchestrator.ReceiptsDigest`, construct + `Start(ctx)` the receipts
  scheduler. Store nil-check same as main.go:3805. Extracting a shared
  `startBriefScheduler`-style helper to cut the ~60-line duplication is
  welcome but optional — do not let it grow the diff into a refactor.

## Acceptance criteria

1. `orchestrator.receipts_digest.enabled: true` with default schedule sends a
   Telegram digest at 18:00 configured-timezone: one line per terminal
   execution that day (issue ref, +adds −dels, duration, $cost) + total line.
2. Empty day sends nothing.
3. `GetLastBriefSent` filters by `brief_type`; daily-brief catch-up and
   receipts catch-up cannot cross-contaminate on a shared channel (test
   covers: both types recorded on same channel, each reads its own).
4. Canary executions excluded from digest rows and totals.
5. Failed runs appear, marked, with their cost counted in the total.
6. Existing daily brief behavior unchanged (its scheduler/generator/delivery
   code paths untouched except the one `GetLastBriefSent` call-site arg).
7. Table-driven tests: formatter (escaping, issue-ref fallback, failed marker,
   totals), `GetExecutionsForReceipts` (column completeness, canary exclusion,
   period boundaries), `GetLastBriefSent` type filter.
8. `configs/pilot.example.yaml` documents `receipts_digest`.
9. `make lint && make test` green.

## Non-goals (v1)

- Slack/email formatting for the digest (Telegram only; channels config shape
  supports adding later).
- `owner/repo` display — `Execution` has only `ProjectPath`, no repo-name
  field; single-project deployments don't need it. Do not add columns.
- Generalizing `briefs.Scheduler` into a multi-brief engine.
- Per-run receipt on PR comments (separate future task).

## Refs

- Research: briefs seam map 2026-08-29 (session research agent; findings
  embedded above with file:line anchors).