### PR TITLE
GH-5278: fix(executor): route all model-invoking spawn sites through env scrub helper

### DIFF
--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -635,7 +635,11 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 	// GH-2328: Signal executor mode to the child process. Project `CLAUDE.md`
 	// and auto-memory can detect this and skip Navigator-only "DO NOT write
 	// code" rules without relying on prompt-prefix heuristics.
-	env := append(os.Environ(), "PILOT_EXECUTOR=1")
+	// GH-5278: route the ambient environment through modelSubprocessEnv
+	// before layering the explicit appends below, so this model-controlled
+	// subprocess never inherits adapter secrets (TELEGRAM_BOT_TOKEN,
+	// SLACK_BOT_TOKEN, LINEAR_API_KEY, AWS_SECRET_*, ...).
+	env := append(modelSubprocessEnv(os.Environ()), "PILOT_EXECUTOR=1")
 	// GH-2371: route the CC subprocess to the configured provider when set.
 	// Values are appended after os.Environ() so they win on Node's last-write
 	// lookup if the user's shell also exports ANTHROPIC_*.

--- a/internal/executor/backend_opencode.go
+++ b/internal/executor/backend_opencode.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -115,6 +116,9 @@ func (b *OpenCodeBackend) startServer(ctx context.Context) error {
 	}
 
 	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	// GH-5278: scrub the ambient environment before this model-controlled
+	// subprocess inherits it.
+	cmd.Env = modelSubprocessEnv(os.Environ())
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start OpenCode server: %w", err)
 	}

--- a/internal/executor/complexity_classifier.go
+++ b/internal/executor/complexity_classifier.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -69,6 +70,9 @@ func NewComplexityClassifier() *ComplexityClassifier {
 // defaultCmdRunner executes the claude command.
 func (c *ComplexityClassifier) defaultCmdRunner(ctx context.Context, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "claude", args...)
+	// GH-5278: scrub the ambient environment before this model-controlled
+	// subprocess inherits it.
+	cmd.Env = modelSubprocessEnv(os.Environ())
 	return cmd.Output()
 }
 

--- a/internal/executor/effort_classifier.go
+++ b/internal/executor/effort_classifier.go
@@ -102,6 +102,9 @@ func NewEffortClassifier() *EffortClassifier {
 // defaultCmdRunner executes the claude command.
 func (c *EffortClassifier) defaultCmdRunner(ctx context.Context, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "claude", args...)
+	// GH-5278: scrub the ambient environment before this model-controlled
+	// subprocess inherits it.
+	cmd.Env = modelSubprocessEnv(os.Environ())
 	return cmd.Output()
 }
 

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -278,7 +278,9 @@ func (r *Runner) PlanEpic(ctx context.Context, task *Task, executionPath string)
 	}
 
 	cmd := exec.CommandContext(ctx, claudeCmd, args...)
-	cmd.Env = append(os.Environ(), "ANTHROPIC_MODEL="+planningModel)
+	// GH-5278: scrub the ambient environment before layering the explicit
+	// ANTHROPIC_MODEL override on top — this subprocess is model-controlled.
+	cmd.Env = append(modelSubprocessEnv(os.Environ()), "ANTHROPIC_MODEL="+planningModel)
 
 	// Set working directory - use executionPath which respects worktree isolation
 	if executionPath != "" {

--- a/internal/executor/intent_judge.go
+++ b/internal/executor/intent_judge.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -189,6 +190,9 @@ func (j *IntentJudge) defaultCmdRunner(ctx context.Context, args ...string) ([]b
 	args, prompt, hasPrompt := extractStdinPrompt(args)
 
 	cmd := exec.CommandContext(ctx, j.claudeCmd, args...)
+	// GH-5278: scrub the ambient environment before this model-controlled
+	// subprocess inherits it.
+	cmd.Env = modelSubprocessEnv(os.Environ())
 	var stdout bytes.Buffer
 	stderr := newBoundedBuffer(maxJudgeStderrCaptureBytes)
 	cmd.Stdout = &stdout

--- a/internal/executor/model_env.go
+++ b/internal/executor/model_env.go
@@ -1,0 +1,195 @@
+package executor
+
+import (
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// GH-5275/GH-5276: every model-invoking subprocess (Claude Code, OpenCode,
+// classifiers, planning, etc.) historically inherited the daemon's full
+// ambient environment — which is where adapter secrets live
+// (TELEGRAM_BOT_TOKEN, SLACK_BOT_TOKEN, LINEAR_API_KEY, AWS_SECRET_*, ...).
+// Claude Code runs with --dangerously-skip-permissions and Bash in its tool
+// allowlist, so any issue body that says "print your env to a file" hands
+// every bot token to the model. modelSubprocessEnv is the single scrub
+// helper every spawn site should route through (wiring across spawn sites
+// is tracked separately — GH-5278).
+
+// modelEnvDenySuffixes lists name suffixes that mark a variable as
+// credential-shaped and therefore scrubbed from model subprocess
+// environments unless explicitly kept or passed through.
+var modelEnvDenySuffixes = []string{
+	"_TOKEN",
+	"_SECRET",
+	"_API_KEY",
+	"_PAT",
+	"_PASSWORD",
+	"_PASSWD",
+	"_WEBHOOK_SECRET",
+}
+
+// modelEnvDenyPrefixes lists name prefixes that mark a variable as
+// credential-shaped regardless of suffix (AWS's SDK-standard env names
+// don't end in any of the suffixes above).
+var modelEnvDenyPrefixes = []string{
+	"AWS_SECRET_",
+	"AWS_SESSION_",
+}
+
+// modelEnvExplicitDeny holds names dropped regardless of the suffix/prefix
+// rules above — pulled from configs/pilot.example.yaml. Chat IDs are
+// targeting data for a bot token: harmless alone, no legitimate use inside
+// a model session.
+var modelEnvExplicitDeny = map[string]bool{
+	"PILOT_GATEWAY_TOKEN":       true,
+	"TELEGRAM_CHAT_ID":          true,
+	"TELEGRAM_APPROVER_CHAT_ID": true,
+}
+
+// modelEnvKeepExact holds names that survive the scrub verbatim, overriding
+// the deny rules above.
+var modelEnvKeepExact = map[string]bool{
+	"GITHUB_TOKEN": true,
+	"GH_TOKEN":     true,
+}
+
+// modelEnvKeepPrefixes holds name prefixes that survive the scrub,
+// overriding the deny rules above. GITHUB_TOKEN/GH_TOKEN stay because the
+// model's read-only `gh` calls through the ghguard shim rely on the ambient
+// token (see gh_credentials.go) — hiding a token from a same-UID process is
+// theater; the real mitigation is token scope (a short-lived GitHub App
+// installation token), not concealment. ANTHROPIC_*/CLAUDE_*/CLAUDE_CODE_*
+// are how the CLI itself is configured and routed (GH-2371, GH-2163).
+var modelEnvKeepPrefixes = []string{
+	"ANTHROPIC_",
+	"CLAUDE_",
+	"CLAUDE_CODE_",
+}
+
+// modelEnvPassthroughMu guards modelEnvPassthrough.
+var modelEnvPassthroughMu sync.RWMutex
+
+// modelEnvPassthrough holds the config-driven escape hatch
+// (claude_code.env_passthrough in pilot config): names listed here survive
+// the scrub even though they'd otherwise be dropped. Wiring this from
+// loaded config is tracked separately (GH-5277); SetModelEnvPassthrough is
+// the seam that wiring calls into.
+var modelEnvPassthrough map[string]bool
+
+// SetModelEnvPassthrough configures the set of environment variable names
+// that survive modelSubprocessEnv's scrub despite matching a deny rule.
+// Intended to be called once at startup from the loaded
+// claude_code.env_passthrough config value (GH-5277). A nil or empty names
+// slice clears the passthrough set.
+func SetModelEnvPassthrough(names []string) {
+	m := make(map[string]bool, len(names))
+	for _, n := range names {
+		m[n] = true
+	}
+	modelEnvPassthroughMu.Lock()
+	modelEnvPassthrough = m
+	modelEnvPassthroughMu.Unlock()
+}
+
+// isModelEnvPassthrough reports whether name is in the config-driven
+// passthrough set.
+func isModelEnvPassthrough(name string) bool {
+	modelEnvPassthroughMu.RLock()
+	defer modelEnvPassthroughMu.RUnlock()
+	return modelEnvPassthrough[name]
+}
+
+// isModelEnvKeptByDefault reports whether name is on the built-in keep-list,
+// which overrides every deny rule below.
+func isModelEnvKeptByDefault(name string) bool {
+	if modelEnvKeepExact[name] {
+		return true
+	}
+	for _, prefix := range modelEnvKeepPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// isModelEnvDenied reports whether name matches a deny rule (explicit name,
+// suffix, or prefix). It does not consider the keep-list or passthrough —
+// callers apply those first/after.
+func isModelEnvDenied(name string) bool {
+	if modelEnvExplicitDeny[name] {
+		return true
+	}
+	for _, suffix := range modelEnvDenySuffixes {
+		if strings.HasSuffix(name, suffix) {
+			return true
+		}
+	}
+	for _, prefix := range modelEnvDenyPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// modelSubprocessEnv returns a scrubbed copy of base (typically
+// os.Environ(), plus whatever a caller has already appended) suitable for a
+// model-controlled subprocess. It is a denylist, not an allowlist — vars
+// like HOME, PATH, TMPDIR, SSH_AUTH_SOCK, XDG_*, TERM, and locale vars pass
+// through untouched because nothing about them looks credential-shaped.
+//
+// Precedence: keep-list (GITHUB_TOKEN, GH_TOKEN, ANTHROPIC_*, CLAUDE_*,
+// CLAUDE_CODE_*) wins over every deny rule. Otherwise, a name matching the
+// explicit-deny set, a deny suffix (_TOKEN, _SECRET, _API_KEY, _PAT,
+// _PASSWORD, _PASSWD, _WEBHOOK_SECRET) or deny prefix (AWS_SECRET_,
+// AWS_SESSION_) is dropped unless it's in the config-driven passthrough set
+// (SetModelEnvPassthrough / claude_code.env_passthrough), in which case it
+// survives. Everything else passes through unchanged.
+//
+// Logs once per call: DEBUG with the COUNT of scrubbed vars (never names or
+// values, just a signal that the scrub ran), and INFO with the names (never
+// values) of any passthrough vars that were let through.
+func modelSubprocessEnv(base []string) []string {
+	out := make([]string, 0, len(base))
+	scrubbedCount := 0
+	var passedThrough []string
+
+	for _, kv := range base {
+		name, _, hasEquals := strings.Cut(kv, "=")
+		if !hasEquals {
+			out = append(out, kv)
+			continue
+		}
+
+		if isModelEnvKeptByDefault(name) {
+			out = append(out, kv)
+			continue
+		}
+
+		if !isModelEnvDenied(name) {
+			out = append(out, kv)
+			continue
+		}
+
+		if isModelEnvPassthrough(name) {
+			out = append(out, kv)
+			passedThrough = append(passedThrough, name)
+			continue
+		}
+
+		scrubbedCount++
+	}
+
+	slog.Default().Debug("model subprocess env scrubbed",
+		slog.Int("scrubbed_count", scrubbedCount),
+	)
+	if len(passedThrough) > 0 {
+		slog.Default().Info("model subprocess env passthrough",
+			slog.Any("names", passedThrough),
+		)
+	}
+
+	return out
+}

--- a/internal/executor/parallel.go
+++ b/internal/executor/parallel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -265,6 +266,9 @@ func (p *ParallelRunner) executeSubagent(ctx context.Context, projectPath string
 
 	cmd := exec.CommandContext(ctx, "claude", args...)
 	cmd.Dir = projectPath
+	// GH-5278: scrub the ambient environment before this model-controlled
+	// subprocess inherits it.
+	cmd.Env = modelSubprocessEnv(os.Environ())
 
 	// GH-4503: same fix as the primary backends — own process group so
 	// Cancel() and ctx-cancellation can reach any children this subagent

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -7225,6 +7225,9 @@ func (r *Runner) getPostExecutionSummary(ctx context.Context, dir string) (*Post
 		"--json-schema", PostExecutionSummarySchema,
 	)
 	cmd.Dir = dir
+	// GH-5278: scrub the ambient environment before this model-controlled
+	// subprocess inherits it.
+	cmd.Env = modelSubprocessEnv(os.Environ())
 
 	output, err := cmd.Output()
 	if err != nil {
@@ -7276,6 +7279,9 @@ func (r *Runner) getContractEvidence(ctx context.Context, dir string, fields []s
 		"--json-schema", ContractEvidenceSchema,
 	)
 	cmd.Dir = dir
+	// GH-5278: scrub the ambient environment before this model-controlled
+	// subprocess inherits it.
+	cmd.Env = modelSubprocessEnv(os.Environ())
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/executor/subtask_parser.go
+++ b/internal/executor/subtask_parser.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -65,6 +66,9 @@ func newSubtaskParserWithRunner(runner func(ctx context.Context, args ...string)
 
 func (p *SubtaskParser) defaultRunner(ctx context.Context, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, p.claudeCmd, args...)
+	// GH-5278: scrub the ambient environment before this model-controlled
+	// subprocess inherits it.
+	cmd.Env = modelSubprocessEnv(os.Environ())
 	return cmd.Output()
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5278.

Closes #5278

## Changes

Update every exec.Command/exec.CommandContext call that launches a model subprocess to build its env via modelSubprocessEnv, layering existing explicit appends (PILOT_EXECUTOR, ANTHROPIC_*, CLAUDE_CODE_*, NODE_OPTIONS, ghGuardTaskEnv, PATH-prepend) on top. Sites: backend_claudecode.go:638 and :691, epic.go:280-281, intent_judge.go:191, complexity_classifier.go:71, effort_classifier.go:104, parallel.go:266, runner.go:7220 and :7271, subtask_parser.go:67, and backend_opencode.go:117.