### PR TITLE
GH-5266: fix(autopilot): review-merge hold is blind after re-adoption and cleared by COMMENTED reviews — harden the CHANGES_REQUESTED backstop

### DIFF
--- a/.agent/tasks/gh-5266.md
+++ b/.agent/tasks/gh-5266.md
@@ -1,0 +1,32 @@
+# GH-5266
+
+**Created:** 2026-08-30
+
+## Problem
+
+GitHub Issue GH-5266: fix(autopilot): review-merge hold is blind after re-adoption and cleared by COMMENTED reviews — harden the CHANGES_REQUESTED backstop
+
+## Problem
+
+Follow-up from the PR#5264 post-merge review (notes N1/N2 — both pre-existing in the reused hasChangesRequested logic in internal/autopilot/controller.go, now load-bearing for the merge hold):
+
+1. **Re-adoption blinds the review hold.** hasChangesRequested ignores reviews submitted before prState.CreatedAt, and both PR registration paths (fresh registration and reconciler re-adoption) set CreatedAt to now. After a daemon restart or orphan re-adoption, a standing CHANGES_REQUESTED review older than the adoption timestamp is invisible — the PR auto-merges over the reviewer's objection. This is exactly the race/revision-spawn-failure scenario #5263 was filed to close; the protection currently holds only within a single tracked lifetime.
+2. **COMMENTED supersedes CHANGES_REQUESTED.** The latest-review-per-user map overwrites with whatever review is chronologically last, so a later COMMENTED review from the same reviewer clears the hold. GitHub's own model does not treat COMMENTED as superseding a change request. Fail-open.
+
+## Fix shape
+
+- For (1): on re-adoption, derive the review-hold cutoff from something durable (e.g. the PR's own creation time from the GitHub API, or the head commit's timestamp) instead of prState.CreatedAt=now — the CreatedAt filter's original purpose (avoid permanently parking on ancient stale reviews) is preserved by cutting off at PR creation, not at adoption.
+- For (2): in the per-user latest map, let only APPROVE or an explicit dismissal (state DISMISSED) supersede a CHANGES_REQUESTED; COMMENTED keeps the standing request.
+
+## Acceptance
+
+- Table-driven tests: (a) PR with CHANGES_REQUESTED → daemon restart/re-adoption simulated (fresh prState) → merge still held; (b) CHANGES_REQUESTED then COMMENTED (same user) → held; then APPROVE → unparked; then a DISMISSED case → unparked.
+- The no-permanent-park property is preserved: a PR whose only change-request predates the PR's own creation (cross-linked/moved review edge) or is dismissed does not park.
+- Genuine-failure accounting untouched.
+
+## Refs
+
+- PR#5264 review notes N1/N2 · #5263 (parent) · the revision-flow interception (ReviewFeedback poller) remains the primary path; this hardens the backstop.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -4212,15 +4212,46 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 }
 
 // hasChangesRequested checks if a PR has unresolved "changes requested" reviews.
-// It filters out bot reviews and only considers reviews submitted after the PR was created.
-func (c *Controller) hasChangesRequested(ctx context.Context, prState *PRState) bool {
+// It filters out bot reviews and only considers reviews submitted after the PR
+// was created.
+//
+// ghPR is the caller's already-fetched live PR object (may be nil if the
+// caller's own GetPullRequest fetch failed and it is proceeding fail-open) —
+// GH-5266: it supplies the review-hold cutoff via ghPR.CreatedAt (the PR's
+// real, durable GitHub creation time) in preference to prState.CreatedAt.
+// prState.CreatedAt is set to time.Now() both by OnPRCreated (fresh
+// registration) and by the reconciler's orphan-PR sweep (re-adoption after a
+// daemon restart or an executor callback miss) — so using it as the cutoff
+// blinded the hold exactly when it mattered most: a standing
+// CHANGES_REQUESTED review submitted before a restart became invisible the
+// moment the PR was re-adopted, because every review now looked "older than
+// tracking" (#5263's race/revision-spawn-failure scenario, N1 from the
+// PR#5264 review). Falls back to prState.CreatedAt only when ghPR is nil or
+// its CreatedAt fails to parse, preserving the original no-permanent-park
+// intent (never hold on a review that predates the PR itself) in that
+// degraded case.
+func (c *Controller) hasChangesRequested(ctx context.Context, prState *PRState, ghPR *github.PullRequest) bool {
 	reviews, err := c.ghClient.ListPullRequestReviews(ctx, c.owner, c.repo, prState.PRNumber)
 	if err != nil {
 		c.log.Warn("failed to fetch reviews for changes_requested check", "pr", prState.PRNumber, "error", err)
 		return false
 	}
 
-	// Track latest review state per user (only non-bot users)
+	cutoff := prState.CreatedAt
+	if ghPR != nil && ghPR.CreatedAt != "" {
+		if parsed, perr := time.Parse(time.RFC3339, ghPR.CreatedAt); perr == nil {
+			cutoff = parsed
+		}
+	}
+
+	// Track latest review state per user (only non-bot users). GH-5266 (N2
+	// from the PR#5264 review): a plain "last review wins" map let a later
+	// COMMENTED review from the same reviewer silently clear a standing
+	// CHANGES_REQUESTED — GitHub's own review model does not treat a
+	// comment-only review as superseding a change request, only a fresh
+	// APPROVED or an explicit DISMISSED does. So once a user's latest
+	// recorded state is CHANGES_REQUESTED, only APPROVED/DISMISSED are
+	// allowed to overwrite it; COMMENTED (or any other state) is ignored.
 	latestState := make(map[string]string)
 	for _, r := range reviews {
 		// Skip bot reviews (self-review)
@@ -4229,13 +4260,16 @@ func (c *Controller) hasChangesRequested(ctx context.Context, prState *PRState) 
 		}
 
 		// Only consider reviews submitted after the PR entered tracking
-		if r.SubmittedAt != "" && !prState.CreatedAt.IsZero() {
+		if r.SubmittedAt != "" && !cutoff.IsZero() {
 			submittedAt, err := time.Parse(time.RFC3339, r.SubmittedAt)
-			if err == nil && submittedAt.Before(prState.CreatedAt) {
+			if err == nil && submittedAt.Before(cutoff) {
 				continue
 			}
 		}
 
+		if latestState[r.User.Login] == "CHANGES_REQUESTED" && r.State != "APPROVED" && r.State != "DISMISSED" {
+			continue
+		}
 		latestState[r.User.Login] = r.State
 	}
 
@@ -4697,15 +4731,19 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 	// API error must not wedge a legitimate merge forever — the existing
 	// 405-on-draft failure path remains as a backstop, now unreachable in the
 	// common case.
-	if ghPR, err := c.ghClient.GetPullRequest(ctx, c.owner, c.repo, prState.PRNumber); err != nil {
+	ghPRForHold, err := c.ghClient.GetPullRequest(ctx, c.owner, c.repo, prState.PRNumber)
+	if err != nil {
 		c.log.Warn("handleMerging: could not fetch PR to check draft/review hold, proceeding (fail-open)",
 			"pr", prState.PRNumber, "error", err)
-	} else if ghPR.Draft {
+	} else if ghPRForHold.Draft {
 		c.log.Info("handleMerging: PR is a draft — holding merge until marked ready for review",
 			"pr", prState.PRNumber)
 		return nil
 	}
-	if c.hasChangesRequested(ctx, prState) {
+	// GH-5266: pass the freshly-fetched ghPRForHold (nil on a fail-open fetch
+	// error) through so hasChangesRequested can anchor its review-hold cutoff
+	// on the PR's own GitHub creation time rather than prState.CreatedAt.
+	if c.hasChangesRequested(ctx, prState, ghPRForHold) {
 		c.log.Info("handleMerging: PR has an outstanding changes-requested review — holding merge until re-reviewed or dismissed",
 			"pr", prState.PRNumber)
 		return nil
@@ -4853,7 +4891,7 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 		"method", c.config.MergeMethod,
 	)
 
-	err := c.autoMerger.MergePR(ctx, prState)
+	err = c.autoMerger.MergePR(ctx, prState)
 	if err != nil {
 		c.log.Error("handleMerging: merge failed",
 			"pr", prState.PRNumber,
@@ -8761,7 +8799,12 @@ func (c *Controller) processAllPRs(ctx context.Context) {
 			// Only check PRs that haven't already been transitioned to review_requested.
 			if pr.Stage != StageReviewRequested && pr.Stage != StageFailed &&
 				c.config.ReviewFeedback != nil && c.config.ReviewFeedback.Enabled {
-				if c.hasChangesRequested(ctx, pr) {
+				// GH-5266: ghPR is the same live fetch used above for
+				// checkExternalMergeOrClose/reAdoptHeldRebasePR — reuse it so the
+				// review-hold cutoff anchors on the PR's own GitHub creation time,
+				// which stays correct across a reconciler re-adoption (unlike
+				// pr.CreatedAt, which the reconciler resets to time.Now()).
+				if c.hasChangesRequested(ctx, pr, ghPR) {
 					c.log.Info("detected changes_requested review in polling mode",
 						"pr", pr.PRNumber,
 						"stage", pr.Stage,

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6768,7 +6768,7 @@ func TestController_HandleReviewRequested_IgnoresSelfReview(t *testing.T) {
 	c.activePRs[42].CreatedAt = time.Date(2026, 3, 5, 9, 0, 0, 0, time.UTC)
 	c.mu.Unlock()
 
-	result := c.hasChangesRequested(context.Background(), prState)
+	result := c.hasChangesRequested(context.Background(), prState, nil)
 	if result {
 		t.Error("hasChangesRequested should return false for bot-only reviews")
 	}
@@ -6845,7 +6845,7 @@ func TestController_HasChangesRequested_FilterByTime(t *testing.T) {
 	c.mu.Unlock()
 
 	prState, _ := c.GetPRState(42)
-	result := c.hasChangesRequested(context.Background(), prState)
+	result := c.hasChangesRequested(context.Background(), prState, nil)
 	if result {
 		t.Error("hasChangesRequested should return false for reviews submitted before PR creation")
 	}

--- a/internal/autopilot/gh5266_test.go
+++ b/internal/autopilot/gh5266_test.go
@@ -1,0 +1,287 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestHasChangesRequested_ReAdoptionCutoff_TableDriven is GH-5266 (N1 from the
+// PR#5264 review): hasChangesRequested used to filter reviews against
+// prState.CreatedAt alone. Both PR registration paths — OnPRCreated (fresh
+// registration) and the reconciler's orphan-PR sweep (re-adoption after a
+// daemon restart or a missed executor callback) — set CreatedAt to
+// time.Now(), so a standing CHANGES_REQUESTED review submitted before the
+// restart looked "older than tracking" and the hold silently vanished the
+// moment the PR was re-adopted. The fix anchors the cutoff on the PR's own
+// GitHub creation time (ghPR.CreatedAt) instead, which survives restarts.
+func TestHasChangesRequested_ReAdoptionCutoff_TableDriven(t *testing.T) {
+	tests := []struct {
+		name           string
+		prCreatedAt    string // the PR's real, durable creation time on GitHub
+		reviewAt       string // when the CHANGES_REQUESTED review was submitted
+		freshPRState   bool   // simulate re-adoption: prState.CreatedAt = time.Now()
+		ghPRFetchFails bool   // caller's GetPullRequest failed, so ghPR is nil
+		wantHeld       bool
+	}{
+		{
+			name:         "re-adoption: standing review predates fresh prState.CreatedAt but postdates real PR creation — still held",
+			prCreatedAt:  "2026-08-01T00:00:00Z",
+			reviewAt:     "2026-08-15T00:00:00Z",
+			freshPRState: true,
+			wantHeld:     true,
+		},
+		{
+			name:         "no re-adoption: fresh registration behaves as before — review after creation holds",
+			prCreatedAt:  "2026-08-29T00:00:00Z",
+			reviewAt:     "2026-08-29T12:00:00Z",
+			freshPRState: false,
+			wantHeld:     true,
+		},
+		{
+			name:         "no-permanent-park preserved: review predates the PR's own creation (cross-linked/moved review edge) — not held",
+			prCreatedAt:  "2026-08-20T00:00:00Z",
+			reviewAt:     "2026-08-01T00:00:00Z",
+			freshPRState: true,
+			wantHeld:     false,
+		},
+		{
+			name:           "fail-open fallback: ghPR fetch failed (nil) — falls back to prState.CreatedAt, review after it holds",
+			prCreatedAt:    "2026-08-01T00:00:00Z",
+			reviewAt:       "2026-08-29T12:00:00Z",
+			freshPRState:   false,
+			ghPRFetchFails: true,
+			wantHeld:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/owner/repo/pulls/42/reviews":
+					resp := []*github.PullRequestReview{
+						{ID: 1, User: github.User{Login: "reviewer"}, State: github.ReviewStateChangesRequested, SubmittedAt: tt.reviewAt},
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{
+				PRNumber:  42,
+				CreatedAt: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), // stale value; only freshPRState below matters
+			}
+			if tt.freshPRState {
+				// Simulate what the reconciler's re-adoption (or a fresh
+				// OnPRCreated registration) actually does: stamp CreatedAt to
+				// "now", long after the real GitHub PR creation date.
+				prState.CreatedAt = time.Now()
+			} else {
+				parsed, err := time.Parse(time.RFC3339, tt.prCreatedAt)
+				if err != nil {
+					t.Fatalf("failed to parse prCreatedAt fixture: %v", err)
+				}
+				prState.CreatedAt = parsed
+			}
+
+			var ghPR *github.PullRequest
+			if !tt.ghPRFetchFails {
+				ghPR = &github.PullRequest{Number: 42, CreatedAt: tt.prCreatedAt}
+			}
+
+			got := c.hasChangesRequested(context.Background(), prState, ghPR)
+			if got != tt.wantHeld {
+				t.Errorf("hasChangesRequested() = %v, want %v", got, tt.wantHeld)
+			}
+		})
+	}
+}
+
+// TestHasChangesRequested_CommentedDoesNotSupersede is GH-5266 (N2 from the
+// PR#5264 review): the per-user latest-review map used to overwrite with
+// whatever review came last chronologically, so a COMMENTED review from the
+// same reviewer after their CHANGES_REQUESTED silently cleared the hold.
+// GitHub's own review model does not treat COMMENTED as superseding a change
+// request — only a fresh APPROVED or an explicit DISMISSED does.
+func TestHasChangesRequested_CommentedDoesNotSupersede(t *testing.T) {
+	baseTime := time.Date(2026, 8, 29, 0, 0, 0, 0, time.UTC)
+	prCreatedAt := baseTime.Add(-24 * time.Hour).Format(time.RFC3339)
+
+	tests := []struct {
+		name     string
+		reviews  []*github.PullRequestReview
+		wantHeld bool
+	}{
+		{
+			name: "CHANGES_REQUESTED then COMMENTED (same user) — still held",
+			reviews: []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "reviewer"}, State: github.ReviewStateChangesRequested, SubmittedAt: baseTime.Add(1 * time.Hour).Format(time.RFC3339)},
+				{ID: 2, User: github.User{Login: "reviewer"}, State: github.ReviewStateCommented, SubmittedAt: baseTime.Add(2 * time.Hour).Format(time.RFC3339)},
+			},
+			wantHeld: true,
+		},
+		{
+			name: "CHANGES_REQUESTED, COMMENTED, then APPROVE (same user) — unparked",
+			reviews: []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "reviewer"}, State: github.ReviewStateChangesRequested, SubmittedAt: baseTime.Add(1 * time.Hour).Format(time.RFC3339)},
+				{ID: 2, User: github.User{Login: "reviewer"}, State: github.ReviewStateCommented, SubmittedAt: baseTime.Add(2 * time.Hour).Format(time.RFC3339)},
+				{ID: 3, User: github.User{Login: "reviewer"}, State: github.ReviewStateApproved, SubmittedAt: baseTime.Add(3 * time.Hour).Format(time.RFC3339)},
+			},
+			wantHeld: false,
+		},
+		{
+			name: "CHANGES_REQUESTED, COMMENTED, then DISMISSED (same user) — unparked",
+			reviews: []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "reviewer"}, State: github.ReviewStateChangesRequested, SubmittedAt: baseTime.Add(1 * time.Hour).Format(time.RFC3339)},
+				{ID: 2, User: github.User{Login: "reviewer"}, State: github.ReviewStateCommented, SubmittedAt: baseTime.Add(2 * time.Hour).Format(time.RFC3339)},
+				{ID: 3, User: github.User{Login: "reviewer"}, State: github.ReviewStateDismissed, SubmittedAt: baseTime.Add(3 * time.Hour).Format(time.RFC3339)},
+			},
+			wantHeld: false,
+		},
+		{
+			name: "COMMENTED only, no prior CHANGES_REQUESTED — never held",
+			reviews: []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "reviewer"}, State: github.ReviewStateCommented, SubmittedAt: baseTime.Add(1 * time.Hour).Format(time.RFC3339)},
+			},
+			wantHeld: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/owner/repo/pulls/42/reviews":
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(tt.reviews)
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{PRNumber: 42, CreatedAt: baseTime.Add(-48 * time.Hour)}
+			ghPR := &github.PullRequest{Number: 42, CreatedAt: prCreatedAt}
+
+			got := c.hasChangesRequested(context.Background(), prState, ghPR)
+			if got != tt.wantHeld {
+				t.Errorf("hasChangesRequested() = %v, want %v", got, tt.wantHeld)
+			}
+		})
+	}
+}
+
+// TestHandleMerging_ReAdoptedPR_StandingChangesRequestedHoldsMerge is the
+// end-to-end counterpart to TestHasChangesRequested_ReAdoptionCutoff_TableDriven:
+// it reproduces the exact GH-5266 scenario through ProcessPR/handleMerging —
+// a PR that already has an outstanding CHANGES_REQUESTED review gets
+// re-adopted with a fresh PRState (as the reconciler's orphan-PR sweep does
+// after a daemon restart, or a fresh OnPRCreated registration would), and the
+// merge must stay held rather than landing over the reviewer's objection.
+func TestHandleMerging_ReAdoptedPR_StandingChangesRequestedHoldsMerge(t *testing.T) {
+	var mergeAttempted bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/5266" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:    5266,
+				Head:      github.PRRef{SHA: "sha5266"},
+				Base:      github.PRRef{Ref: "main"},
+				Draft:     false,
+				CreatedAt: "2026-08-01T00:00:00Z", // real, durable PR creation time
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/5266/reviews":
+			// Standing review, submitted well before the (simulated) restart
+			// but after the PR's real creation time.
+			resp := []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "reviewer"}, State: github.ReviewStateChangesRequested, SubmittedAt: "2026-08-15T00:00:00Z"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/commits/sha5266/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/5266/merge" && r.Method == http.MethodPut:
+			mergeAttempted = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoMerge = true
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	c.activePRs[5266] = &PRState{
+		PRNumber:     5266,
+		PRURL:        "https://github.com/owner/repo/pull/5266",
+		IssueNumber:  70,
+		BranchName:   "pilot/GH-70",
+		HeadSHA:      "sha5266",
+		Stage:        StageMerging,
+		TargetBranch: "main",
+		// Re-adoption/restart shape: CreatedAt stamped to "now", long after
+		// both the PR's real creation and the standing review above.
+		CreatedAt: time.Now(),
+	}
+	c.mu.Unlock()
+
+	if err := c.ProcessPR(context.Background(), 5266, nil); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	if mergeAttempted {
+		t.Error("merge API must not be called — a standing CHANGES_REQUESTED review predates the re-adoption but postdates the PR's real creation")
+	}
+	pr, ok := c.GetPRState(5266)
+	if !ok {
+		t.Fatal("PR should still be tracked")
+	}
+	if pr.Stage != StageMerging || pr.MergeAttempts != 0 {
+		t.Errorf("stage=%s attempts=%d, want stage=%s attempts=0 (held, not failed)", pr.Stage, pr.MergeAttempts, StageMerging)
+	}
+	if c.GetPRFailures(5266) != 0 {
+		t.Errorf("PR failure count = %d, want 0 (a hold must not feed the per-PR circuit breaker)", c.GetPRFailures(5266))
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5266.

Closes #5266

## Changes

GitHub Issue GH-5266: fix(autopilot): review-merge hold is blind after re-adoption and cleared by COMMENTED reviews — harden the CHANGES_REQUESTED backstop

## Problem

Follow-up from the PR#5264 post-merge review (notes N1/N2 — both pre-existing in the reused hasChangesRequested logic in internal/autopilot/controller.go, now load-bearing for the merge hold):

1. **Re-adoption blinds the review hold.** hasChangesRequested ignores reviews submitted before prState.CreatedAt, and both PR registration paths (fresh registration and reconciler re-adoption) set CreatedAt to now. After a daemon restart or orphan re-adoption, a standing CHANGES_REQUESTED review older than the adoption timestamp is invisible — the PR auto-merges over the reviewer's objection. This is exactly the race/revision-spawn-failure scenario #5263 was filed to close; the protection currently holds only within a single tracked lifetime.
2. **COMMENTED supersedes CHANGES_REQUESTED.** The latest-review-per-user map overwrites with whatever review is chronologically last, so a later COMMENTED review from the same reviewer clears the hold. GitHub's own model does not treat COMMENTED as superseding a change request. Fail-open.

## Fix shape

- For (1): on re-adoption, derive the review-hold cutoff from something durable (e.g. the PR's own creation time from the GitHub API, or the head commit's timestamp) instead of prState.CreatedAt=now — the CreatedAt filter's original purpose (avoid permanently parking on ancient stale reviews) is preserved by cutting off at PR creation, not at adoption.
- For (2): in the per-user latest map, let only APPROVE or an explicit dismissal (state DISMISSED) supersede a CHANGES_REQUESTED; COMMENTED keeps the standing request.

## Acceptance

- Table-driven tests: (a) PR with CHANGES_REQUESTED → daemon restart/re-adoption simulated (fresh prState) → merge still held; (b) CHANGES_REQUESTED then COMMENTED (same user) → held; then APPROVE → unparked; then a DISMISSED case → unparked.
- The no-permanent-park property is preserved: a PR whose only change-request predates the PR's own creation (cross-linked/moved review edge) or is dismissed does not park.
- Genuine-failure accounting untouched.

## Refs

- PR#5264 review notes N1/N2 · #5263 (parent) · the revision-flow interception (ReviewFeedback poller) remains the primary path; this hardens the backstop.