### PR TITLE
GH-5301: fix(dispatch): row-less-claim reaper only sweeps at startup — post-boot orphaned claims wedge tasks until the next restart (GH-257 incident)

### DIFF
--- a/.agent/tasks/gh-5301.md
+++ b/.agent/tasks/gh-5301.md
@@ -1,0 +1,38 @@
+# GH-5301
+
+**Created:** 2026-09-03
+
+## Problem
+
+GitHub Issue GH-5301: fix(dispatch): row-less-claim reaper only sweeps at startup — post-boot orphaned claims wedge tasks until the next restart (GH-257 incident)
+
+## Context
+
+The GH-5273/#5274 row-less-claim reaper works — but only as a **startup sweep**. Every reap line in the founder-box daemon log shares a single timestamp (`2026-09-01T14:22:30.150Z`, the 2.271.4 boot): it swept 10 orphans aged 340-838h in one batch and has not run since. An orphaned claim created *after* boot wedges its task until the next daemon restart, which on the current cadence can be days.
+
+## Evidence (GH-257 in pilot-console, 2026-09-02 → 09-03)
+
+- 09-02 09:29:14: task picked, `execution_claims` row created (task_id=GH-257, project=/var/lib/pilot/repos/startups/pilot-console, generation=0), "started" comment posted — then the run died before any `executions` row was inserted, and the issue was labeled `pilot-needs-human` with no explanatory comment.
+- 27+ hours of dispatch collisions: `claim_lost_drops` climbed to 94, repick-backoff cycling every ~5m30s, poller logging the (self-admittedly misleading) "Skipping re-dispatch — completed execution exists".
+- Reaper never fired for it: claim age far past any reasonable grace window, but no sweep ran between 09-01 boot and 09-03.
+- Manual recovery 09-03 ~12:40Z: exact-key `DELETE FROM execution_claims ... AND generation=0` (changes=1) + label cycle → unwedged.
+
+## Task
+
+1. Run the row-less-claim reap on a periodic tick (e.g. piggyback the dispatcher's existing sweep interval), not only at startup. Same grace window and logging as the boot sweep (`GH-5273: reaped orphaned execution claim ...`).
+2. Verify the reaper's match criteria cover a claim whose execution_id is empty/NULL as well as one pointing at a missing execution row — GH-257's claim was created at admission and may never have had an execution_id at all.
+3. Secondary (same incident, can be a follow-up if scope grows): whatever failure path applied `pilot-needs-human` did so with **no comment** — every needs-human labeling should post the reason, else the operator sees a silently frozen task.
+
+## Acceptance
+
+- An orphaned claim created while the daemon is running is reaped within one grace-window + one tick, without a restart; covered by a test that inserts a row-less claim mid-run and observes the reap.
+- Reap log line preserved (same format), so existing runbooks keep working.
+- (If 3 is in scope) any `pilot-needs-human` application is accompanied by a comment naming the cause.
+
+## Refs
+
+- Boot-sweep implementation: #5274 · claim-leak sibling: #5273
+- Label-side loop family (distinct, in flight): #5297 (+ children #5298-#5300) — this issue is the claim-side gap, no overlap.
+
+## Acceptance Criteria
+

--- a/internal/executor/base_presence_escalation_gh5056_test.go
+++ b/internal/executor/base_presence_escalation_gh5056_test.go
@@ -67,6 +67,44 @@ func TestEscalateBasePresenceHold_ShedsRetryReadyInSameMutation(t *testing.T) {
 	}
 }
 
+// TestEscalateBasePresenceHold_PostsExplanatoryComment is GH-5301: before
+// this, escalateBasePresenceHold applied pilot-needs-human via a bare `gh
+// issue edit` with no accompanying comment — an operator looking at the
+// issue saw a silently frozen task with no explanation (the GH-257 incident
+// evidence). The escalation must post a comment naming the cause alongside
+// the label mutation.
+func TestEscalateBasePresenceHold_PostsExplanatoryComment(t *testing.T) {
+	logFile := setupFakeGhCLI(t)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	worker := NewProjectWorker(t.TempDir(), store, runner, slog.Default())
+
+	task := &Task{
+		ID:            "GH-9503",
+		Title:         "escalation posts a comment",
+		ProjectPath:   t.TempDir(),
+		SourceAdapter: "github",
+	}
+	reason := "referenced PR #4 is still open (not merged)"
+
+	worker.escalateBasePresenceHold(context.Background(), task, reason)
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read gh CLI log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "issue comment 9503") {
+		t.Fatalf("expected a `gh issue comment 9503` call, got log: %q", log)
+	}
+	if !strings.Contains(log, reason) {
+		t.Errorf("expected the comment to name the escalation reason %q, got log: %q", reason, log)
+	}
+}
+
 // TestEscalateBasePresenceHold_EmitsAlertsEngineEvent covers defect 3: the
 // escalation must fire an alerts-engine event (mirroring escalateAndHold's
 // AlertEventTypeTaskFailed emission), not just label + log + EmitProgress.

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -3684,6 +3684,21 @@ func (w *ProjectWorker) escalateBasePresenceHold(ctx context.Context, task *Task
 	labelCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	// GH-5301: every pilot-needs-human application must post a comment
+	// naming the cause — without one, an operator sees a task silently
+	// parked with no explanation of why (the GH-257 incident evidence: a
+	// needs-human label with no accompanying comment). Best-effort like the
+	// label mutation below: a comment failure is logged, not fatal, and does
+	// not block the label or alert.
+	commentBody := fmt.Sprintf(
+		"Pilot parked this task under `pilot-needs-human`: %s\n\nThis escalation fired after the base-presence hold exceeded its max held cycles waiting on an unmet prerequisite. No further automatic retries will run until the label is cleared.",
+		reason,
+	)
+	if err := ghIssueComment(labelCtx, task.ProjectPath, issueNum, commentBody); err != nil {
+		w.log.Warn("base-presence hold escalation: failed to post explanatory comment",
+			slog.String("task_id", task.ID), slog.Any("error", err))
+	}
+
 	if err := ghEditLabels(labelCtx, task.ProjectPath, issueNum, []string{labelPilotNeedsHuman}, []string{labelPilotRetryReady}); err != nil {
 		w.log.Warn("base-presence hold escalation: failed to apply label",
 			slog.String("task_id", task.ID), slog.Any("error", err))

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -2674,6 +2674,63 @@ func TestRunStaleRecoveryLoop_Periodic(t *testing.T) {
 	}
 }
 
+// TestRunStaleRecoveryLoop_ReapsOrphanedClaimPeriodically is GH-5301's core
+// acceptance case: the row-less-claim reaper (GH-5273/#5274) must fire on
+// the periodic tick, not only at Dispatcher.Start — an orphaned claim
+// created *after* boot must be reaped within one grace window + one tick,
+// with no daemon restart involved. Before this fix's test coverage existed,
+// every ReapOrphanedClaims test called dispatcher.reapOrphanedClaims()
+// directly, which exercises the query but never proves the ticker
+// (runStaleRecoveryLoop) actually drives it end to end — this test starts
+// the real dispatcher, waits for it to be running, only then creates the
+// orphaned claim, and asserts it disappears without ever calling Stop/Start
+// again. Mirrors TestRunStaleRecoveryLoop_Periodic's structure exactly.
+func TestRunStaleRecoveryLoop_ReapsOrphanedClaimPeriodically(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Very short interval and grace window so the loop ticks quickly and the
+	// claim is already past its grace window by the time it does.
+	config := &DispatcherConfig{
+		StaleRunningThreshold:    0,
+		StaleQueuedThreshold:     0,
+		StaleRecoveryInterval:    50 * time.Millisecond,
+		OrphanedClaimGraceWindow: 5 * time.Millisecond,
+	}
+	runner := NewRunner()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dispatcher := NewDispatcher(store, runner, config)
+	if err := dispatcher.Start(ctx); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	// Create the orphaned claim AFTER Start() — simulating GH-257's shape,
+	// where the claim is created while the daemon is already running, long
+	// after any boot-time sweep has come and gone.
+	time.Sleep(20 * time.Millisecond)
+	claimed, err := store.ClaimExecution("GH-257", "/project", 0, "exec-gh257-orphan")
+	if err != nil || !claimed {
+		t.Fatalf("expected orphan claim to win, claimed=%v err=%v", claimed, err)
+	}
+
+	// Wait for the periodic loop to tick past the grace window and reap it —
+	// no restart, no direct reapOrphanedClaims() call.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, _, found, err := store.LatestClaimGeneration("GH-257", "/project"); err != nil {
+			t.Fatalf("LatestClaimGeneration failed: %v", err)
+		} else if !found {
+			return // reaped
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("expected the periodic stale-recovery loop to reap the orphaned claim created after Start(), but it was never reaped")
+}
+
 func TestRecoverStaleTasks_DeletesOrphanWhenCompleted(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -3476,6 +3476,25 @@ type OrphanedClaim struct {
 // execution row is a candidate, matching Begin's own claim-then-immediately-
 // save contract (see ExecutionLifecycle.Begin's doc comment).
 //
+// GH-5301: the match uses a correlated NOT EXISTS rather than
+// `execution_id NOT IN (SELECT id FROM executions)` deliberately. SQL's
+// three-valued logic makes NOT IN poison itself the moment the subquery
+// produces even one NULL: `x NOT IN (a, NULL)` evaluates to NULL (not true)
+// for every x that doesn't literally equal a, so a single NULL id anywhere
+// in the executions table would silently turn this reap into a permanent
+// no-op for every claim, forever, with no error surfaced (executions.id is
+// TEXT PRIMARY KEY, which SQLite does not implicitly enforce NOT NULL on
+// for non-INTEGER primary keys — a NULL row there is not the schema's
+// design intent, but nothing today would reject one on insert). NOT EXISTS
+// is immune to this: it is a per-row correlated check, so it correctly
+// reaps a claim regardless of what is or isn't in other rows of the
+// executions table, and independently covers a claim whose own
+// execution_id is empty — that also never matches, so it reaps exactly the
+// same as before. GH-257 (pilot-console): a claim created at admission with
+// no execution row ever written sat unreaped for 27+ hours despite the
+// periodic sweep ticking every StaleRecoveryInterval; this closes any
+// codepath through which that could reproduce.
+//
 // Returns the reaped claims (possibly empty) for the caller to log —
 // deletion already happened by the time this returns.
 func (s *Store) ReapOrphanedClaims(graceWindow time.Duration) ([]OrphanedClaim, error) {
@@ -3483,9 +3502,9 @@ func (s *Store) ReapOrphanedClaims(graceWindow time.Duration) ([]OrphanedClaim, 
 
 	rows, err := s.db.Query(`
 		SELECT task_id, project_path, generation, execution_id, created_at
-		FROM execution_claims
+		FROM execution_claims ec
 		WHERE created_at < ?
-		AND execution_id NOT IN (SELECT id FROM executions)
+		AND NOT EXISTS (SELECT 1 FROM executions e WHERE e.id = ec.execution_id)
 	`, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("querying orphaned claims: %w", err)

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -872,6 +872,81 @@ func TestReapOrphanedClaims_LeavesClaimWithExecutionRowAlone(t *testing.T) {
 	}
 }
 
+// TestReapOrphanedClaims_SurvivesNullIDInExecutionsTable is GH-5301's
+// regression case for the `NOT IN` SQL trap: SQL's three-valued logic makes
+// `x NOT IN (SELECT id FROM executions)` evaluate to NULL (not true) for
+// every claim, forever, the moment executions.id contains even one NULL row
+// — executions.id is a TEXT PRIMARY KEY, which SQLite does not implicitly
+// enforce NOT NULL on, so nothing rejects such a row on insert. This pins
+// the fix (a correlated NOT EXISTS instead of NOT IN): a genuine orphaned
+// claim must still be reaped even with a NULL-id row sitting in executions.
+func TestReapOrphanedClaims_SurvivesNullIDInExecutionsTable(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	// Plant a NULL-id row directly (SaveExecution's Execution.ID is a plain
+	// Go string and can never be nil, so this bypasses the normal write path
+	// on purpose — it's simulating the schema gap, not a real code path).
+	if _, err := store.db.Exec(`
+		INSERT INTO executions (id, task_id, project_path, status)
+		VALUES (NULL, 'GH-NULLROW', '/project', 'completed')
+	`); err != nil {
+		t.Fatalf("failed to plant NULL-id executions row: %v", err)
+	}
+
+	claimed, err := store.ClaimExecution("GH-257", "/project", 0, "exec-orphan-null-poisoned")
+	if err != nil || !claimed {
+		t.Fatalf("expected orphan claim to win, claimed=%v err=%v", claimed, err)
+	}
+	backdateClaim(t, store, "GH-257", "/project", 0, time.Now().Add(-15*time.Minute))
+
+	orphans, err := store.ReapOrphanedClaims(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("ReapOrphanedClaims failed: %v", err)
+	}
+	if len(orphans) != 1 {
+		t.Fatalf("expected the orphan to still be reaped despite the NULL-id row in executions, got %d: %+v", len(orphans), orphans)
+	}
+	if orphans[0].TaskID != "GH-257" {
+		t.Errorf("unexpected reaped claim: %+v", orphans[0])
+	}
+}
+
+// TestReapOrphanedClaims_ReapsClaimWithEmptyExecutionID covers a claim row
+// whose execution_id was never a real ID at all — the shape GH-257's own
+// incident produced (created at admission, the run died before Begin's
+// SaveExecution ever ran). execution_claims.execution_id is TEXT NOT NULL,
+// so the column can never hold SQL NULL, but an empty string is the
+// realistic worst case of "no execution row was ever associated" and must
+// be reaped exactly like a claim pointing at a real-but-missing ID.
+func TestReapOrphanedClaims_ReapsClaimWithEmptyExecutionID(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	claimed, err := store.ClaimExecution("GH-257", "/project", 0, "")
+	if err != nil || !claimed {
+		t.Fatalf("expected orphan claim to win, claimed=%v err=%v", claimed, err)
+	}
+	backdateClaim(t, store, "GH-257", "/project", 0, time.Now().Add(-15*time.Minute))
+
+	orphans, err := store.ReapOrphanedClaims(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("ReapOrphanedClaims failed: %v", err)
+	}
+	if len(orphans) != 1 {
+		t.Fatalf("expected the empty-execution_id claim to be reaped, got %d: %+v", len(orphans), orphans)
+	}
+	if orphans[0].TaskID != "GH-257" || orphans[0].ExecutionID != "" {
+		t.Errorf("unexpected reaped claim: %+v", orphans[0])
+	}
+}
+
 // TestRepickBackoff_PersistsAcrossStoreReopen is the GH-4394 regression test:
 // the whole point of persisting repick-backoff state (rather than keeping it
 // purely in-process, as it was under #4385) is that a fresh Store handle —


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5301.

Closes #5301

## Changes

GitHub Issue GH-5301: fix(dispatch): row-less-claim reaper only sweeps at startup — post-boot orphaned claims wedge tasks until the next restart (GH-257 incident)

## Context

The GH-5273/#5274 row-less-claim reaper works — but only as a **startup sweep**. Every reap line in the founder-box daemon log shares a single timestamp (`2026-09-01T14:22:30.150Z`, the 2.271.4 boot): it swept 10 orphans aged 340-838h in one batch and has not run since. An orphaned claim created *after* boot wedges its task until the next daemon restart, which on the current cadence can be days.

## Evidence (GH-257 in pilot-console, 2026-09-02 → 09-03)

- 09-02 09:29:14: task picked, `execution_claims` row created (task_id=GH-257, project=/var/lib/pilot/repos/startups/pilot-console, generation=0), "started" comment posted — then the run died before any `executions` row was inserted, and the issue was labeled `pilot-needs-human` with no explanatory comment.
- 27+ hours of dispatch collisions: `claim_lost_drops` climbed to 94, repick-backoff cycling every ~5m30s, poller logging the (self-admittedly misleading) "Skipping re-dispatch — completed execution exists".
- Reaper never fired for it: claim age far past any reasonable grace window, but no sweep ran between 09-01 boot and 09-03.
- Manual recovery 09-03 ~12:40Z: exact-key `DELETE FROM execution_claims ... AND generation=0` (changes=1) + label cycle → unwedged.

## Task

1. Run the row-less-claim reap on a periodic tick (e.g. piggyback the dispatcher's existing sweep interval), not only at startup. Same grace window and logging as the boot sweep (`GH-5273: reaped orphaned execution claim ...`).
2. Verify the reaper's match criteria cover a claim whose execution_id is empty/NULL as well as one pointing at a missing execution row — GH-257's claim was created at admission and may never have had an execution_id at all.
3. Secondary (same incident, can be a follow-up if scope grows): whatever failure path applied `pilot-needs-human` did so with **no comment** — every needs-human labeling should post the reason, else the operator sees a silently frozen task.

## Acceptance

- An orphaned claim created while the daemon is running is reaped within one grace-window + one tick, without a restart; covered by a test that inserts a row-less claim mid-run and observes the reap.
- Reap log line preserved (same format), so existing runbooks keep working.
- (If 3 is in scope) any `pilot-needs-human` application is accompanied by a comment naming the cause.

## Refs

- Boot-sweep implementation: #5274 · claim-leak sibling: #5273
- Label-side loop family (distinct, in flight): #5297 (+ children #5298-#5300) — this issue is the claim-side gap, no overlap.