### PR TITLE
GH-5273: fix(dispatch): orphaned claim with no execution row wedges a task permanently — reap row-less claims past a grace window

### DIFF
--- a/.agent/tasks/gh-5273.md
+++ b/.agent/tasks/gh-5273.md
@@ -1,0 +1,45 @@
+# GH-5273
+
+**Created:** 2026-09-01
+
+## Problem
+
+GitHub Issue GH-5273: fix(dispatch): orphaned claim with no execution row wedges a task permanently — reap row-less claims past a grace window
+
+## Context
+
+Live incident 2026-08-31→09-01 (founder box, task GH-249 on the pilot-console project): a dispatch claim row was created at generation 0 and its owner died before writing any execution row. Result — a permanent, self-sustaining wedge:
+
+- Every subsequent poll: SDK poller dispatches → the dispatcher's claim insert collides with the dead generation-0 claim → "dispatch claim lost … dropping duplicate pickup" → pilot-in-progress label unwound → poller re-arms after backoff → repeat. 67 claim-lost drops over ~18 hours, one dashboard queue row per attempt.
+- No recovery mechanism could see it. Generation bump requires a terminal execution row — there was none, so retries could never claim generation+1. The stalled re-arm sweep (GH-5212 family) scans execution rows — there were none. The repick hard cap deliberately excludes claim-lost drops (the "repick storm" WARN), so the loop never terminated either.
+- Detection already exists — the dispatcher logs the WARN with a running claim_lost_drops counter (67 at recovery) — but nothing acts on it.
+
+Recovery was manual: exact-key DELETE of the orphaned claim row on the box DB, after verifying zero execution rows existed for the task. Post-delete the claim table is clean and dispatch proceeds.
+
+A secondary observation for the fix: the orphaned claim row carried the RESOLVED project path (the box's real repo path), while dispatcher logs report the canonical macOS-era shim path — canonicalization makes them collide as intended, but any tooling that queries claims by the logged path string will miss the row. Worth normalizing what gets STORED to the canonical key form.
+
+## Approach
+
+An orphaned claim (a claim row whose (task, generation) has no corresponding execution row after a grace window) is provably dead — the owner writes the execution row immediately after winning the claim, so a claim that stays row-less for minutes has a dead owner. Two candidate mechanisms, implementer's choice or both:
+
+1. Reaper leg on an existing periodic sweep (the stale-recovery tick is the natural home): delete claim rows older than a grace window (e.g. 10 minutes) that have no execution row for the same task and generation, with an INFO journal line naming the claim key and its age. This heals rows created by any past or future crash window.
+2. Adopt-on-conflict at the dispatcher: when a claim insert loses and the winning row's (task, generation) has no execution row and exceeds the grace age, take the claim over (delete + re-insert or update owner) instead of dropping the pickup. Heals faster but only when a new pickup arrives.
+
+The claim_lost_drops counter should feed an alert or at least the reaper's urgency — a counter crossing double digits for one task is exactly this wedge's signature.
+
+## Acceptance
+
+- An injected orphan claim (claim row present, no execution row, older than the grace window) is removed automatically and the task dispatches successfully on the next poll — end-to-end test at the dispatcher level.
+- A FRESH claim inside the grace window is never reaped (the legitimate claim-then-write race stays safe) — test pins the window boundary.
+- A claim whose (task, generation) HAS an execution row (running or terminal) is never touched by the reaper — existing semantics unchanged.
+- The reap emits a journal/log line with the claim key, generation, age, and claim_lost_drops count at reap time.
+- Repick/label-unwind behavior unchanged for all non-orphan drop reasons.
+
+## Refs
+
+- Incident evidence: box daemon log 2026-09-01 ~09:48Z ("repick storm: claim-lost/terminal drop recurring — not counted toward repick hard cap", claim_lost_drops=67) · recovery = exact-key claim DELETE after verifying zero execution rows.
+- Related: the dead-owner execution-row class and its stalled workaround (GH-4392) · stalled re-arm sweep (GH-5212) — both key on execution rows, which is why this variant was invisible to them.
+- Claim design: dedicated claims table keyed (task, project, generation), canonicalized path, retries claim generation+1 (GH-4319 decisions).
+
+## Acceptance Criteria
+

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -112,6 +112,15 @@ type DispatcherConfig struct {
 	// runs. Default: 5 minutes.
 	StaleRecoveryInterval time.Duration
 
+	// OrphanedClaimGraceWindow is how long an execution_claims row may sit
+	// with no matching executions row before it is reaped as orphaned
+	// (GH-5273). Must comfortably exceed the ordinary claim-then-write
+	// latency (ClaimExecution succeeding, then SaveExecution landing —
+	// normally microseconds) so a claim that is merely mid-write is never
+	// mistaken for one whose owner died before writing it. Default: 10
+	// minutes.
+	OrphanedClaimGraceWindow time.Duration
+
 	// BasePresenceHoldMaxCycles bounds how many consecutive claim-path
 	// held cycles (GH-5045/GH-5052: an explicit "Depends on: #N" ref still
 	// an open PR — directly, or via an issue whose attached PR is still
@@ -133,6 +142,7 @@ func DefaultDispatcherConfig() *DispatcherConfig {
 		StaleRunningThreshold:     30 * time.Minute,
 		StaleQueuedThreshold:      5 * time.Minute,
 		StaleRecoveryInterval:     5 * time.Minute,
+		OrphanedClaimGraceWindow:  10 * time.Minute,
 		BasePresenceHoldMaxCycles: 20,
 	}
 }
@@ -146,6 +156,9 @@ func (c *DispatcherConfig) resolveDefaults() {
 	}
 	if c.StaleRecoveryInterval == 0 {
 		c.StaleRecoveryInterval = 5 * time.Minute
+	}
+	if c.OrphanedClaimGraceWindow == 0 {
+		c.OrphanedClaimGraceWindow = 10 * time.Minute
 	}
 	if c.BasePresenceHoldMaxCycles == 0 {
 		c.BasePresenceHoldMaxCycles = 20
@@ -589,8 +602,47 @@ func (d *Dispatcher) Stop() {
 func (d *Dispatcher) recoverStaleTasks() int {
 	resetCount := d.recoverStaleRunningTasks()
 	resetCount += d.recoverStaleQueuedTasks()
+	d.reapOrphanedClaims()
 	d.log.Info("stale recovery complete, reset N tasks", slog.Int("count", resetCount))
 	return resetCount
+}
+
+// reapOrphanedClaims deletes execution_claims rows whose owner died before
+// ever writing the executions row Begin normally saves immediately after
+// winning the claim (GH-5273). Riding the existing stale-recovery tick
+// rather than a dedicated ticker mirrors wakeHeldWorkers' reasoning above: a
+// row-less claim is exceedingly rare (a crash landing in the exact window
+// between ClaimExecution and SaveExecution), so it does not need its own
+// cadence, and the two sweeps sharing one tick means an orphaned claim is
+// never wedged longer than one StaleRecoveryInterval past its grace window.
+//
+// A dispatch attempt for the same (task_id, project_path) that arrives
+// before this reaps the row keeps dropping as "dispatch claim lost" exactly
+// as it did during the incident this closes — the fix is the row's removal,
+// not a change to the drop path itself, so the next admission attempt after
+// this reaps it claims generation 0 fresh instead of colliding forever.
+func (d *Dispatcher) reapOrphanedClaims() {
+	orphans, err := d.store.ReapOrphanedClaims(d.config.OrphanedClaimGraceWindow)
+	if err != nil {
+		d.log.Warn("failed to reap orphaned execution claims", slog.Any("error", err))
+		return
+	}
+	for _, o := range orphans {
+		backoffKey := repickBackoffKey(o.ProjectPath, o.TaskID)
+		claimLostDrops, _, err := d.store.GetClaimLostDropCount(backoffKey)
+		if err != nil {
+			d.log.Warn("failed to read claim-lost drop count while logging reaped claim",
+				slog.String("task_id", o.TaskID), slog.Any("error", err))
+		}
+		d.log.Info("GH-5273: reaped orphaned execution claim — claim row had no execution row past the grace window, dispatch was permanently wedged colliding with it",
+			slog.String("task_id", o.TaskID),
+			slog.String("project", o.ProjectPath),
+			slog.Int("generation", o.Generation),
+			slog.String("execution_id", o.ExecutionID),
+			slog.Duration("age", o.Age),
+			slog.Int("claim_lost_drops", claimLostDrops),
+		)
+	}
 }
 
 // recoverStaleRunningTasks marks orphaned running tasks (crashed workers) as

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -6213,3 +6213,139 @@ func TestDispatcher_QueueDecomposedTask_ClaimLostDropsSilently(t *testing.T) {
 		t.Errorf("expected winning execution to belong to %q, got %q", parent.ID, exec.TaskID)
 	}
 }
+
+// TestDispatcher_ReapOrphanedClaims_UnwedgesDispatch is the dispatcher-level
+// acceptance test for GH-5273: a claim whose owner died before ever writing
+// the executions row (ExecutionLifecycle.Begin's ClaimExecution-then-
+// SaveExecution window) must not wedge dispatch forever. It uses a
+// deliberately tiny OrphanedClaimGraceWindow plus a short sleep instead of
+// backdating the claim's created_at directly — the SQL-level backdating
+// helper (backdateClaim) lives in internal/memory's test file and is
+// unexported, so it isn't reachable from this package; aging the claim in
+// real time sidesteps that boundary entirely.
+//
+// Claiming generation 0 again (not generation 1) after the reap is the part
+// that actually proves the row was removed rather than merely bypassed —
+// nextRetryGeneration's existing dangling-claim fallthrough (GH-4409) can
+// independently grant a fresh generation for a dead claim, so a naive
+// "dispatch eventually succeeds" assertion alone wouldn't isolate the
+// reaper's own effect from that pre-existing path.
+func TestDispatcher_ReapOrphanedClaims_UnwedgesDispatch(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	config := DefaultDispatcherConfig()
+	config.OrphanedClaimGraceWindow = 10 * time.Millisecond
+	dispatcher := NewDispatcher(store, runner, config)
+
+	var buf bytes.Buffer
+	dispatcher.log = slog.New(slog.NewTextHandler(&buf, nil))
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	ctx := context.Background()
+	task := &Task{
+		ID:          "GH-249",
+		Title:       "orphaned claim regression",
+		ProjectPath: "/tmp/pilot-console-test-project",
+	}
+
+	// Simulate the incident: a claim wins generation 0 but its owner dies
+	// before ever calling SaveExecution — no executions row is ever created.
+	claimed, err := store.ClaimExecution(task.ID, task.ProjectPath, 0, "exec-dead-owner")
+	if err != nil || !claimed {
+		t.Fatalf("expected to seed the orphan claim, claimed=%v err=%v", claimed, err)
+	}
+
+	// Let the claim age past the (deliberately tiny, for this test) grace
+	// window without needing to touch created_at directly.
+	time.Sleep(20 * time.Millisecond)
+
+	// Run the reaper — this is exactly what the periodic stale-recovery tick
+	// calls (recoverStaleTasks -> reapOrphanedClaims).
+	dispatcher.reapOrphanedClaims()
+
+	if !strings.Contains(buf.String(), "GH-5273") || !strings.Contains(buf.String(), "reaped orphaned execution claim") {
+		t.Errorf("expected an info log reporting the reaped claim, got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "task_id=GH-249") {
+		t.Errorf("expected the reap log to include the claim's task_id, got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "generation=0") {
+		t.Errorf("expected the reap log to include the claim's generation, got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "claim_lost_drops=") {
+		t.Errorf("expected the reap log to include the claim_lost_drops count, got: %s", buf.String())
+	}
+
+	// Dispatch must now succeed — the reap removed the row that was
+	// colliding with every retry.
+	execID, err := dispatcher.QueueTask(ctx, task)
+	if err != nil {
+		t.Fatalf("expected dispatch to succeed after the orphan was reaped, got error: %v", err)
+	}
+	if execID == "" {
+		t.Fatal("expected a non-empty execution ID after the orphan was reaped")
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if exec.TaskID != task.ID {
+		t.Errorf("expected task ID %s, got %s", task.ID, exec.TaskID)
+	}
+
+	gen, _, found, err := store.LatestClaimGeneration(task.ID, task.ProjectPath)
+	if err != nil {
+		t.Fatalf("LatestClaimGeneration failed: %v", err)
+	}
+	if !found || gen != 0 {
+		t.Errorf("expected the fresh dispatch to claim generation 0 (proving the orphan row was removed, not just bypassed via generation-bump), got gen=%d found=%v", gen, found)
+	}
+}
+
+// TestDispatcher_ReapOrphanedClaims_LeavesFreshClaimWedgedForDuplicatePickup
+// pins the other side of the same acceptance criteria at the dispatcher
+// level: a claim inside the grace window must survive the reap untouched,
+// so an in-flight (not-yet-crashed) owner's duplicate-pickup drop path is
+// unaffected by GH-5273's reaper.
+func TestDispatcher_ReapOrphanedClaims_LeavesFreshClaimWedgedForDuplicatePickup(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	config := DefaultDispatcherConfig()
+	config.OrphanedClaimGraceWindow = 10 * time.Minute
+	dispatcher := NewDispatcher(store, runner, config)
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	task := &Task{
+		ID:          "GH-250",
+		Title:       "fresh claim must not be reaped",
+		ProjectPath: "/tmp/pilot-console-test-project-fresh",
+	}
+
+	claimed, err := store.ClaimExecution(task.ID, task.ProjectPath, 0, "exec-fresh-owner")
+	if err != nil || !claimed {
+		t.Fatalf("expected to seed the fresh claim, claimed=%v err=%v", claimed, err)
+	}
+
+	dispatcher.reapOrphanedClaims()
+
+	gen, execID, found, err := store.LatestClaimGeneration(task.ID, task.ProjectPath)
+	if err != nil {
+		t.Fatalf("LatestClaimGeneration failed: %v", err)
+	}
+	if !found || gen != 0 || execID != "exec-fresh-owner" {
+		t.Fatalf("expected the fresh claim to survive the reap untouched, got gen=%d execID=%q found=%v", gen, execID, found)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -3437,6 +3437,102 @@ func (s *Store) LatestClaimGeneration(taskID, projectPath string) (generation in
 	return generation, executionID, true, nil
 }
 
+// OrphanedClaim describes one execution_claims row reaped by
+// ReapOrphanedClaims (GH-5273): a claim whose owner died before ever writing
+// the executions row Begin normally saves immediately after winning the
+// claim (ExecutionLifecycle.Begin in internal/executor/lifecycle.go). Unlike
+// GH-4409's dangling-claim fallthrough in nextRetryGeneration — which only
+// helps once a NEW dispatch attempt loses ErrClaimLost against the row —
+// this is the row itself being removed, so a future admission attempt for
+// (TaskID, ProjectPath) claims generation 0 fresh rather than colliding with
+// a permanently row-less claim forever.
+type OrphanedClaim struct {
+	TaskID      string
+	ProjectPath string
+	Generation  int
+	ExecutionID string
+	Age         time.Duration
+}
+
+// ReapOrphanedClaims deletes every execution_claims row older than
+// graceWindow whose claimed execution_id has no matching row in the
+// executions table at all — a claim whose owner crashed between winning
+// ClaimExecution and the immediately-following SaveExecution (GH-5273 live
+// incident: a generation-0 claim survived with no execution row behind it,
+// so every subsequent dispatch attempt's INSERT OR IGNORE collided with it
+// and dropped as "dispatch claim lost", 67 times over ~18 hours, with no
+// existing recovery mechanism able to see it — the stalled re-arm sweep
+// (GH-5212) and nextRetryGeneration's dangling-claim fallthrough (GH-4409)
+// both key off ledger/execution-row evidence that, by construction, does not
+// exist for this class).
+//
+// The grace window guards the legitimate claim-then-write race
+// (ClaimExecution succeeds, SaveExecution follows within the same call —
+// normally microseconds): a claim younger than graceWindow may simply be
+// mid-write, not orphaned, so it is left alone regardless of whether its
+// execution row exists yet. A claim whose (task_id, generation) DOES have a
+// matching executions row — running, queued, or any terminal status — is
+// never selected here regardless of age; only a claim with literally no
+// execution row is a candidate, matching Begin's own claim-then-immediately-
+// save contract (see ExecutionLifecycle.Begin's doc comment).
+//
+// Returns the reaped claims (possibly empty) for the caller to log —
+// deletion already happened by the time this returns.
+func (s *Store) ReapOrphanedClaims(graceWindow time.Duration) ([]OrphanedClaim, error) {
+	cutoff := time.Now().Add(-graceWindow)
+
+	rows, err := s.db.Query(`
+		SELECT task_id, project_path, generation, execution_id, created_at
+		FROM execution_claims
+		WHERE created_at < ?
+		AND execution_id NOT IN (SELECT id FROM executions)
+	`, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("querying orphaned claims: %w", err)
+	}
+
+	type claimKey struct {
+		taskID      string
+		projectPath string
+		generation  int
+	}
+	var orphans []OrphanedClaim
+	var keys []claimKey
+	for rows.Next() {
+		var taskID, projectPath, executionID string
+		var generation int
+		var createdAt time.Time
+		if err := rows.Scan(&taskID, &projectPath, &generation, &executionID, &createdAt); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scanning orphaned claim: %w", err)
+		}
+		orphans = append(orphans, OrphanedClaim{
+			TaskID:      taskID,
+			ProjectPath: projectPath,
+			Generation:  generation,
+			ExecutionID: executionID,
+			Age:         time.Since(createdAt),
+		})
+		keys = append(keys, claimKey{taskID: taskID, projectPath: projectPath, generation: generation})
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterating orphaned claims: %w", err)
+	}
+	_ = rows.Close()
+
+	for _, k := range keys {
+		if _, err := s.db.Exec(`
+			DELETE FROM execution_claims
+			WHERE task_id = ? AND project_path = ? AND generation = ?
+		`, k.taskID, k.projectPath, k.generation); err != nil {
+			return orphans, fmt.Errorf("deleting orphaned claim (task=%s, project=%s, generation=%d): %w", k.taskID, k.projectPath, k.generation, err)
+		}
+	}
+
+	return orphans, nil
+}
+
 // GetRepickBackoff returns the persisted repick-backoff cooldown state for
 // key (a "project_path|task_id" string minted by cmd/pilot's
 // repickBackoffKey). found is false when no drop has ever been recorded for

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -733,6 +733,145 @@ func TestClaimExecution_ProjectScoping(t *testing.T) {
 	}
 }
 
+// backdateClaim rewrites an execution_claims row's created_at directly via
+// SQL — ClaimExecution always stamps CURRENT_TIMESTAMP, so tests pinning the
+// grace-window boundary need a way to simulate a claim that has actually
+// aged past it.
+func backdateClaim(t *testing.T, store *Store, taskID, projectPath string, generation int, createdAt time.Time) {
+	t.Helper()
+	res, err := store.db.Exec(`
+		UPDATE execution_claims SET created_at = ?
+		WHERE task_id = ? AND project_path = ? AND generation = ?
+	`, createdAt, taskID, canonicalizeProjectPath(projectPath), generation)
+	if err != nil {
+		t.Fatalf("backdateClaim: %v", err)
+	}
+	if n, _ := res.RowsAffected(); n != 1 {
+		t.Fatalf("backdateClaim: expected to update exactly 1 row, updated %d", n)
+	}
+}
+
+// TestReapOrphanedClaims_RemovesRowlessClaimPastGraceWindow is GH-5273's core
+// acceptance case: a claim whose owner died before ever writing the
+// executions row Begin normally saves right after winning (the live
+// incident's exact shape — a generation-0 claim survived with no execution
+// row behind it, wedging every subsequent dispatch attempt against it
+// forever) is removed once it is older than the grace window.
+func TestReapOrphanedClaims_RemovesRowlessClaimPastGraceWindow(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	claimed, err := store.ClaimExecution("GH-249", "/project", 0, "exec-orphan")
+	if err != nil || !claimed {
+		t.Fatalf("expected orphan claim to win, claimed=%v err=%v", claimed, err)
+	}
+	backdateClaim(t, store, "GH-249", "/project", 0, time.Now().Add(-15*time.Minute))
+
+	orphans, err := store.ReapOrphanedClaims(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("ReapOrphanedClaims failed: %v", err)
+	}
+	if len(orphans) != 1 {
+		t.Fatalf("expected exactly 1 reaped orphan, got %d: %+v", len(orphans), orphans)
+	}
+	if orphans[0].TaskID != "GH-249" || orphans[0].Generation != 0 || orphans[0].ExecutionID != "exec-orphan" {
+		t.Errorf("unexpected reaped claim: %+v", orphans[0])
+	}
+
+	// The row must actually be gone — a fresh claim for the same key must be
+	// able to win generation 0 again.
+	claimed, err = store.ClaimExecution("GH-249", "/project", 0, "exec-fresh")
+	if err != nil {
+		t.Fatalf("ClaimExecution after reap failed: %v", err)
+	}
+	if !claimed {
+		t.Error("expected generation 0 to be claimable again after the orphan was reaped")
+	}
+}
+
+// TestReapOrphanedClaims_LeavesFreshClaimAlone pins the grace-window
+// boundary: a claim younger than graceWindow is never reaped even though it
+// has no execution row yet, since Begin's claim-then-write race is normally
+// microseconds, not minutes — reaping too eagerly would delete a
+// legitimately in-flight claim out from under its own owner.
+func TestReapOrphanedClaims_LeavesFreshClaimAlone(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	claimed, err := store.ClaimExecution("GH-250", "/project", 0, "exec-fresh")
+	if err != nil || !claimed {
+		t.Fatalf("expected fresh claim to win, claimed=%v err=%v", claimed, err)
+	}
+	// No backdating: created_at stays at "now", well inside a 10-minute grace
+	// window.
+
+	orphans, err := store.ReapOrphanedClaims(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("ReapOrphanedClaims failed: %v", err)
+	}
+	if len(orphans) != 0 {
+		t.Fatalf("expected fresh claim to survive the reap, got %d reaped: %+v", len(orphans), orphans)
+	}
+
+	// Confirm the row is still there: a second claim for the same key must
+	// still lose.
+	claimed, err = store.ClaimExecution("GH-250", "/project", 0, "exec-other")
+	if err != nil {
+		t.Fatalf("ClaimExecution failed: %v", err)
+	}
+	if claimed {
+		t.Error("expected the fresh claim to still hold generation 0 after the reap")
+	}
+}
+
+// TestReapOrphanedClaims_LeavesClaimWithExecutionRowAlone verifies existing
+// semantics are unchanged: a claim whose execution_id has a matching
+// executions row — running or terminal — is never reaped regardless of age.
+// This is the vast majority of claims in production; the reaper must only
+// ever touch the narrow row-less class.
+func TestReapOrphanedClaims_LeavesClaimWithExecutionRowAlone(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	for i, status := range []string{"running", "failed", "completed"} {
+		taskID := fmt.Sprintf("GH-%d", 300+i)
+		execID := fmt.Sprintf("exec-%d", i)
+
+		claimed, err := store.ClaimExecution(taskID, "/project", 0, execID)
+		if err != nil || !claimed {
+			t.Fatalf("expected claim to win for %s, claimed=%v err=%v", taskID, claimed, err)
+		}
+		backdateClaim(t, store, taskID, "/project", 0, time.Now().Add(-15*time.Minute))
+
+		if err := store.SaveExecution(&Execution{
+			ID:          execID,
+			TaskID:      taskID,
+			ProjectPath: "/project",
+			Status:      status,
+			CreatedAt:   time.Now().Add(-15 * time.Minute),
+		}); err != nil {
+			t.Fatalf("SaveExecution failed for %s: %v", taskID, err)
+		}
+	}
+
+	orphans, err := store.ReapOrphanedClaims(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("ReapOrphanedClaims failed: %v", err)
+	}
+	if len(orphans) != 0 {
+		t.Fatalf("expected no claims reaped when every claim has a matching execution row, got %d: %+v", len(orphans), orphans)
+	}
+}
+
 // TestRepickBackoff_PersistsAcrossStoreReopen is the GH-4394 regression test:
 // the whole point of persisting repick-backoff state (rather than keeping it
 // purely in-process, as it was under #4385) is that a fresh Store handle —


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5273.

Closes #5273

## Changes

GitHub Issue GH-5273: fix(dispatch): orphaned claim with no execution row wedges a task permanently — reap row-less claims past a grace window

## Context

Live incident 2026-08-31→09-01 (founder box, task GH-249 on the pilot-console project): a dispatch claim row was created at generation 0 and its owner died before writing any execution row. Result — a permanent, self-sustaining wedge:

- Every subsequent poll: SDK poller dispatches → the dispatcher's claim insert collides with the dead generation-0 claim → "dispatch claim lost … dropping duplicate pickup" → pilot-in-progress label unwound → poller re-arms after backoff → repeat. 67 claim-lost drops over ~18 hours, one dashboard queue row per attempt.
- No recovery mechanism could see it. Generation bump requires a terminal execution row — there was none, so retries could never claim generation+1. The stalled re-arm sweep (GH-5212 family) scans execution rows — there were none. The repick hard cap deliberately excludes claim-lost drops (the "repick storm" WARN), so the loop never terminated either.
- Detection already exists — the dispatcher logs the WARN with a running claim_lost_drops counter (67 at recovery) — but nothing acts on it.

Recovery was manual: exact-key DELETE of the orphaned claim row on the box DB, after verifying zero execution rows existed for the task. Post-delete the claim table is clean and dispatch proceeds.

A secondary observation for the fix: the orphaned claim row carried the RESOLVED project path (the box's real repo path), while dispatcher logs report the canonical macOS-era shim path — canonicalization makes them collide as intended, but any tooling that queries claims by the logged path string will miss the row. Worth normalizing what gets STORED to the canonical key form.

## Approach

An orphaned claim (a claim row whose (task, generation) has no corresponding execution row after a grace window) is provably dead — the owner writes the execution row immediately after winning the claim, so a claim that stays row-less for minutes has a dead owner. Two candidate mechanisms, implementer's choice or both:

1. Reaper leg on an existing periodic sweep (the stale-recovery tick is the natural home): delete claim rows older than a grace window (e.g. 10 minutes) that have no execution row for the same task and generation, with an INFO journal line naming the claim key and its age. This heals rows created by any past or future crash window.
2. Adopt-on-conflict at the dispatcher: when a claim insert loses and the winning row's (task, generation) has no execution row and exceeds the grace age, take the claim over (delete + re-insert or update owner) instead of dropping the pickup. Heals faster but only when a new pickup arrives.

The claim_lost_drops counter should feed an alert or at least the reaper's urgency — a counter crossing double digits for one task is exactly this wedge's signature.

## Acceptance

- An injected orphan claim (claim row present, no execution row, older than the grace window) is removed automatically and the task dispatches successfully on the next poll — end-to-end test at the dispatcher level.
- A FRESH claim inside the grace window is never reaped (the legitimate claim-then-write race stays safe) — test pins the window boundary.
- A claim whose (task, generation) HAS an execution row (running or terminal) is never touched by the reaper — existing semantics unchanged.
- The reap emits a journal/log line with the claim key, generation, age, and claim_lost_drops count at reap time.
- Repick/label-unwind behavior unchanged for all non-orphan drop reasons.

## Refs

- Incident evidence: box daemon log 2026-09-01 ~09:48Z ("repick storm: claim-lost/terminal drop recurring — not counted toward repick hard cap", claim_lost_drops=67) · recovery = exact-key claim DELETE after verifying zero execution rows.
- Related: the dead-owner execution-row class and its stalled workaround (GH-4392) · stalled re-arm sweep (GH-5212) — both key on execution rows, which is why this variant was invisible to them.
- Claim design: dedicated claims table keyed (task, project, generation), canonicalized path, retries claim generation+1 (GH-4319 decisions).