### PR TITLE
GH-5263: fix(autopilot): merging stage attempts to merge draft PRs and ignores CHANGES_REQUESTED reviews — burns attempts, trips breaker, and only the draft flag prevents merging over a reviewer

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -4670,6 +4670,47 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 		return nil
 	}
 
+	// GH-5263: never attempt to merge a draft PR or one with an outstanding
+	// changes-requested review. Root incident, PR#5258 (2026-08-30): CI went
+	// green, then a REQUEST-CHANGES review landed and the founder-review-flow
+	// drafted the PR + spawned a revision issue (#5261) — but nothing in this
+	// stage checked either signal, so the very next tick called MergePR blind.
+	// verifyCIBeforeMerge only verifies CI; it has no opinion on draft/review
+	// state, so every attempt was a guaranteed GitHub 405 ("still a draft")
+	// that burned the MergeAttempts budget and fed the per-PR circuit breaker
+	// for what was a deliberate, healthy hold — not a failure. On this repo
+	// (no branch protection) the draft flag was ALSO the only thing stopping a
+	// PR carrying an outstanding CHANGES_REQUESTED review from auto-merging
+	// over the reviewer's objection; a race, a manual review without the
+	// revision trigger phrase, or a revision-spawn failure would leave a
+	// non-draft PR with unaddressed feedback exposed to the next green tick.
+	// Both checks below are a plain `return nil` — like the platformBreaker
+	// guard above — not a park via prState.Parked: no label, no alert, no
+	// escalation comment. This is routine review-cycle state, not an incident
+	// requiring human attention, and it self-resolves the moment the PR is
+	// marked ready or re-reviewed/dismissed — both poll-visible fields
+	// re-checked fresh every tick, so no new event plumbing is needed.
+	// MergeAttempts is not incremented and recordPRFailure is never reached
+	// (ProcessPR only calls it when this handler returns a non-nil error), so
+	// neither check can trip the breaker. Fails open on a GetPullRequest
+	// error (mirrors the CI re-validation fail-open just below): a transient
+	// API error must not wedge a legitimate merge forever — the existing
+	// 405-on-draft failure path remains as a backstop, now unreachable in the
+	// common case.
+	if ghPR, err := c.ghClient.GetPullRequest(ctx, c.owner, c.repo, prState.PRNumber); err != nil {
+		c.log.Warn("handleMerging: could not fetch PR to check draft/review hold, proceeding (fail-open)",
+			"pr", prState.PRNumber, "error", err)
+	} else if ghPR.Draft {
+		c.log.Info("handleMerging: PR is a draft — holding merge until marked ready for review",
+			"pr", prState.PRNumber)
+		return nil
+	}
+	if c.hasChangesRequested(ctx, prState) {
+		c.log.Info("handleMerging: PR has an outstanding changes-requested review — holding merge until re-reviewed or dismissed",
+			"pr", prState.PRNumber)
+		return nil
+	}
+
 	// GH-4477: re-validate CI live at the merge chokepoint instead of trusting
 	// the ci_status frozen by handleCIPassed/handleWaitingCI. Once a PR
 	// reaches StageAwaitApproval, ci_status is never touched again — a

--- a/internal/autopilot/gh5263_test.go
+++ b/internal/autopilot/gh5263_test.go
@@ -1,0 +1,436 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestHandleMerging_DraftReview_TableDriven reproduces the PR#5258 incident
+// (2026-08-30): the merging stage never checked draft status or outstanding
+// review state, so a draft PR (or one with an unresolved CHANGES_REQUESTED
+// review) was merged blind — guaranteed to fail with GitHub 405 ("still a
+// draft") in the draft case, or to actually land over a reviewer's objection
+// in the non-draft changes-requested case. Both must now be held with zero
+// merge attempts, zero attempted merge calls, and zero circuit-breaker feed.
+func TestHandleMerging_DraftReview_TableDriven(t *testing.T) {
+	tests := []struct {
+		name     string
+		draft    bool
+		reviews  []*github.PullRequestReview
+		wantHold bool
+	}{
+		{
+			name:     "draft PR holds regardless of CI",
+			draft:    true,
+			reviews:  nil,
+			wantHold: true,
+		},
+		{
+			name:  "non-draft PR with outstanding changes-requested review holds",
+			draft: false,
+			reviews: []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "reviewer"}, State: github.ReviewStateChangesRequested, SubmittedAt: "2026-08-29T17:20:00Z"},
+			},
+			wantHold: true,
+		},
+		{
+			name:  "PR#5258 shape: draft AND changes-requested AND green CI still holds, no attempt",
+			draft: true,
+			reviews: []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "reviewer"}, State: github.ReviewStateChangesRequested, SubmittedAt: "2026-08-29T17:20:00Z"},
+			},
+			wantHold: true,
+		},
+		{
+			name:  "non-draft PR with only an approval merges normally",
+			draft: false,
+			reviews: []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "reviewer"}, State: github.ReviewStateApproved, SubmittedAt: "2026-08-29T17:20:00Z"},
+			},
+			wantHold: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mergeAttempted bool
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/repos/owner/repo/pulls/5258" && r.Method == http.MethodGet:
+					resp := github.PullRequest{
+						Number: 5258,
+						Head:   github.PRRef{SHA: "sha5258"},
+						Base:   github.PRRef{Ref: "main"},
+						Draft:  tt.draft,
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+
+				case r.URL.Path == "/repos/owner/repo/pulls/5258/reviews":
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(tt.reviews)
+
+				case r.URL.Path == "/repos/owner/repo/commits/sha5258/check-runs":
+					resp := github.CheckRunsResponse{
+						TotalCount: 1,
+						CheckRuns: []github.CheckRun{
+							{Name: "build", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+
+				case r.URL.Path == "/repos/owner/repo/pulls/5258/merge" && r.Method == http.MethodPut:
+					mergeAttempted = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.Environment = EnvDev
+			cfg.AutoMerge = true
+			cfg.RequiredChecks = []string{"build"}
+
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+			c.mu.Lock()
+			c.activePRs[5258] = &PRState{
+				PRNumber:     5258,
+				PRURL:        "https://github.com/owner/repo/pull/5258",
+				IssueNumber:  61,
+				BranchName:   "pilot/GH-61",
+				HeadSHA:      "sha5258",
+				Stage:        StageMerging,
+				TargetBranch: "main",
+				CreatedAt:    time.Date(2026, 8, 29, 0, 0, 0, 0, time.UTC),
+			}
+			c.mu.Unlock()
+
+			if err := c.ProcessPR(context.Background(), 5258, nil); err != nil {
+				t.Fatalf("ProcessPR returned error: %v", err)
+			}
+
+			pr, ok := c.GetPRState(5258)
+			if !ok {
+				t.Fatal("PR should still be tracked")
+			}
+
+			if tt.wantHold {
+				if mergeAttempted {
+					t.Error("merge API must not be called while held")
+				}
+				if pr.MergeAttempts != 0 {
+					t.Errorf("MergeAttempts = %d, want 0 (held ticks must not burn the attempt budget)", pr.MergeAttempts)
+				}
+				if pr.Stage != StageMerging {
+					t.Errorf("Stage = %s, want %s (held PR stays in merging, no error/backoff)", pr.Stage, StageMerging)
+				}
+				if c.GetPRFailures(5258) != 0 {
+					t.Errorf("PR failure count = %d, want 0 (a hold must not feed the per-PR circuit breaker)", c.GetPRFailures(5258))
+				}
+				if c.IsPRCircuitOpen(5258) {
+					t.Error("per-PR circuit breaker must not open on a draft/changes-requested hold")
+				}
+			} else {
+				if !mergeAttempted {
+					t.Error("merge API should have been called for a mergeable, approved PR")
+				}
+				if pr.Stage != StageMerged {
+					t.Errorf("Stage = %s, want %s", pr.Stage, StageMerged)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleMerging_DraftPR_ReadyResumesMergeOnNextTick verifies that a draft
+// PR held at StageMerging (GH-5263) resumes and merges automatically on the
+// very next tick once GitHub reports it as no longer a draft — no extra event
+// plumbing, since draft state is a plain field re-read from GetPullRequest
+// every tick.
+func TestHandleMerging_DraftPR_ReadyResumesMergeOnNextTick(t *testing.T) {
+	draft := true
+	var mergeAttempted bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/5259" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number: 5259,
+				Head:   github.PRRef{SHA: "sha5259"},
+				Base:   github.PRRef{Ref: "main"},
+				Draft:  draft,
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/5259/reviews":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequestReview{})
+
+		case r.URL.Path == "/repos/owner/repo/commits/sha5259/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/5259/merge" && r.Method == http.MethodPut:
+			mergeAttempted = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoMerge = true
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	c.activePRs[5259] = &PRState{
+		PRNumber:     5259,
+		PRURL:        "https://github.com/owner/repo/pull/5259",
+		IssueNumber:  62,
+		BranchName:   "pilot/GH-62",
+		HeadSHA:      "sha5259",
+		Stage:        StageMerging,
+		TargetBranch: "main",
+		CreatedAt:    time.Now(),
+	}
+	c.mu.Unlock()
+
+	// Tick 1: still a draft — held, no attempt.
+	if err := c.ProcessPR(context.Background(), 5259, nil); err != nil {
+		t.Fatalf("ProcessPR (tick 1) returned error: %v", err)
+	}
+	if mergeAttempted {
+		t.Fatal("merge must not be attempted while the PR is a draft")
+	}
+	pr, _ := c.GetPRState(5259)
+	if pr.Stage != StageMerging || pr.MergeAttempts != 0 {
+		t.Fatalf("after tick 1: stage=%s attempts=%d, want stage=%s attempts=0", pr.Stage, pr.MergeAttempts, StageMerging)
+	}
+
+	// Marked ready for review.
+	draft = false
+
+	// Tick 2: no longer a draft — merges.
+	if err := c.ProcessPR(context.Background(), 5259, nil); err != nil {
+		t.Fatalf("ProcessPR (tick 2) returned error: %v", err)
+	}
+	if !mergeAttempted {
+		t.Error("merge should be attempted once the PR is marked ready")
+	}
+	pr, _ = c.GetPRState(5259)
+	if pr.Stage != StageMerged {
+		t.Errorf("Stage = %s, want %s after draft->ready transition", pr.Stage, StageMerged)
+	}
+}
+
+// TestHandleMerging_ChangesRequested_DismissalResumesMerge verifies that a
+// non-draft PR held for an outstanding CHANGES_REQUESTED review (GH-5263)
+// resumes once the review is superseded — either a later APPROVE from the
+// same reviewer or an explicit dismissal (GitHub flips the review's own
+// State to DISMISSED in place; hasChangesRequested already treats that as
+// "no longer the latest CHANGES_REQUESTED state" for that user).
+func TestHandleMerging_ChangesRequested_DismissalResumesMerge(t *testing.T) {
+	reviewState := github.ReviewStateChangesRequested
+	var mergeAttempted bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/5260" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number: 5260,
+				Head:   github.PRRef{SHA: "sha5260"},
+				Base:   github.PRRef{Ref: "main"},
+				Draft:  false,
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/5260/reviews":
+			resp := []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "reviewer"}, State: reviewState, SubmittedAt: "2026-08-29T17:20:00Z"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/commits/sha5260/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/5260/merge" && r.Method == http.MethodPut:
+			mergeAttempted = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoMerge = true
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	c.activePRs[5260] = &PRState{
+		PRNumber:     5260,
+		PRURL:        "https://github.com/owner/repo/pull/5260",
+		IssueNumber:  63,
+		BranchName:   "pilot/GH-63",
+		HeadSHA:      "sha5260",
+		Stage:        StageMerging,
+		TargetBranch: "main",
+		CreatedAt:    time.Date(2026, 8, 29, 0, 0, 0, 0, time.UTC),
+	}
+	c.mu.Unlock()
+
+	// Tick 1: outstanding changes-requested review — held, no attempt.
+	if err := c.ProcessPR(context.Background(), 5260, nil); err != nil {
+		t.Fatalf("ProcessPR (tick 1) returned error: %v", err)
+	}
+	if mergeAttempted {
+		t.Fatal("merge must not be attempted while a changes-requested review is outstanding")
+	}
+	pr, _ := c.GetPRState(5260)
+	if pr.Stage != StageMerging || pr.MergeAttempts != 0 {
+		t.Fatalf("after tick 1: stage=%s attempts=%d, want stage=%s attempts=0", pr.Stage, pr.MergeAttempts, StageMerging)
+	}
+	if c.GetPRFailures(5260) != 0 {
+		t.Errorf("PR failure count = %d, want 0", c.GetPRFailures(5260))
+	}
+
+	// Reviewer dismisses their own changes-requested review.
+	reviewState = github.ReviewStateDismissed
+
+	// Tick 2: review no longer blocking — merges.
+	if err := c.ProcessPR(context.Background(), 5260, nil); err != nil {
+		t.Fatalf("ProcessPR (tick 2) returned error: %v", err)
+	}
+	if !mergeAttempted {
+		t.Error("merge should be attempted once the changes-requested review is dismissed")
+	}
+	pr, _ = c.GetPRState(5260)
+	if pr.Stage != StageMerged {
+		t.Errorf("Stage = %s, want %s after dismissal", pr.Stage, StageMerged)
+	}
+}
+
+// TestHandleMerging_GenuineMergeFailure_StillFeedsBreaker verifies the
+// GH-5263 fix does not weaken the existing failure path: a real merge
+// failure (not draft, not changes-requested) still increments MergeAttempts
+// and feeds the per-PR circuit breaker exactly as before.
+func TestHandleMerging_GenuineMergeFailure_StillFeedsBreaker(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/5261" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:         5261,
+				Head:           github.PRRef{SHA: "sha5261"},
+				Base:           github.PRRef{Ref: "main"},
+				Draft:          false,
+				Mergeable:      boolPtr(true),
+				MergeableState: "clean",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/5261/reviews":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequestReview{})
+
+		case r.URL.Path == "/repos/owner/repo/commits/sha5261/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/5261/merge" && r.Method == http.MethodPut:
+			// Simulate a genuine, non-draft/non-review merge failure (e.g. a
+			// transient API error) — not a conflict, so handleMergeConflict's
+			// close path is not taken.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"internal error"}`))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoMerge = true
+	cfg.RequiredChecks = []string{"build"}
+	cfg.MaxMergeAttempts = 5
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	c.activePRs[5261] = &PRState{
+		PRNumber:     5261,
+		PRURL:        "https://github.com/owner/repo/pull/5261",
+		IssueNumber:  64,
+		BranchName:   "pilot/GH-64",
+		HeadSHA:      "sha5261",
+		Stage:        StageMerging,
+		TargetBranch: "main",
+		CreatedAt:    time.Date(2026, 8, 29, 0, 0, 0, 0, time.UTC),
+	}
+	c.mu.Unlock()
+
+	if err := c.ProcessPR(context.Background(), 5261, nil); err == nil {
+		t.Fatal("expected a genuine merge failure to return an error")
+	}
+
+	pr, _ := c.GetPRState(5261)
+	if pr.MergeAttempts != 1 {
+		t.Errorf("MergeAttempts = %d, want 1 (a genuine failure must still count)", pr.MergeAttempts)
+	}
+	if c.GetPRFailures(5261) != 1 {
+		t.Errorf("PR failure count = %d, want 1 (a genuine failure must still feed the breaker)", c.GetPRFailures(5261))
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5263.

Closes #5263

## Changes

GitHub Issue GH-5263: fix(autopilot): merging stage attempts to merge draft PRs and ignores CHANGES_REQUESTED reviews — burns attempts, trips breaker, and only the draft flag prevents merging over a reviewer

## Problem

Live incident 2026-08-30 ~13:47-13:52Z, founder box, PR#5258. The autopilot merging stage attempted to merge a DRAFT PR three times, failed each time with GitHub 405 "Pull Request is still a draft", and tripped the per-PR circuit breaker — producing a failure alert for what is actually a healthy, deliberately-held PR.

Ledger evidence (autopilot_pr_state + daemon.log): stage=merging, "merge attempt 3 failed: ... status 405 ... still a draft"; log sequence per attempt is "verifyCIBeforeMerge: CI passed" → "handleMerging: merge failed" → "autopilot stage failed", then "per-PR circuit breaker open" every tick after.

Context: PR#5258 had green CI, then received a REQUEST-CHANGES review (2026-08-29 17:20Z) which spawned revision issue #5261 and converted the PR to draft. When #5261 began executing (13:47Z), the controller re-processed PR#5258 and went straight to merging.

## Two defects

1. **The merge path never checks draft status.** verifyCIBeforeMerge passes and handleMerging calls the merge API blind; every attempt is a guaranteed 405 that burns the attempt budget and feeds the breaker. A draft is a deliberate hold — it should park the PR (no attempts, no breaker feed, no failure alert), and resume automatically when the PR is marked ready.

2. **The merge path never checks review state.** On this repo (no branch protection) the ONLY thing that stopped a PR with an outstanding REQUEST-CHANGES review from auto-merging was the draft flag that the revision flow happens to set. If a REQUEST-CHANGES review lands without the revision flow drafting the PR (race, manual review without the trigger phrase, revision-spawn failure), the next green tick merges over the reviewer's objection. The merge gate should treat an outstanding changes-requested review as a hold until re-review or dismissal, independent of draft state.

## Fix shape

In the merging stage (and ideally as a pre-check in verifyCIBeforeMerge's caller):
- Query PR draft status; if draft → do not attempt, do not count an attempt, do not feed the breaker; log a hold at INFO and re-check next tick (drafts flip to ready via a webhook/poll-visible field — no new event plumbing needed).
- Query review state; if the latest review by any maintainer is CHANGES_REQUESTED and not dismissed/superseded by a later APPROVE → same hold semantics, distinct log reason.
- The existing 405-on-draft failure path stays as a backstop but should be unreachable.

## Acceptance

- A draft PR at stage merging is parked with zero merge attempts, zero breaker feeds, zero failure alerts; marking it ready resumes the merge on the next tick (test both).
- A non-draft PR with an outstanding CHANGES_REQUESTED review is parked the same way; a subsequent APPROVE or review dismissal unparks it (test both).
- Genuine merge failures (conflicts, real API errors) still count attempts and feed the breaker exactly as today.
- The PR#5258 shape (draft + changes-requested + green CI) reproduced in a table-driven test: no attempt made.

## Refs

- Incident: PR#5258 / revision #5261 (2026-08-30) · breaker semantics #5237/#5239 · revision-cycle drafting behavior (review-feedback loop) · TASK-460 family (a failure alert on a healthy hold is false evidence)