### PR TITLE
docs(config): finish the autopilot nesting sweep — 8 stale top-level snippets + phantom keys

### DIFF
--- a/docs/content/deployment/docker-helm.mdx
+++ b/docs/content/deployment/docker-helm.mdx
@@ -309,8 +309,15 @@ config:
       enabled: true
       repo: "your-org/your-repo"
   autopilot:
-    enabled: true
-    auto_merge: false
+    # Rendered as a literal top-level `autopilot:` key in the generated
+    # config.yaml (deploy/helm/pilot/templates/configmap.yaml) — the chart
+    # does not nest it under `orchestrator:`. Only `mode` is templated here,
+    # and it doesn't bind to any autopilot.Config field (there is no `mode`
+    # yaml tag — only `environment`). The environment is actually applied
+    # via the `--autopilot=<mode>` CLI flag appended to the container's
+    # start args (templates/_helpers.tpl), a hidden alias for `--env` — this
+    # ConfigMap block does not otherwise configure autopilot behavior.
+    mode: "stage"  # dev | stage | prod
 
 # Secrets — injected as env vars
 secrets:
@@ -384,9 +391,10 @@ data:
         token: "${GITHUB_TOKEN}"
         repo: "your-org/your-repo"
         project_path: "/workspace"
-    autopilot:
-      enabled: true
-      auto_merge: true
+    orchestrator:
+      autopilot:
+        enabled: true
+        auto_merge: true
 ```
 
 <Callout type="warning">

--- a/docs/content/deployment/kubernetes.mdx
+++ b/docs/content/deployment/kubernetes.mdx
@@ -184,9 +184,10 @@ data:
         enabled: true
         token: "${GITHUB_TOKEN}"
         repo: "your-org/your-repo"
-    autopilot:
-      enabled: true
-      auto_merge: true
+    orchestrator:
+      autopilot:
+        enabled: true
+        auto_merge: true
 ```
 
 ---

--- a/docs/content/deployment/local.mdx
+++ b/docs/content/deployment/local.mdx
@@ -64,11 +64,12 @@ executor:
   type: "claude-code"
   auto_create_pr: true
 
-autopilot:
-  enabled: true
-  auto_merge: true
-  merge_method: "squash"
-  ci_wait_timeout: 30m
+orchestrator:
+  autopilot:
+    enabled: true
+    auto_merge: true
+    merge_method: "squash"
+    ci_wait_timeout: 30m
 ```
 
 ---

--- a/docs/content/features/autopilot.mdx
+++ b/docs/content/features/autopilot.mdx
@@ -27,11 +27,6 @@ orchestrator:
     enabled: true
     environment: stage
     auto_merge: true
-    require_ci: true
-    merge_delay: 5m  # Wait before merging (stage only)
-    protected_branches:
-      - main
-      - production
 ```
 
 ## Usage
@@ -56,15 +51,6 @@ Autopilot always waits for CI to pass:
 ```
 Task → PR → CI Running → CI Passes → Merge
                       ↘ CI Fails → Notify, No Merge
-```
-
-### Merge Delay (Stage)
-
-In `stage` mode, there's a configurable delay:
-
-```
-CI Passes → 5min delay → Check for comments → Merge
-                       ↘ Comments found → Notify, No Merge
 ```
 
 ### Protected Branches
@@ -150,14 +136,10 @@ Auto-rebase avoids ~$8–15 per full re-execution for conflicts that are trivial
 orchestrator:
   autopilot:
     enabled: true
-    conflict_handling:
-      auto_rebase: true        # Enable auto-rebase via GitHub API (default: true)
-      close_on_failure: true   # Close PR if rebase fails (default: true)
-      requeue_on_failure: true # Re-queue issue for fresh execution (default: true)
-      max_rebase_attempts: 1   # Attempts before falling back to close (default: 1)
+    max_rebase_attempts: 3   # Attempts before falling back to close+requeue (default: 3)
 ```
 
-Set `auto_rebase: false` to skip the rebase attempt and immediately close-and-requeue on any conflict. This is useful if your CI is fast and re-execution is cheaper than debugging merge artifacts.
+Auto-rebase itself is not a toggle — autopilot always attempts an API rebase on conflict, then closes-and-requeues on failure (see the flow above). `max_rebase_attempts` (`autopilot.Config.MaxRebaseAttempts` in `internal/autopilot/types.go`) is a flat, top-level field on the `autopilot` config struct — not nested under a `conflict_handling:` block — and is the only part of this behavior that's configurable today.
 
 ## CI Fix Dependencies
 

--- a/docs/content/features/epic-decomposition.mdx
+++ b/docs/content/features/epic-decomposition.mdx
@@ -216,10 +216,10 @@ Epic subtasks work seamlessly with autopilot mode:
 
 ```yaml
 # Each subtask PR is tracked independently
-autopilot:
-  enabled: true
-  environment: stage
-  merge_delay: 5m  # Applied to each subtask PR
+orchestrator:
+  autopilot:
+    enabled: true
+    environment: stage
 ```
 
 ### Callback Registration

--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -507,7 +507,6 @@ orchestrator:
     environment: "stage"                  # dev, stage, prod
     approval_source: "telegram"           # telegram, slack, github-review
 
-    auto_review: true                     # self-review before PR
     auto_merge: true                      # merge after CI passes
     merge_method: "squash"                # squash, merge, rebase
 
@@ -546,7 +545,6 @@ orchestrator:
 | `enabled` | bool | `false` | Enable autopilot mode |
 | `environment` | string | `"stage"` | Environment: `dev`, `stage`, `prod` |
 | `approval_source` | string | `"telegram"` | Where to get approvals: `telegram`, `slack`, `github-review` |
-| `auto_review` | bool | `true` | Run self-review before creating PR |
 | `auto_merge` | bool | `true` | Auto-merge after CI passes |
 | `merge_method` | string | `"squash"` | Git merge strategy |
 | `ci_wait_timeout` | duration | `30m` | Max time to wait for CI |

--- a/docs/content/integrations/github.mdx
+++ b/docs/content/integrations/github.mdx
@@ -207,8 +207,9 @@ Each failed execution bumps the persistent retry counter (`pilot-retry-1` → `p
 Pilot supports all GitHub merge methods:
 
 ```yaml
-autopilot:
-  merge_method: squash   # "merge", "squash", or "rebase"
+orchestrator:
+  autopilot:
+    merge_method: squash   # "merge", "squash", or "rebase"
 ```
 
 | Method | Description |
@@ -245,12 +246,12 @@ Pilot monitors both commit statuses and check runs:
 With Autopilot enabled, Pilot can automatically merge PRs after checks pass:
 
 ```yaml
-autopilot:
-  enabled: true
-  environment: dev
-  auto_merge: true
-  require_approval: false
-  max_failures: 3
+orchestrator:
+  autopilot:
+    enabled: true
+    environment: dev
+    auto_merge: true
+    max_failures: 3
 ```
 
 ### Auto-Merge Flow
@@ -267,9 +268,14 @@ autopilot:
 
 ### Approval Requirements
 
+`require_approval` is a per-environment setting — it lives on each entry under `orchestrator.autopilot.environments`, not on the autopilot block directly. The built-in `prod` environment already defaults to `require_approval: true`; override any environment explicitly like this:
+
 ```yaml
-autopilot:
-  require_approval: true
+orchestrator:
+  autopilot:
+    environments:
+      prod:
+        require_approval: true
 ```
 
 When enabled, Pilot waits for a human approval review before auto-merging.


### PR DESCRIPTION
## Summary

Deferred docs leg from #5255 / PR#5256 (review note N1), filed as GH-5259.

- Re-nests the 8 remaining top-level `autopilot:` snippets to canonical `orchestrator.autopilot:` across `github.mdx` (x3), `local.mdx`, `epic-decomposition.mdx`, `docker-helm.mdx` (x2), and `kubernetes.mdx`.
- Removes documented keys that yaml.v3 silently drops (bind to no Go struct field): `merge_delay`, `protected_branches`, the whole `conflict_handling:` block, autopilot-level `require_ci`, and `auto_review`.
- Fixes `require_approval`, which only exists on `EnvironmentConfig` (i.e. `orchestrator.autopilot.environments.<name>.require_approval`) — never flat on the autopilot block, so every doc showing it flat was also silently a no-op.
- Docs only. No changes under `internal/`, `cmd/`, or `configs/*.yaml` loader paths.

## Special case: Helm/Kubernetes values-block snippets

Two of the flagged snippets sit inside Helm/Kubernetes values or raw-manifest blocks, so I verified against the real chart before touching them (`deploy/helm/pilot/`):

- **`kubernetes.mdx` (bare `ConfigMap` manifest)** and **`docker-helm.mdx`'s "config.yaml in Kubernetes" raw `ConfigMap` example** are hand-authored `config.yaml` content, not templated by the chart at all — these got the standard `orchestrator.autopilot:` re-nest.
- **`docker-helm.mdx`'s "values.yaml Reference"** (`config.autopilot:`) is genuinely different: the real chart's `templates/configmap.yaml` renders `.Values.autopilot.mode` as a **literal top-level `autopilot:` key** in the generated `config.yaml` — it does **not** nest under `orchestrator:`. And `templates/_helpers.tpl`'s `pilot.startArgs` separately appends `--autopilot=<mode>` (a hidden alias for `--env`) to the container's start args — that CLI flag, not the ConfigMap's `autopilot:` block, is what actually sets the environment. I could not run `helm template` in this sandbox (no `helm` binary), so I hand-traced the templates instead; substituting chart defaults (`autopilot.mode: "stage"`, `adapters.github.enabled: true`) gives:

  ```yaml
  # rendered config.yaml (configmap.yaml)
  gateway: {host: "0.0.0.0", port: 9090}
  adapters: {github: {enabled: true}, telegram: {enabled: false}, slack: {enabled: false}, linear: {enabled: false}}
  autopilot:
    mode: "stage"
  storage: {path: /home/pilot/.pilot/data/pilot.db}
  ```
  ```json
  // rendered start args (_helpers.tpl)
  ["start", "--github", "--autopilot=stage"]
  ```

  Per the task's guidance ("if the values block legitimately emits `autopilot:` at the values top-level... keep the values-block shape and add a clarifying comment instead of blindly re-nesting"), I kept the top-level shape and added a comment documenting this — plus that `mode` itself doesn't bind to any `autopilot.Config` field (only `environment` does; the ConfigMap block is presently a no-op duplicate of the CLI flag). This is a real, separate chart-side gap (out of scope for a docs-only PR — flagging here for a follow-up issue rather than fixing `deploy/helm/pilot/templates/` in this PR).

  I also noticed the surrounding "values.yaml Reference" example (`config.gateway`, `config.adapters.github.repo`, etc.) doesn't match the real chart's flat `values.yaml` schema at all (real values.yaml has no `config:` wrapper) — a larger, pre-existing drift beyond this ticket's autopilot-nesting scope. Flagging for a separate ticket rather than doing a full Helm-docs rewrite here.

## Verification table — every documented autopilot key vs. real yaml tag

Source: `internal/autopilot/types.go` (`Config`, `EnvironmentConfig`, `ReleaseConfig`, `GitHubReviewConfig`, `CIChecksConfig`, `ReviewFeedbackConfig`, `PlatformBreakerConfig`, `TestEvidenceConfig`, `ProjectCIChecksOverride`, `ProjectApprovalOverride`, `ProjectReleaseConfig`).

**`orchestrator.autopilot.*` (flat on `autopilot.Config`) — all real:**
`enabled`, `environment`, `default_environment`, `environments`, `approval_source`, `github_review`, `auto_merge`, `merge_method`, `ci_wait_timeout`, `dev_ci_timeout`, `ci_poll_interval`, `required_checks`, `ci_checks`, `auto_create_issues`, `issue_labels`, `notify_on_failure`, `review_feedback`, `max_failures`, `max_ci_fix_iterations`, `max_ci_fix_pr_size`, `failure_reset_timeout`, `platform_breaker`, `max_merges_per_hour`, `max_merge_attempts`, `max_rebase_attempts`, `max_releasing_attempts`, `approval_timeout`, `release`, `merged_pr_scan_window`, `startup_merged_pr_scan_window`, `rate_limit_floor_pct`, `scan_stagger_interval`, `name`, `test_evidence`.

**Nested, real:** `environments.<name>.{branch,require_approval,approval_source,approval_timeout,ci_timeout,skip_post_merge_ci,merge_method,post_merge,release}`; `release.{enabled,trigger,version_strategy,tag_prefix,generate_changelog,notify_on_release,require_ci,generate_summary,publish,verify_release,verify_timeout,tag_human_merges,scope_label_prefix,scope_lookback,schedule,schedule_timezone,scope_stale_after}`; `ci_checks.{mode,exclude,required,discovery_grace_period}`; `review_feedback.{enabled,max_iterations}`; `github_review.poll_interval`; `platform_breaker.{enabled,min_correlated_prs,correlation_window,quiet_period,probe_interval,pause_admission}`; `test_evidence.{enabled,min_tests,max_skip_ratio}`.

**Phantom — removed from docs in this PR (bind to no struct field anywhere):**
| Key | Where it was documented | Why it's phantom |
|---|---|---|
| `merge_delay` | `autopilot.mdx`, `epic-decomposition.mdx` | No `MergeDelay` field/behavior anywhere in `internal/autopilot` |
| `protected_branches` | `autopilot.mdx` | No `ProtectedBranches` field/behavior anywhere |
| `conflict_handling.*` (`auto_rebase`, `close_on_failure`, `requeue_on_failure`, `max_rebase_attempts` nested) | `autopilot.mdx` | No `conflict_handling` struct; real field is the **flat** `max_rebase_attempts` on `Config` — replaced the block with that |
| `require_ci` (flat on autopilot) | `autopilot.mdx` | Real `RequireCI` field only exists on `ReleaseConfig` (`release.require_ci`) |
| `require_approval` (flat on autopilot) | `github.mdx` (x2) | Real `RequireApproval` field only exists on `EnvironmentConfig` — fixed to `environments.<name>.require_approval` |
| `auto_review` | `getting-started/configuration.mdx` | No such field; self-review is actually `executor.skip_self_review` (`internal/executor/backend.go:370`), already documented separately in the same file |

## Non-goals honored
- No changes under `internal/`, `cmd/`, or `configs/*.yaml` loader paths.
- No new docs-lint tooling.
- No Helm chart template changes (the chart-side `autopilot.mode` gap is flagged above for a follow-up issue, not fixed here).

## Test plan
- [x] `grep -rn "^autopilot:" docs/ configs/` returns empty
- [x] All edited YAML code fences parse with `yaml.safe_load_all` (ran a one-shot Python check)
- [x] `go build ./...` passes (no Go files touched)
- [x] Manually verified every doc-documented autopilot key against `internal/autopilot/types.go` struct tags (table above)
- [x] Manually traced `deploy/helm/pilot/templates/configmap.yaml` + `_helpers.tpl` rendering (no `helm` binary available in this sandbox)

Refs: #5255 / PR#5256 (review note N1) · #5251 / PR#5253 (origin of the lift) · GH-5227/PR#5245