### PR TITLE
GH-5282: test(hooks): update existing env-mirror and hooks-default tests

### DIFF
--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -1548,8 +1548,11 @@ func TestSetProviderEnv(t *testing.T) {
 				t.Errorf("defaultModel = %q, want %q", b.defaultModel, tt.model)
 			}
 
-			// Mirror Execute()'s env-build logic.
-			env := []string{"PATH=/usr/bin", "PILOT_EXECUTOR=1"}
+			// Mirror Execute()'s env-build logic: route through the real
+			// modelSubprocessEnv scrub helper (GH-5278) instead of a
+			// hand-built slice, so this test tracks the actual spawn-site
+			// behavior rather than a stale copy of it.
+			env := append(modelSubprocessEnv([]string{"PATH=/usr/bin"}), "PILOT_EXECUTOR=1")
 			if b.apiBaseURL != "" {
 				env = append(env, "ANTHROPIC_BASE_URL="+b.apiBaseURL)
 			}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5282.

Closes #5282

## Changes

Update backend_claudecode_test.go:1552 to call the real modelSubprocessEnv helper instead of hand-building the env slice, and flip TestHooksConfig_Defaults (hooks_test.go:10) to assert Enabled == true.