### PR TITLE
GH-5268: fix(briefs): receipts digest — record SentAt = query End to close the sub-second (End, SentAt) skip window

### DIFF
--- a/internal/briefs/delivery_test.go
+++ b/internal/briefs/delivery_test.go
@@ -36,6 +36,11 @@ func (m *mockSlackClient) PostMessage(ctx context.Context, msg *slack.Message) (
 type mockTelegramSender struct {
 	calls         []telegramSendCall
 	failParseMode string // parse mode for which the send fails with a parse-entities error
+	// onSend, if set, runs synchronously inside SendBriefMessage before it
+	// returns — lets tests simulate state changes (e.g. an execution
+	// completing) that happen during delivery latency, after the caller's
+	// executions query already ran (GH-5268).
+	onSend func()
 }
 
 type telegramSendCall struct {
@@ -46,6 +51,9 @@ type telegramSendCall struct {
 
 func (m *mockTelegramSender) SendBriefMessage(ctx context.Context, chatID, text, parseMode string) (*TelegramMessageResponse, error) {
 	m.calls = append(m.calls, telegramSendCall{chatID: chatID, text: text, parseMode: parseMode})
+	if m.onSend != nil {
+		m.onSend()
+	}
 	if parseMode == m.failParseMode {
 		return nil, errors.New("telegram API error: Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 1090 (code: 400)")
 	}

--- a/internal/briefs/receipts.go
+++ b/internal/briefs/receipts.go
@@ -195,7 +195,14 @@ func (s *ReceiptsScheduler) runDigest(ctx context.Context) error {
 
 	if delivered && s.store != nil {
 		record := &memory.BriefRecord{
-			SentAt:    time.Now(),
+			// SentAt is stamped with the same `now` used as the query's End
+			// bound (not a fresh time.Now()) so consecutive digest windows
+			// tile exactly as [prev.End, now) with no gap. Stamping with a
+			// later time.Now() here would leave a sub-second (End, SentAt)
+			// window — anything completing during Telegram delivery latency
+			// would fall after this digest's End and before the next
+			// digest's start, and never get receipted (GH-5268).
+			SentAt:    now,
 			Channel:   receiptsRepresentativeChannel,
 			BriefType: receiptsBriefType,
 		}

--- a/internal/briefs/receipts_test.go
+++ b/internal/briefs/receipts_test.go
@@ -396,3 +396,99 @@ func TestReceiptsSchedulerRunNow_InFlightRunAppearsInNextDigest(t *testing.T) {
 		t.Errorf("digest 2 must NOT re-mention already-receipted #5300, got: %s", sender.calls[1].text)
 	}
 }
+
+// TestReceiptsSchedulerRunNow_SentAtMatchesQueryEnd is GH-5268, a sibling of
+// InFlightRunAppearsInNextDigest: a run whose completed_at lands in the
+// sub-second gap between the executions query's End bound and the (formerly
+// later) post-delivery time.Now() used to stamp SentAt must still appear in
+// the next digest. The mock sender's onSend hook simulates that gap
+// directly — it inserts the completing execution mid-SendBriefMessage, i.e.
+// strictly after runDigest has already captured `now`/End and run the
+// executions query, but strictly before the (fixed) code stamps
+// brief_history.SentAt. Before the fix, SentAt was stamped with a fresh
+// time.Now() taken after delivery finished, later than this execution's
+// completed_at — putting it in the dead (End, SentAt) window that neither
+// digest 1 nor digest 2 would ever cover.
+func TestReceiptsSchedulerRunNow_SentAtMatchesQueryEnd(t *testing.T) {
+	store, cleanup := setupSchedulerTestStore(t)
+	defer cleanup()
+
+	// exec-seed: completed well before digest 1 fires — guarantees digest 1
+	// actually sends (a digest with zero rows skips delivery entirely, and
+	// then there'd be nothing to stamp a SentAt from).
+	seedCompleted := time.Now().Add(-2 * time.Hour)
+	if err := store.SaveExecution(&memory.Execution{
+		ID:                "exec-seed",
+		TaskID:            "GH-5400",
+		ProjectPath:       "/tmp/proj",
+		Status:            "completed",
+		CreatedAt:         seedCompleted,
+		CompletedAt:       &seedCompleted,
+		EstimatedCostUSD:  0.50,
+		TaskSourceAdapter: "github",
+	}); err != nil {
+		t.Fatalf("SaveExecution (seed): %v", err)
+	}
+
+	sender := &mockTelegramSender{}
+	sender.onSend = func() {
+		// Fires synchronously inside digest 1's SendBriefMessage call —
+		// after the executions query already ran (so exec-gap can't appear
+		// in digest 1) but before runDigest stamps SentAt after delivery.
+		completedDuringSend := time.Now()
+		if err := store.SaveExecution(&memory.Execution{
+			ID:                "exec-gap",
+			TaskID:            "GH-5401",
+			ProjectPath:       "/tmp/proj",
+			Status:            "completed",
+			CreatedAt:         completedDuringSend.Add(-time.Minute),
+			CompletedAt:       &completedDuringSend,
+			EstimatedCostUSD:  0.75,
+			TaskSourceAdapter: "github",
+		}); err != nil {
+			t.Fatalf("SaveExecution (gap): %v", err)
+		}
+	}
+
+	config := &ReceiptsConfig{
+		Enabled:  true,
+		Schedule: "0 18 * * *",
+		Timezone: "UTC",
+		Channels: []ChannelConfig{{Type: "telegram", Channel: "@test"}},
+	}
+	scheduler := NewReceiptsScheduler(store, sender, config, nil)
+
+	// Digest 1: only exec-seed exists at query time; exec-gap is inserted by
+	// the onSend hook mid-delivery.
+	if err := scheduler.RunNow(context.Background()); err != nil {
+		t.Fatalf("RunNow (digest 1) failed: %v", err)
+	}
+	if len(sender.calls) != 1 {
+		t.Fatalf("expected 1 send after digest 1, got %d", len(sender.calls))
+	}
+	if !strings.Contains(sender.calls[0].text, "#5400") {
+		t.Errorf("digest 1 should mention #5400, got: %s", sender.calls[0].text)
+	}
+	if strings.Contains(sender.calls[0].text, "#5401") {
+		t.Errorf("digest 1 must NOT mention #5401 (didn't exist at query time), got: %s", sender.calls[0].text)
+	}
+
+	sender.onSend = nil
+
+	// Digest 2 must still find exec-gap: SentAt was recorded as digest 1's
+	// query End (not a later post-delivery time.Now()), so digest 2's
+	// window starts exactly where digest 1's query left off — no (End,
+	// SentAt) gap for exec-gap's completed_at to fall into.
+	if err := scheduler.RunNow(context.Background()); err != nil {
+		t.Fatalf("RunNow (digest 2) failed: %v", err)
+	}
+	if len(sender.calls) != 2 {
+		t.Fatalf("expected 2 sends after digest 2, got %d", len(sender.calls))
+	}
+	if !strings.Contains(sender.calls[1].text, "#5401") {
+		t.Errorf("digest 2 should mention #5401 (completed during digest 1's delivery), got: %s", sender.calls[1].text)
+	}
+	if strings.Contains(sender.calls[1].text, "#5400") {
+		t.Errorf("digest 2 must NOT re-mention already-receipted #5400, got: %s", sender.calls[1].text)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5268.

Closes #5268

## Changes

GitHub Issue GH-5268: fix(briefs): receipts digest — record SentAt = query End to close the sub-second (End, SentAt) skip window

## Problem

Follow-up from PR#5258 re-review (note-level, non-blocking): in `ReceiptsScheduler.runDigest` (`internal/briefs/receipts.go`), the executions query uses `End: now` captured at the top of the function, but after delivery the brief_history record is stamped with a fresh `time.Now()`:

```go
record := &memory.BriefRecord{
    SentAt:    time.Now(),   // later than the query's End by delivery latency
    ...
}
```

The next digest windows `[lastRecord.SentAt, now)`. A run whose `completed_at` lands in the gap `(End, SentAt)` — i.e. completes during the ~100–500ms of Telegram delivery — is after this digest's window and before the next one's start, so it is never receipted. Breaks the exactly-once guarantee established by GH-5261, just at sub-second scale.

## Fix

One line: stamp the record with the same `now` used as the query `End` (`SentAt: now`), so consecutive windows tile exactly: `[prev.End, now)`.

## Acceptance

1. `runDigest` records `SentAt` equal to the query's `End` bound (same `time.Time` value).
2. Test: an execution with `completed_at` exactly between the first digest's query `End` and its (formerly later) send-completion time appears in the second digest — extend `TestReceiptsSchedulerRunNow_InFlightRunAppearsInNextDigest` or add a sibling.
3. `make lint && make test` green; no other behavior change.

## Refs

- PR#5258 re-review note: https://github.com/qf-studio/pilot/pull/5258#issuecomment-5469607710
- GH-5261 (the window redesign this completes)