### PR TITLE
GH-5299: fix(github): stale-label cleanup skips superseded/terminal issues and suppres...

### DIFF
--- a/internal/adapters/github/cleanup.go
+++ b/internal/adapters/github/cleanup.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -11,6 +13,26 @@ import (
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
 )
+
+// pilotTerminalExecutionStatuses mirrors memory.terminalExecutionStatuses
+// (internal/memory/store.go) — that slice is unexported, and importing
+// internal/executor's IsTerminalStatus wrapper would introduce an
+// internal/adapters/github <-> internal/executor cross-package coupling
+// this codebase deliberately avoids elsewhere (see the cycle-avoidance
+// comment in internal/executor/contract_evidence.go). Duplicated here
+// rather than imported, same pattern.
+var pilotTerminalExecutionStatuses = []string{
+	"completed", "failed", "cancelled", "canceled", "declined", "stalled", "no_op", "rate_limited", "infra", "skipped",
+}
+
+func isPilotTerminalStatus(status string) bool {
+	for _, s := range pilotTerminalExecutionStatuses {
+		if status == s {
+			return true
+		}
+	}
+	return false
+}
 
 // Cleaner handles automatic cleanup of stale pilot labels (pilot-in-progress and pilot-failed).
 // When Pilot crashes or is killed, labels remain on issues. This cleaner
@@ -339,6 +361,43 @@ func (c *Cleaner) cleanupLabel(ctx context.Context, label string, threshold time
 				slog.String("label", label),
 			)
 			continue
+		}
+
+		// GH-5299: a pilot-in-progress issue that otherwise qualifies for
+		// staleness cleanup must still be left alone if either (a) it has
+		// since been marked pilot-superseded — a hand-off already owns the
+		// work under a different issue number, so re-admitting this one via
+		// the "available for processing again" comment would race the
+		// continuation — or (b) the task's latest execution already reached
+		// a terminal status, meaning the label is stale bookkeeping on an
+		// issue whose work is actually done/declined/etc, not a crash
+		// orphan. In either case, removing the label and posting the
+		// cleanup comment would misrepresent the issue's true state and
+		// could wrongly re-admit it into the dispatch queue.
+		if label == LabelInProgress {
+			if HasLabel(issue, LabelSuperseded) {
+				c.logger.Debug("Issue is superseded, leaving stale pilot-in-progress label alone",
+					slog.Int("issue", issue.Number),
+				)
+				continue
+			}
+
+			latest, latestErr := c.store.GetLatestExecutionByTaskID(taskID, "")
+			switch {
+			case latestErr == nil && isPilotTerminalStatus(latest.Status):
+				c.logger.Debug("Issue's latest execution is terminal, leaving stale pilot-in-progress label alone",
+					slog.Int("issue", issue.Number),
+					slog.String("task_id", taskID),
+					slog.String("status", latest.Status),
+				)
+				continue
+			case latestErr != nil && !errors.Is(latestErr, sql.ErrNoRows):
+				c.logger.Warn("Failed to look up latest execution for staleness gate",
+					slog.Int("issue", issue.Number),
+					slog.String("task_id", taskID),
+					slog.Any("error", latestErr),
+				)
+			}
 		}
 
 		// Remove the stale label

--- a/internal/adapters/github/cleanup_test.go
+++ b/internal/adapters/github/cleanup_test.go
@@ -229,6 +229,153 @@ func TestCleaner_Cleanup_StaleIssuesRemoved(t *testing.T) {
 	}
 }
 
+// TestCleaner_Cleanup_SupersededIssueLeftAlone is a GH-5299 regression test:
+// a stale pilot-in-progress issue that has since been marked
+// pilot-superseded (a hand-off already owns the work under a different
+// issue number) must not have its label removed or a cleanup comment
+// posted — doing so would misrepresent the issue as "available for
+// processing again" and race the continuation.
+func TestCleaner_Cleanup_SupersededIssueLeftAlone(t *testing.T) {
+	store := createTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	staleTime := time.Now().Add(-2 * time.Hour)
+	issues := []*Issue{
+		{
+			Number:    321,
+			Title:     "Superseded Issue",
+			Labels:    []Label{{Name: LabelInProgress}, {Name: LabelSuperseded}},
+			UpdatedAt: staleTime,
+		},
+	}
+
+	var removeLabelCalled, addCommentCalled bool
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues" {
+			_ = json.NewEncoder(w).Encode(issues)
+			return
+		}
+
+		if r.Method == http.MethodDelete {
+			removeLabelCalled = true
+		}
+		if r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues/321/comments" {
+			addCommentCalled = true
+			_ = json.NewEncoder(w).Encode(&Comment{ID: 1, Body: "cleanup"})
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
+		Enabled:   true,
+		Interval:  30 * time.Minute,
+		Threshold: 1 * time.Hour,
+	})
+
+	if err := cleaner.Cleanup(context.Background()); err != nil {
+		t.Errorf("Cleanup() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if removeLabelCalled {
+		t.Error("RemoveLabel should NOT have been called for a superseded issue")
+	}
+	if addCommentCalled {
+		t.Error("AddComment should NOT have been called for a superseded issue")
+	}
+}
+
+// TestCleaner_Cleanup_TerminalExecutionIssueLeftAlone is a GH-5299
+// regression test: a stale pilot-in-progress issue whose task's latest
+// execution already reached a terminal status (e.g. "completed") must not
+// have its label removed or a cleanup comment posted — the label is stale
+// bookkeeping on finished work, not a crash orphan, and posting "available
+// for processing again" would misrepresent the issue's true state.
+func TestCleaner_Cleanup_TerminalExecutionIssueLeftAlone(t *testing.T) {
+	store := createTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	exec := &memory.Execution{
+		ID:     "exec-terminal-001",
+		TaskID: "GH-654",
+		Status: "completed",
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("Failed to save execution: %v", err)
+	}
+
+	staleTime := time.Now().Add(-2 * time.Hour)
+	issues := []*Issue{
+		{
+			Number:    654,
+			Title:     "Issue With Terminal Execution",
+			Labels:    []Label{{Name: LabelInProgress}},
+			UpdatedAt: staleTime,
+		},
+	}
+
+	var removeLabelCalled, addCommentCalled bool
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues" {
+			_ = json.NewEncoder(w).Encode(issues)
+			return
+		}
+
+		if r.Method == http.MethodDelete {
+			removeLabelCalled = true
+		}
+		if r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues/654/comments" {
+			addCommentCalled = true
+			_ = json.NewEncoder(w).Encode(&Comment{ID: 1, Body: "cleanup"})
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
+		Enabled:   true,
+		Interval:  30 * time.Minute,
+		Threshold: 1 * time.Hour,
+	})
+
+	if err := cleaner.Cleanup(context.Background()); err != nil {
+		t.Errorf("Cleanup() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if removeLabelCalled {
+		t.Error("RemoveLabel should NOT have been called for an issue with a terminal execution")
+	}
+	if addCommentCalled {
+		t.Error("AddComment should NOT have been called for an issue with a terminal execution")
+	}
+}
+
 func TestCleaner_Cleanup_RecentIssuesSkipped(t *testing.T) {
 	store := createTestStore(t)
 	defer func() { _ = store.Close() }()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5299.

Closes #5299

## Changes

<!--autopilot-meta
parent: GH-5297
inherited-spec: true
-->

Parent: GH-5297

In `internal/adapters/github/cleanup.go` (around lines 365-367 where the "available for processing again" comment is posted after removing stale `pilot-in-progress`), gate the removal + comment behind two checks: (a) issue is NOT labeled `pilot-superseded`, and (b) the task's latest execution is not terminal. When either is true, leave the label alone and post nothing. Extend `internal/adapters/github/cleanup_test.go` with cases for: superseded-labeled open issue (no comment, no unlabel), terminal-execution open issue (no comment, no unlabel), and the existing healthy stale case (unchanged behavior).

## Scope fence

Implement ONLY the slice described above. The parent issue GH-5297 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.