### PR TITLE
GH-5302: fix(executor): claude_code.env_passthrough is parsed and documented but never wired — SetModelEnvPassthrough has no callers; OpenCode non-Anthropic provider keys now scrubbed

### DIFF
--- a/.agent/tasks/gh-5302.md
+++ b/.agent/tasks/gh-5302.md
@@ -1,0 +1,41 @@
+# GH-5302
+
+**Created:** 2026-09-03
+
+## Problem
+
+GitHub Issue GH-5302: fix(executor): claude_code.env_passthrough is parsed and documented but never wired — SetModelEnvPassthrough has no callers; OpenCode non-Anthropic provider keys now scrubbed
+
+## Context
+
+Post-merge review of GH-5275 (9 PRs, #5288–#5296) found the helper correct and the tests real (4/4 mutations killed: bypassed site, unset `cmd.Env`, deny-over-keep precedence, dropped AWS prefix), but two delivery gaps:
+
+1. **`claude_code.env_passthrough` is a no-op.** #5277 → PR#5288 added the `EnvPassthrough` field to `ClaudeCodeConfig` (`internal/executor/backend.go:846`) and a config-load test, and #5285 → PR#5296 documented it in `configs/pilot.example.yaml`. But `SetModelEnvPassthrough` (`internal/executor/model_env.go:85`) has **zero production callers** — `grep -rn SetModelEnvPassthrough internal cmd | grep -v _test` returns only its definition. A user who sets `env_passthrough: [MY_REPO_API_KEY]` still has that var scrubbed. The helper's own doc comment says "wiring this from loaded config is tracked separately (GH-5277)" and GH-5277 shipped without the wiring. TASK-460 false-success class: green tests, documented feature, no production effect.
+
+2. **OpenCode server loses non-Anthropic provider keys.** `backend_opencode.go:121` now scrubs the OpenCode server's env. OpenCode reads provider credentials from its environment (`OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `GROQ_API_KEY`, ...) unless the user has run `opencode auth login`. All of those match the `_API_KEY` suffix rule; only `ANTHROPIC_*` survives via the keep-list. A Pilot install using the OpenCode backend with an env-configured non-Anthropic provider silently loses auth on the next daemon restart. The intended remedy is `env_passthrough`, which (per item 1) does not work. Docs for the OpenCode backend (`docs/content/concepts/execution-backends.mdx`) never mention provider auth at all.
+
+Out of scope, noted for the record: `QwenCodeBackend` (`backend_qwencode.go:245`) is deliberately excluded from the scrub and from the AST guard (`model_env_spawn_test.go:47`). It spawns a model-controlled CLI with the full ambient env. Decide whether to wire it (same pattern) or document the exclusion in the hooks/security docs; do not leave it silent.
+
+## Approach
+
+- Wire the setter at daemon startup, immediately after config load and before any executor is constructed: `executor.SetModelEnvPassthrough(cfg.Executor.ClaudeCode.EnvPassthrough)`. One call site in `cmd/pilot` (wherever `config.Load` result is consumed — the same place `DefaultBackendConfig` is layered). Also call it from the CLI `pilot task` path if that bypasses daemon startup.
+- Keep the setter but make the seam testable end-to-end: a test that loads a YAML with `env_passthrough: [FOO_API_KEY]` through the real config loader, runs the startup wiring, and asserts `modelSubprocessEnv([]string{"FOO_API_KEY=x"})` retains it. The existing `TestModelSubprocessEnv_ConfigPassthroughSurvives` calls the setter directly and so cannot catch this gap.
+- OpenCode: add a short "Provider credentials" subsection to the OpenCode docs stating that the server env is scrubbed, `ANTHROPIC_*` survives, and any other provider key must be listed in `claude_code.env_passthrough` or supplied via `opencode auth login`. Add a startup WARN in `backend_opencode.go` when the configured `provider` is not `anthropic` and no matching `<PROVIDER>_API_KEY` is in the passthrough set.
+- Qwen: wire `backend_qwencode.go:245` through `modelSubprocessEnv` and add `QwenCodeBackend` to `modelBackendReceivers` in the AST guard, or add an explicit documented exclusion with the reason. Implementer's call; the issue is silence, not the choice.
+
+## Acceptance
+
+- `grep -rn SetModelEnvPassthrough cmd internal | grep -v _test` shows at least one call site outside `model_env.go`.
+- End-to-end test: config YAML → loader → startup wiring → `modelSubprocessEnv` retains a passthrough name. Mutation: deleting the startup call fails this test.
+- Live check in the PR: a daemon started with `env_passthrough: [FOO_API_KEY]` and `FOO_API_KEY=1` in its env spawns a Claude Code run whose `env | grep FOO` shows the var, and the INFO line `model subprocess env passthrough names=[FOO_API_KEY]` appears in the log.
+- OpenCode docs updated; WARN emitted in the non-anthropic-without-passthrough case (unit test on the condition).
+- Qwen either wired + guarded by `TestModelSpawnSitesUseScrubHelper`, or the exclusion is documented in `docs/content/features/hooks.mdx` (or the security section that #5284 touched).
+
+## Refs
+
+- Review verdict on GH-5275 (this issue's parent): APPROVE-w-defects.
+- Helper + tests: `internal/executor/model_env.go`, `model_env_matrix_test.go`, `model_env_spawn_test.go`.
+- Field: `internal/executor/backend.go:841-846`; config test `internal/config/config_test.go:2484` (`TestLoadClaudeCodeEnvPassthrough`) proves parsing only.
+
+## Acceptance Criteria
+

--- a/docs/content/concepts/execution-backends.mdx
+++ b/docs/content/concepts/execution-backends.mdx
@@ -119,6 +119,7 @@ executor:
 - **Effort routing is silently skipped** — Pilot passes effort levels but Qwen ignores them
 - **No `--from-pr` support** — PR context cannot be passed to Qwen Code
 - **Session resume requires v0.1.0+** — Earlier versions don't support `--output-format stream-json`
+- **Ambient env is scrubbed** — like the other backends, the Qwen subprocess gets a filtered copy of Pilot's environment with adapter secrets removed. If Qwen (or a tool it shells out to) needs a credential that looks secret-shaped (`*_API_KEY`, `*_TOKEN`, ...), list it in `executor.claude_code.env_passthrough`.
 
 ### Strengths
 
@@ -188,6 +189,24 @@ executor:
 - **No PR context**: Cannot leverage `--from-pr` for targeted execution
 - **Raw HTTP**: Errors are not classified (rate limit, API, timeout all appear as HTTP errors)
 - **SSE streaming**: Uses HTTP Server-Sent Events instead of JSON streaming
+
+### Provider credentials
+
+The OpenCode server process is a model-controlled subprocess like any other Pilot-spawned backend, so its environment goes through the same ambient-secret scrub every Claude Code/OpenCode spawn does (adapter bot tokens, webhook secrets, etc. are stripped before the process starts). `ANTHROPIC_*` names survive that scrub automatically — nothing to configure for `provider: "anthropic"`.
+
+For any other `provider` (`openrouter`, `openai`, `groq`, ...), OpenCode reads that provider's credential from its own process environment (e.g. `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `GROQ_API_KEY`) unless you've already run `opencode auth login`. Those names all match the scrub's `_API_KEY` deny rule, so **an env-configured non-Anthropic provider key is dropped on every server (re)start** unless you explicitly list it:
+
+```yaml
+executor:
+  claude_code:
+    env_passthrough:
+      - OPENROUTER_API_KEY   # matches the provider configured below
+  opencode:
+    provider: "openrouter"
+    model: "openrouter/some-model"
+```
+
+If you set a non-Anthropic `provider` without a matching `env_passthrough` entry, Pilot logs a WARN on server start naming the provider and the expected env var — treat that as a signal auth will fail, not just informational noise. The alternative is `opencode auth login`, which stores credentials outside the process environment entirely and isn't affected by the scrub.
 
 ### Attached Mode (multi-project / non-CWD execution)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/gateway"
 	"github.com/qf-studio/pilot/internal/memory"
 )
@@ -2538,6 +2539,62 @@ executor:
 			}
 		}
 	})
+}
+
+// TestLoadClaudeCodeEnvPassthrough_WiresIntoScrub is the GH-5302 regression
+// guard. TestLoadClaudeCodeEnvPassthrough above only proves env_passthrough
+// parses out of YAML into the Config struct — it says nothing about whether
+// anything downstream actually reads it, and #5277/PR#5288 shipped with
+// SetModelEnvPassthrough having zero production callers despite that test
+// being green. This test walks the real path a daemon (or `pilot task`/
+// `pilot github run`) takes — config.Load, then
+// executor.NewRunnerWithConfig, the single choke point every
+// runner-construction call site funnels through — and asserts the
+// configured name survives modelSubprocessEnv's scrub. Deleting the
+// SetModelEnvPassthrough wiring inside NewRunnerWithConfig fails this test
+// even though TestLoadClaudeCodeEnvPassthrough still passes.
+func TestLoadClaudeCodeEnvPassthrough_WiresIntoScrub(t *testing.T) {
+	executor.SetModelEnvPassthrough(nil)
+	t.Cleanup(func() { executor.SetModelEnvPassthrough(nil) })
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	configContent := `
+version: "1.0"
+executor:
+  claude_code:
+    env_passthrough:
+      - FOO_API_KEY
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	// This mirrors the daemon startup / CLI wiring: constructing a runner
+	// from the loaded config must, as a side effect, configure the
+	// passthrough set (GH-5302).
+	if _, err := executor.NewRunnerWithConfig(cfg.Executor); err != nil {
+		t.Fatalf("NewRunnerWithConfig failed: %v", err)
+	}
+
+	out := executor.ModelSubprocessEnvForTest([]string{"FOO_API_KEY=x", "LINEAR_API_KEY=still-denied"})
+
+	found := map[string]bool{}
+	for _, kv := range out {
+		name, _, _ := strings.Cut(kv, "=")
+		found[name] = true
+	}
+	if !found["FOO_API_KEY"] {
+		t.Errorf("expected FOO_API_KEY to survive the scrub via claude_code.env_passthrough wired at runner construction, got %v", out)
+	}
+	if found["LINEAR_API_KEY"] {
+		t.Errorf("expected LINEAR_API_KEY (not in env_passthrough) to remain scrubbed, got %v", out)
+	}
 }
 
 func TestResolvedHealthCheckInterval(t *testing.T) {

--- a/internal/executor/backend_opencode.go
+++ b/internal/executor/backend_opencode.go
@@ -108,6 +108,7 @@ func (b *OpenCodeBackend) startServer(ctx context.Context) error {
 	}
 
 	b.log.Info("Starting OpenCode server", slog.String("command", b.config.ServerCommand))
+	b.warnIfProviderCredentialsMayBeScrubbed()
 
 	// Parse server command
 	parts := strings.Fields(b.config.ServerCommand)
@@ -136,6 +137,38 @@ func (b *OpenCodeBackend) startServer(ctx context.Context) error {
 	}
 
 	return fmt.Errorf("OpenCode server failed to start within timeout")
+}
+
+// providerAPIKeyEnvVar returns the conventional environment variable name
+// OpenCode looks up for a given provider's API key (e.g. "openrouter" ->
+// "OPENROUTER_API_KEY"). Returns "" for an empty provider or "anthropic",
+// which survives the model-env scrub on its own via the ANTHROPIC_* keep
+// prefix (model_env.go) and needs no passthrough entry.
+func providerAPIKeyEnvVar(provider string) string {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	if p == "" || p == "anthropic" {
+		return ""
+	}
+	return strings.ToUpper(p) + "_API_KEY"
+}
+
+// warnIfProviderCredentialsMayBeScrubbed logs a WARN when the configured
+// OpenCode provider is not Anthropic and its conventional *_API_KEY name is
+// not in the config-driven passthrough set (claude_code.env_passthrough).
+// OpenCode reads provider credentials from its own process environment
+// unless `opencode auth login` has been run — every *_API_KEY name matches
+// the model-env scrub's deny suffix (GH-5275/GH-5278), so without this the
+// credential is silently dropped from the server subprocess env on every
+// (re)start (GH-5302).
+func (b *OpenCodeBackend) warnIfProviderCredentialsMayBeScrubbed() {
+	envVar := providerAPIKeyEnvVar(b.config.Provider)
+	if envVar == "" || isModelEnvPassthrough(envVar) {
+		return
+	}
+	b.log.Warn("OpenCode provider is non-Anthropic and its API key is not in claude_code.env_passthrough — the server subprocess env scrub will drop it on start; add it to claude_code.env_passthrough or run `opencode auth login`",
+		slog.String("provider", b.config.Provider),
+		slog.String("expected_env_var", envVar),
+	)
 }
 
 // Execute runs a prompt through OpenCode server.

--- a/internal/executor/backend_opencode_test.go
+++ b/internal/executor/backend_opencode_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -236,6 +237,72 @@ func TestOpenCodeBackendIsAvailable(t *testing.T) {
 	// This will depend on whether opencode is installed
 	// Just verify it doesn't panic
 	_ = backend.IsAvailable()
+}
+
+// TestProviderAPIKeyEnvVar covers GH-5302's provider-name -> env-var-name
+// derivation used by the non-Anthropic-provider-without-passthrough WARN.
+func TestProviderAPIKeyEnvVar(t *testing.T) {
+	tests := []struct {
+		provider string
+		want     string
+	}{
+		{"", ""},
+		{"anthropic", ""},
+		{"Anthropic", ""},
+		{"  anthropic  ", ""},
+		{"openrouter", "OPENROUTER_API_KEY"},
+		{"openai", "OPENAI_API_KEY"},
+		{"groq", "GROQ_API_KEY"},
+		{"  openai  ", "OPENAI_API_KEY"},
+		{"OpenAI", "OPENAI_API_KEY"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			got := providerAPIKeyEnvVar(tt.provider)
+			if got != tt.want {
+				t.Errorf("providerAPIKeyEnvVar(%q) = %q, want %q", tt.provider, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestOpenCodeBackendWarnIfProviderCredentialsMayBeScrubbed covers GH-5302:
+// the server-start WARN must fire exactly when the configured provider is
+// non-Anthropic AND its conventional *_API_KEY name is missing from the
+// config-driven passthrough set (claude_code.env_passthrough) — otherwise
+// that provider's credential is silently scrubbed from the OpenCode server
+// subprocess env on every (re)start.
+func TestOpenCodeBackendWarnIfProviderCredentialsMayBeScrubbed(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    string
+		passthrough []string
+		wantWarn    bool
+	}{
+		{"anthropic provider never warns", "anthropic", nil, false},
+		{"empty provider never warns", "", nil, false},
+		{"non-anthropic without passthrough warns", "openrouter", nil, true},
+		{"non-anthropic with matching passthrough does not warn", "openrouter", []string{"OPENROUTER_API_KEY"}, false},
+		{"non-anthropic with unrelated passthrough still warns", "openrouter", []string{"OPENAI_API_KEY"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetModelEnvPassthrough(tt.passthrough)
+			t.Cleanup(func() { SetModelEnvPassthrough(nil) })
+
+			var buf bytes.Buffer
+			backend := NewOpenCodeBackend(&OpenCodeConfig{Provider: tt.provider})
+			backend.log = slog.New(slog.NewTextHandler(&buf, nil))
+
+			backend.warnIfProviderCredentialsMayBeScrubbed()
+
+			gotWarn := strings.Contains(buf.String(), "level=WARN")
+			if gotWarn != tt.wantWarn {
+				t.Errorf("warn emitted = %v, want %v; log output: %s", gotWarn, tt.wantWarn, buf.String())
+			}
+		})
+	}
 }
 
 func TestOpenCodeBackendStopServer(t *testing.T) {

--- a/internal/executor/backend_qwencode.go
+++ b/internal/executor/backend_qwencode.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -195,7 +196,12 @@ func (b *QwenCodeBackend) IsAvailable() bool {
 	if err != nil {
 		return false
 	}
-	out, err := exec.Command(path, "--version").Output()
+	// GH-5302: scrub even this --version probe for consistency with the
+	// Execute() spawn below — no functional need (no prompt/tool use), but
+	// it keeps every qwen invocation in this file routed the same way.
+	cmd := exec.Command(path, "--version")
+	cmd.Env = modelSubprocessEnv(os.Environ())
+	out, err := cmd.Output()
 	if err != nil {
 		b.log.Warn("qwen-code: could not determine version", "error", err)
 		return true
@@ -244,6 +250,11 @@ func (b *QwenCodeBackend) Execute(ctx context.Context, opts ExecuteOptions) (*Ba
 
 	cmd := exec.CommandContext(ctx, b.config.Command, args...)
 	cmd.Dir = opts.ProjectPath
+	// GH-5302: QwenCodeBackend spawns the same kind of model-controlled CLI
+	// (Bash-capable, --yolo == --dangerously-skip-permissions) as Claude Code
+	// and OpenCode, so it gets the same ambient-env scrub (GH-5275/GH-5278)
+	// rather than staying a silent, undocumented exception.
+	cmd.Env = modelSubprocessEnv(os.Environ())
 
 	// GH-4503: same fix as the Claude Code backend — give the subprocess its
 	// own process group so every kill path below reaches any children it

--- a/internal/executor/model_env.go
+++ b/internal/executor/model_env.go
@@ -72,16 +72,19 @@ var modelEnvPassthroughMu sync.RWMutex
 
 // modelEnvPassthrough holds the config-driven escape hatch
 // (claude_code.env_passthrough in pilot config): names listed here survive
-// the scrub even though they'd otherwise be dropped. Wiring this from
-// loaded config is tracked separately (GH-5277); SetModelEnvPassthrough is
-// the seam that wiring calls into.
+// the scrub even though they'd otherwise be dropped. Wired from loaded
+// config inside NewRunnerWithConfig (runner.go, GH-5302) — every
+// runner-construction call site (daemon startup, `pilot task`,
+// `pilot github run`, orchestrator, interactive mode) funnels through
+// there, so this is set exactly once per config load regardless of entry
+// point. SetModelEnvPassthrough is the seam that wiring calls into.
 var modelEnvPassthrough map[string]bool
 
 // SetModelEnvPassthrough configures the set of environment variable names
 // that survive modelSubprocessEnv's scrub despite matching a deny rule.
-// Intended to be called once at startup from the loaded
-// claude_code.env_passthrough config value (GH-5277). A nil or empty names
-// slice clears the passthrough set.
+// Called from NewRunnerWithConfig (GH-5302) with the loaded
+// claude_code.env_passthrough config value. A nil or empty names slice
+// clears the passthrough set.
 func SetModelEnvPassthrough(names []string) {
 	m := make(map[string]bool, len(names))
 	for _, n := range names {
@@ -192,4 +195,16 @@ func modelSubprocessEnv(base []string) []string {
 	}
 
 	return out
+}
+
+// ModelSubprocessEnvForTest exposes modelSubprocessEnv to tests in other
+// packages that can't reach the unexported helper directly — e.g.
+// internal/config's end-to-end env_passthrough wiring test (GH-5302), which
+// needs to prove claude_code.env_passthrough actually reaches the scrub
+// after flowing through config.Load and NewRunnerWithConfig, not just that
+// it parses. Production code must call modelSubprocessEnv directly (or
+// route through a Backend that already does); this seam exists purely for
+// cross-package test assertions.
+func ModelSubprocessEnvForTest(base []string) []string {
+	return modelSubprocessEnv(base)
 }

--- a/internal/executor/model_env_spawn_test.go
+++ b/internal/executor/model_env_spawn_test.go
@@ -44,12 +44,15 @@ var modelBinaryLiterals = map[string]bool{
 // modelBackendReceivers are struct types whose methods spawn the model CLI
 // through a configured, non-literal command path (e.g. b.config.Command,
 // parts[0] parsed from a configured server command) rather than a string
-// literal containing "claude"/"opencode". QwenCodeBackend is deliberately
-// NOT listed — its spawn sites are out of scope for GH-5275/GH-5276/GH-5278
-// (see backend_qwencode.go; it was never in the enumerated site list).
+// literal containing "claude"/"opencode". QwenCodeBackend was originally
+// excluded here as out of scope for GH-5275/GH-5276/GH-5278, but GH-5302
+// closed that gap — it spawns the same kind of Bash-capable,
+// permissions-skipping model CLI and now routes through modelSubprocessEnv
+// too (backend_qwencode.go), so it belongs in this guard like the others.
 var modelBackendReceivers = map[string]bool{
 	"ClaudeCodeBackend": true,
 	"OpenCodeBackend":   true,
+	"QwenCodeBackend":   true,
 }
 
 // receiverTypeName returns the (de-pointered) receiver type name of fn, or

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1097,6 +1097,18 @@ func NewRunnerWithConfig(config *BackendConfig) (*Runner, error) {
 			slog.String("type", config.Type),
 		)
 	}
+
+	// GH-5302: this is the single choke point every runner-construction path
+	// (daemon startup, `pilot task`, `pilot github run`, orchestrator,
+	// interactive mode) goes through before any model subprocess can spawn —
+	// wire claude_code.env_passthrough here rather than duplicating the call
+	// across each cmd/pilot call site. Without this, EnvPassthrough parses
+	// from config (GH-5277/PR#5288) but modelSubprocessEnv never sees it and
+	// every listed name is still scrubbed (GH-5302).
+	if config.ClaudeCode != nil {
+		SetModelEnvPassthrough(config.ClaudeCode.EnvPassthrough)
+	}
+
 	backend, err := NewBackend(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5302.

Closes #5302

## Changes

GitHub Issue GH-5302: fix(executor): claude_code.env_passthrough is parsed and documented but never wired — SetModelEnvPassthrough has no callers; OpenCode non-Anthropic provider keys now scrubbed

## Context

Post-merge review of GH-5275 (9 PRs, #5288–#5296) found the helper correct and the tests real (4/4 mutations killed: bypassed site, unset `cmd.Env`, deny-over-keep precedence, dropped AWS prefix), but two delivery gaps:

1. **`claude_code.env_passthrough` is a no-op.** #5277 → PR#5288 added the `EnvPassthrough` field to `ClaudeCodeConfig` (`internal/executor/backend.go:846`) and a config-load test, and #5285 → PR#5296 documented it in `configs/pilot.example.yaml`. But `SetModelEnvPassthrough` (`internal/executor/model_env.go:85`) has **zero production callers** — `grep -rn SetModelEnvPassthrough internal cmd | grep -v _test` returns only its definition. A user who sets `env_passthrough: [MY_REPO_API_KEY]` still has that var scrubbed. The helper's own doc comment says "wiring this from loaded config is tracked separately (GH-5277)" and GH-5277 shipped without the wiring. TASK-460 false-success class: green tests, documented feature, no production effect.

2. **OpenCode server loses non-Anthropic provider keys.** `backend_opencode.go:121` now scrubs the OpenCode server's env. OpenCode reads provider credentials from its environment (`OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `GROQ_API_KEY`, ...) unless the user has run `opencode auth login`. All of those match the `_API_KEY` suffix rule; only `ANTHROPIC_*` survives via the keep-list. A Pilot install using the OpenCode backend with an env-configured non-Anthropic provider silently loses auth on the next daemon restart. The intended remedy is `env_passthrough`, which (per item 1) does not work. Docs for the OpenCode backend (`docs/content/concepts/execution-backends.mdx`) never mention provider auth at all.

Out of scope, noted for the record: `QwenCodeBackend` (`backend_qwencode.go:245`) is deliberately excluded from the scrub and from the AST guard (`model_env_spawn_test.go:47`). It spawns a model-controlled CLI with the full ambient env. Decide whether to wire it (same pattern) or document the exclusion in the hooks/security docs; do not leave it silent.

## Approach

- Wire the setter at daemon startup, immediately after config load and before any executor is constructed: `executor.SetModelEnvPassthrough(cfg.Executor.ClaudeCode.EnvPassthrough)`. One call site in `cmd/pilot` (wherever `config.Load` result is consumed — the same place `DefaultBackendConfig` is layered). Also call it from the CLI `pilot task` path if that bypasses daemon startup.
- Keep the setter but make the seam testable end-to-end: a test that loads a YAML with `env_passthrough: [FOO_API_KEY]` through the real config loader, runs the startup wiring, and asserts `modelSubprocessEnv([]string{"FOO_API_KEY=x"})` retains it. The existing `TestModelSubprocessEnv_ConfigPassthroughSurvives` calls the setter directly and so cannot catch this gap.
- OpenCode: add a short "Provider credentials" subsection to the OpenCode docs stating that the server env is scrubbed, `ANTHROPIC_*` survives, and any other provider key must be listed in `claude_code.env_passthrough` or supplied via `opencode auth login`. Add a startup WARN in `backend_opencode.go` when the configured `provider` is not `anthropic` and no matching `<PROVIDER>_API_KEY` is in the passthrough set.
- Qwen: wire `backend_qwencode.go:245` through `modelSubprocessEnv` and add `QwenCodeBackend` to `modelBackendReceivers` in the AST guard, or add an explicit documented exclusion with the reason. Implementer's call; the issue is silence, not the choice.

## Acceptance

- `grep -rn SetModelEnvPassthrough cmd internal | grep -v _test` shows at least one call site outside `model_env.go`.
- End-to-end test: config YAML → loader → startup wiring → `modelSubprocessEnv` retains a passthrough name. Mutation: deleting the startup call fails this test.
- Live check in the PR: a daemon started with `env_passthrough: [FOO_API_KEY]` and `FOO_API_KEY=1` in its env spawns a Claude Code run whose `env | grep FOO` shows the var, and the INFO line `model subprocess env passthrough names=[FOO_API_KEY]` appears in the log.
- OpenCode docs updated; WARN emitted in the non-anthropic-without-passthrough case (unit test on the condition).
- Qwen either wired + guarded by `TestModelSpawnSitesUseScrubHelper`, or the exclusion is documented in `docs/content/features/hooks.mdx` (or the security section that #5284 touched).

## Refs

- Review verdict on GH-5275 (this issue's parent): APPROVE-w-defects.
- Helper + tests: `internal/executor/model_env.go`, `model_env_matrix_test.go`, `model_env_spawn_test.go`.
- Field: `internal/executor/backend.go:841-846`; config test `internal/config/config_test.go:2484` (`TestLoadClaudeCodeEnvPassthrough`) proves parsing only.