### PR TITLE
GH-5267: fix(helm+docs): phantom --set examples and fictional existingSecret flow remain; add helm lint/template CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,66 @@ jobs:
           # instead of on every PR's hot path.
           verify: false
 
+  # GH-5267: the Helm chart had no CI coverage at all — a phantom top-level
+  # `autopilot:` block (GH-5251) and doc/values drift (PR#5265, GH-5267)
+  # both landed unnoticed. Lints + renders the chart, and greps the render
+  # for the exact regression class GH-5251 fixed: a top-level `autopilot:`
+  # key inside the generated config.yaml, which silently binds to nothing.
+  helm-chart:
+    name: Helm Lint + Template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check whether the chart or its docs page changed
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+          if git diff --name-only "$base" "${{ github.sha }}" -- deploy/helm/ docs/content/deployment/docker-helm.mdx | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Helm
+        if: steps.changed.outputs.changed == 'true'
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: helm lint
+        if: steps.changed.outputs.changed == 'true'
+        run: helm lint deploy/helm/pilot
+
+      - name: helm template (default values)
+        if: steps.changed.outputs.changed == 'true'
+        run: helm template pilot deploy/helm/pilot --show-only templates/configmap.yaml > /tmp/pilot-configmap.yaml
+
+      - name: Fail if a top-level autopilot key renders into config.yaml (GH-5251)
+        if: steps.changed.outputs.changed == 'true'
+        run: |
+          if grep -qE '^\s{4}autopilot:' /tmp/pilot-configmap.yaml; then
+            echo "::error::rendered config.yaml contains a top-level 'autopilot:' key — it binds to nothing (see GH-5251); only orchestrator.autopilot binds"
+            exit 1
+          fi
+
+      - name: helm template (existingSecret + adapters.github.repo overrides)
+        if: steps.changed.outputs.changed == 'true'
+        run: |
+          helm template pilot deploy/helm/pilot \
+            --set existingSecret=pilot-secrets \
+            --set adapters.github.repo=your-org/your-repo > /tmp/pilot-rendered-overrides.yaml
+          if grep -qE '^kind: Secret$' /tmp/pilot-rendered-overrides.yaml; then
+            echo "::error::existingSecret was set but the chart still rendered its own Secret"
+            exit 1
+          fi
+
   # GH-5087: schema verification for .golangci.yml, split out of the
   # per-PR lint job (see the `verify: false` note above). Only runs when
   # .golangci.yml itself changes, so the remote schema-host dependency

--- a/deploy/helm/pilot/templates/_helpers.tpl
+++ b/deploy/helm/pilot/templates/_helpers.tpl
@@ -62,6 +62,14 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Return the name of the Secret to mount — an externally-managed Secret
+when .Values.existingSecret is set, otherwise the chart-managed one.
+*/}}
+{{- define "pilot.secretName" -}}
+{{- .Values.existingSecret | default (include "pilot.fullname" .) }}
+{{- end }}
+
+{{/*
 Return the image tag — defaults to Chart.appVersion.
 */}}
 {{- define "pilot.imageTag" -}}

--- a/deploy/helm/pilot/templates/configmap.yaml
+++ b/deploy/helm/pilot/templates/configmap.yaml
@@ -16,6 +16,9 @@ data:
     adapters:
       github:
         enabled: {{ .Values.adapters.github.enabled }}
+        {{- if .Values.adapters.github.repo }}
+        repo: {{ .Values.adapters.github.repo | quote }}
+        {{- end }}
       telegram:
         enabled: {{ .Values.adapters.telegram.enabled }}
       slack:
@@ -23,14 +26,18 @@ data:
       linear:
         enabled: {{ .Values.adapters.linear.enabled }}
 
-    # Autopilot mode is NOT set here — a top-level `autopilot:` block only
-    # binds to config.Orchestrator.Autopilot.Environment via the deprecated
-    # top-level lift (internal/config/config.go liftTopLevelAutopilot), and
-    # that field is unconditionally overridden by the `--autopilot=<mode>`
-    # start arg below (a hidden alias for `--env`, GH-5262) — so rendering it
-    # here would only trigger a DEPRECATED config log with zero effect.
-    # .Values.autopilot.mode is applied via the container's start args
-    # instead (see templates/_helpers.tpl pilot.startArgs).
+    # Autopilot mode is NOT set here — a top-level `autopilot:` block gets
+    # lifted wholesale onto config.Orchestrator.Autopilot (internal/config/
+    # config.go liftTopLevelAutopilot decodes the raw block's keys straight
+    # onto that struct), but the struct's field is yaml-tagged `environment`,
+    # not `mode` — so a `mode:` key (the shape this chart's own
+    # .Values.autopilot.mode implies) would decode to nothing even after
+    # the lift. And a correctly-named `environment:` key would still be
+    # moot: it's unconditionally overridden by the `--autopilot=<mode>`
+    # start arg below (a hidden alias for `--env`, GH-5262). So rendering
+    # anything here would only trigger a DEPRECATED config log with zero
+    # effect. .Values.autopilot.mode is applied via the container's start
+    # args instead (see templates/_helpers.tpl pilot.startArgs).
 
     storage:
       # SQLite database lives on the PVC so it survives pod restarts

--- a/deploy/helm/pilot/templates/deployment.yaml
+++ b/deploy/helm/pilot/templates/deployment.yaml
@@ -24,7 +24,9 @@ spec:
         {{- end }}
         # Force pod restart when ConfigMap or Secret changes
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         {{- include "pilot.selectorLabels" . | nindent 8 }}
     spec:
@@ -47,24 +49,24 @@ spec:
             - name: ANTHROPIC_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "pilot.fullname" . }}
+                  name: {{ include "pilot.secretName" . }}
                   key: anthropic-api-key
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "pilot.fullname" . }}
+                  name: {{ include "pilot.secretName" . }}
                   key: github-token
             {{- if .Values.adapters.slack.enabled }}
             - name: SLACK_BOT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "pilot.fullname" . }}
+                  name: {{ include "pilot.secretName" . }}
                   key: slack-bot-token
                   optional: true
             - name: SLACK_APP_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "pilot.fullname" . }}
+                  name: {{ include "pilot.secretName" . }}
                   key: slack-app-token
                   optional: true
             {{- end }}
@@ -72,7 +74,7 @@ spec:
             - name: TELEGRAM_BOT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "pilot.fullname" . }}
+                  name: {{ include "pilot.secretName" . }}
                   key: telegram-bot-token
                   optional: true
             {{- end }}
@@ -80,7 +82,7 @@ spec:
             - name: LINEAR_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "pilot.fullname" . }}
+                  name: {{ include "pilot.secretName" . }}
                   key: linear-api-key
                   optional: true
             {{- end }}

--- a/deploy/helm/pilot/templates/secret.yaml
+++ b/deploy/helm/pilot/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,3 +16,4 @@ stringData:
   slack-app-token: {{ .Values.secrets.slackAppToken | quote }}
   telegram-bot-token: {{ .Values.secrets.telegramBotToken | quote }}
   linear-api-key: {{ .Values.secrets.linearApiKey | quote }}
+{{- end }}

--- a/deploy/helm/pilot/values.yaml
+++ b/deploy/helm/pilot/values.yaml
@@ -51,6 +51,9 @@ gateway:
 adapters:
   github:
     enabled: true
+    # Default "owner/repo" pilot polls for issues labeled `pilot`.
+    # Leave empty to configure it another way (e.g. a custom configmap).
+    repo: ""
   telegram:
     enabled: false
   slack:
@@ -62,8 +65,16 @@ autopilot:
   # dev | stage | prod
   mode: "stage"
 
+# Name of a pre-existing Kubernetes Secret to use instead of the one this
+# chart creates from `secrets` below. Must define the same keys as
+# templates/secret.yaml: anthropic-api-key, github-token, slack-bot-token,
+# slack-app-token, telegram-bot-token, linear-api-key. Leave empty to have
+# the chart create and manage the Secret itself.
+existingSecret: ""
+
 # API tokens and secrets — provide via --set or an external secret manager.
 # Leave empty strings here; never commit real tokens.
+# Ignored when existingSecret is set.
 secrets:
   # Required
   anthropicApiKey: ""

--- a/docs/content/deployment/docker-helm.mdx
+++ b/docs/content/deployment/docker-helm.mdx
@@ -224,19 +224,20 @@ cd pilot
 helm install pilot ./helm/pilot \
   --set secrets.githubToken="ghp_..." \
   --set secrets.anthropicApiKey="sk-ant-..." \
-  --set config.adapters.github.repo="your-org/your-repo"
+  --set adapters.github.repo="your-org/your-repo"
 ```
 
 ```bash
-# Create secrets separately (recommended)
+# Create a secret with the keys the chart expects (see templates/secret.yaml)
 kubectl create secret generic pilot-secrets \
   --from-literal=github-token="ghp_..." \
   --from-literal=anthropic-api-key="sk-ant-..."
 
-# Install referencing existing secret
+# Install referencing the existing secret instead of chart-managed secrets —
+# the chart skips creating its own Secret when existingSecret is set
 helm install pilot ./helm/pilot \
   --set existingSecret=pilot-secrets \
-  --set config.adapters.github.repo="your-org/your-repo"
+  --set adapters.github.repo="your-org/your-repo"
 ```
 
 ```bash
@@ -283,6 +284,7 @@ gateway:
 adapters:
   github:
     enabled: true
+    repo: ""                # "owner/repo" pilot polls for `pilot`-labeled issues
   telegram:
     enabled: false
   slack:
@@ -296,7 +298,13 @@ adapters:
 autopilot:
   mode: "stage"
 
-# API tokens and secrets — provide via --set or an external secret manager
+# Name of a pre-existing Secret to use instead of the one this chart
+# creates. Must define the same keys as templates/secret.yaml. Leave
+# empty to have the chart create and manage the Secret itself.
+existingSecret: ""
+
+# API tokens and secrets — provide via --set or an external secret manager.
+# Ignored when existingSecret is set.
 secrets:
   anthropicApiKey: ""
   githubToken: ""


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5267.

Closes #5267

## Changes

GitHub Issue GH-5267: fix(helm+docs): phantom --set examples and fictional existingSecret flow remain; add helm lint/template CI

## Problem

Residual drifts from the PR#5265 post-merge review (notes N1-N3 + finding 5) — same class the parent fixed, adjacent sections:

1. Install tabs in `docs/content/deployment/docker-helm.mdx` (~227, ~239) still use the nonexistent `config.` prefix in `--set` examples (`--set config.adapters.github.repo=...`) — silent no-ops.
2. `--set existingSecret=pilot-secrets` appears at ~238 and ~798, but no `existingSecret` key exists anywhere in the chart — the documented "recommended" secrets flow is fictional. Either implement the key (standard helm pattern: honor an existing secret name in deployment.yaml/secret.yaml) or rewrite the docs to the chart-managed secret; implementing is the conventional choice, but keep it small.
3. The new comment in `deploy/helm/pilot/templates/configmap.yaml` says the old top-level block "binds to config.Orchestrator.Autopilot.Environment via the lift" — imprecise: the lift moves the whole block, and the old `mode:` key inside binds to nothing (the field's yaml tag is `environment`). Fix the wording.
4. **No CI validates the chart**: no workflow runs `helm lint` or `helm template`. Add a small job (helm lint + template with default values + grep the render for a top-level autopilot key) so this drift class fails loudly next time.

## Acceptance

- Every `--set` example in docker-helm.mdx round-trips against values.yaml (keys exist, paths real).
- The secrets flow documented is one the chart actually implements.
- Chart comment wording accurate.
- CI job renders + lints the chart on PRs touching `deploy/helm/**` or the docker-helm docs page.

## Refs

- PR#5265 review (notes N1-N3, finding 5) · #5262 (parent)