### PR TITLE
fix(memory): stamp all Go-written DB timestamps in UTC

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -5981,7 +5981,7 @@
       },
       "go-time-cutoff-vs-sqlite-current-timestamp-timezone": {
         "type": "pitfall",
-        "summary": "Binding a Go time.Now()-derived cutoff against a SQLite CURRENT_TIMESTAMP column compares local-time text to UTC text; grace windows break on non-UTC hosts (reaper reaped live claims on UTC+2, invisible on UTC box/CI). Rule: cutoff.UTC() or compare in Go; test under a non-UTC time.Local. pilot#5308.",
+        "summary": "Binding a Go time.Now()-derived cutoff against a SQLite CURRENT_TIMESTAMP column compares local-time text to UTC text; grace windows break on non-UTC hosts (reaper reaped live claims on UTC+2, invisible on UTC box/CI). Rule: cutoff.UTC() or compare in Go; test under a non-UTC time.Local. pilot#5308. Follow-up audit (#5310) found the same local-vs-UTC split on other columns of the same row (executions.created_at/completed_at, sessions.started_at/ended_at) — fixed by normalizing every Go-written DB timestamp to UTC at the write boundary, not just cutoffs.",
         "file": ".agent/knowledge/memories/pitfalls/go-time-cutoff-vs-sqlite-current-timestamp-timezone.md",
         "concepts": [
           "sqlite",

--- a/.agent/knowledge/memories/pitfalls/go-time-cutoff-vs-sqlite-current-timestamp-timezone.md
+++ b/.agent/knowledge/memories/pitfalls/go-time-cutoff-vs-sqlite-current-timestamp-timezone.md
@@ -34,3 +34,27 @@ the pattern anyway — the pitfall is not discoverable from the call site.
 - When reviewing: grep `store.go` for `_at\s*[<>]=?\s*\?` and check each
   param's construction. Related: [[absolute-state-paths-bypass-cutover-shim]]
   (another "correct on the box, wrong elsewhere" class).
+
+**Follow-up (GH-5310, 2026-09-03):** #5309 fixed only the two sites flagged in
+review (`ReapOrphanedClaims`, `GetExecutionsForReceipts`). A full audit of
+every Go-written DB timestamp in `store.go` found the underlying bug was
+broader than "cutoff vs `CURRENT_TIMESTAMP`": `executions.created_at`
+(Go-written) and `executions.completed_at` (`CURRENT_TIMESTAMP`-written) sat
+on the *same row*, one local one UTC — invisible today because no query joins
+them, but a landmine for any future duration/ordering query. The same pattern
+turned up independently in `sessions`: `started_at` was Go-`time.Now()` while
+`EndSession`'s `ended_at` is `CURRENT_TIMESTAMP` — nobody had flagged that one
+at all until this audit swept every `time.Now()` in the file, not just the
+ones already bound into a `WHERE` clause. Fix: normalize every Go-written DB
+timestamp to `.UTC()` at the write boundary (`SaveExecution`, `SaveLogEntry`,
+`SaveAutopilotMetrics`, `GetOrCreateDailySession`) *and* every read-side bound
+compared against those columns (`GetExecutionsInPeriod`, `GetBriefMetrics`,
+`GetWindowedStats`, `PruneExecutionLogs`, `PruneAutopilotMetrics`) in the same
+PR, so main never has a mixed-normalization window. One regression surfaced
+by this: `TestPruneExecutionLogs` inserted rows via direct SQL (bypassing
+`SaveLogEntry`'s new normalization) using local `time.Now()` — once the prune
+cutoff went UTC, the test's own fixture became the inconsistent one.
+**Corollary rule:** a raw `db.Exec(INSERT ...)` test fixture that stamps a
+timestamp column must match whatever normalization the real write path now
+applies, or the fixture silently drifts into simulating a row shape
+production can no longer produce.

--- a/internal/executor/worktree.go
+++ b/internal/executor/worktree.go
@@ -253,7 +253,7 @@ func (m *WorktreeManager) createPooledWorktree(ctx context.Context, index int) (
 
 	return &PooledWorktree{
 		Path:      worktreePath,
-		CreatedAt: time.Now(),
+		CreatedAt: time.Now().UTC(),
 		InUse:     false,
 	}, nil
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -709,9 +709,24 @@ func (s *Store) SaveExecution(exec *Execution) error {
 	// The period queries (GetExecutionsInPeriod, GetBriefMetrics) filter on
 	// this column against Go time.Time bounds — letting SQLite pick the
 	// timestamp raced the caller's bounds under load (GH-4332).
+	//
+	// GH-5310: both createdAt and completedAt are normalized to UTC before
+	// binding. completed_at is already only ever written via SQL
+	// `CURRENT_TIMESTAMP` elsewhere (UTC, offset-less text) — see
+	// GetExecutionsForReceipts's GH-5308 note — but callers that hand
+	// SaveExecution a pre-set exec.CompletedAt (tests, migrations) must match
+	// that same on-disk layout, or the two timestamp columns on one row end
+	// up in different zones and any future query joining them is off by the
+	// host's UTC offset.
 	createdAt := exec.CreatedAt
 	if createdAt.IsZero() {
 		createdAt = time.Now()
+	}
+	createdAt = createdAt.UTC()
+	var completedAt *time.Time
+	if exec.CompletedAt != nil {
+		ca := exec.CompletedAt.UTC()
+		completedAt = &ca
 	}
 	return s.withRetry("SaveExecution", func() error {
 		_, err := s.db.Exec(`
@@ -722,7 +737,7 @@ func (s *Store) SaveExecution(exec *Execution) error {
 				task_source_adapter, task_source_issue_id, task_labels,
 				approval_request_id, effort_level, complexity_level, is_canary)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		`, exec.ID, exec.TaskID, exec.ProjectPath, exec.Status, exec.Output, exec.Error, exec.DurationMs, exec.PRUrl, exec.CommitSHA, createdAt, exec.CompletedAt,
+		`, exec.ID, exec.TaskID, exec.ProjectPath, exec.Status, exec.Output, exec.Error, exec.DurationMs, exec.PRUrl, exec.CommitSHA, createdAt, completedAt,
 			exec.TokensInput, exec.TokensOutput, exec.TokensTotal, exec.TokensCacheRead, exec.TokensCacheWrite,
 			exec.EstimatedCostUSD, exec.FilesChanged, exec.LinesAdded, exec.LinesRemoved, exec.ModelName,
 			exec.TaskTitle, exec.TaskDescription, exec.TaskBranch, exec.TaskBaseBranch, exec.TaskCreatePR, exec.TaskVerbose,
@@ -2072,15 +2087,21 @@ type BriefQuery struct {
 
 // GetExecutionsInPeriod retrieves executions within the specified time range.
 // If query.Projects is non-empty, results are filtered to those projects only.
+//
+// GH-5310: query.Start/End are normalized to UTC before binding — created_at
+// is now always written in UTC (SaveExecution), so an un-normalized local
+// bound would carry a different on-disk text layout than the rows it's being
+// compared against, silently skewing the window by the host's UTC offset.
 func (s *Store) GetExecutionsInPeriod(query BriefQuery) ([]*Execution, error) {
 	var rows *sql.Rows
 	var err error
+	start, end := query.Start.UTC(), query.End.UTC()
 
 	if len(query.Projects) > 0 {
 		// Build placeholders for IN clause
 		placeholders := ""
 		args := make([]interface{}, 0, len(query.Projects)+2)
-		args = append(args, query.Start, query.End)
+		args = append(args, start, end)
 		for i, p := range query.Projects {
 			if i > 0 {
 				placeholders += ","
@@ -2101,7 +2122,7 @@ func (s *Store) GetExecutionsInPeriod(query BriefQuery) ([]*Execution, error) {
 			FROM executions
 			WHERE created_at >= ? AND created_at < ?
 			ORDER BY created_at DESC
-		`, query.Start, query.End)
+		`, start, end)
 	}
 	if err != nil {
 		return nil, err
@@ -2335,12 +2356,16 @@ func (s *Store) ResolveOrphanedRunningExecution(id, prURL string) error {
 // stalled, rate_limited, infra, superseded, decomposed, canceled) are
 // excluded from the rate denominator. TotalTasks remains COUNT(*) as a
 // volume stat and is NOT the SuccessRate denominator.
+//
+// GH-5310: query.Start/End are normalized to UTC before binding — see
+// GetExecutionsInPeriod's note on why an un-normalized bound skews the
+// window against UTC-written created_at rows.
 func (s *Store) GetBriefMetrics(query BriefQuery) (*BriefMetricsData, error) {
 	var result BriefMetricsData
 
 	var args []interface{}
 	whereClause := "WHERE created_at >= ? AND created_at < ? AND COALESCE(is_canary, 0) = 0"
-	args = append(args, query.Start, query.End)
+	args = append(args, query.Start.UTC(), query.End.UTC())
 
 	if len(query.Projects) > 0 {
 		placeholders := ""
@@ -4156,10 +4181,14 @@ func (s *Store) GetOrCreateDailySession() (*Session, error) {
 
 	if err == sql.ErrNoRows {
 		// Create new session for today
+		// GH-5310: StartedAt is stamped in UTC — EndSession writes ended_at via
+		// SQL CURRENT_TIMESTAMP (UTC), so a local-zone StartedAt would leave
+		// this row in the same mixed-zone state the executions table had
+		// before this fix (started_at/ended_at differing by the host offset).
 		session = Session{
 			ID:        fmt.Sprintf("session-%s-%d", today, time.Now().UnixNano()),
 			Date:      today,
-			StartedAt: time.Now(),
+			StartedAt: time.Now().UTC(),
 		}
 		err = s.withRetry("GetOrCreateDailySession", func() error {
 			_, err := s.db.Exec(`
@@ -4365,7 +4394,12 @@ type WindowedStats struct {
 // that project are counted. See WindowedStats for the exact population and
 // neutral-status handling. GH-4735: replaces lifetime headline numbers,
 // which blend model eras and mismatch aggregate populations.
+//
+// GH-5310: since is normalized to UTC before binding — see
+// GetExecutionsInPeriod's note on why an un-normalized bound skews the
+// window against UTC-written created_at rows.
 func (s *Store) GetWindowedStats(projectPath string, since time.Time) (WindowedStats, error) {
+	since = since.UTC()
 	const cols = `
 		SELECT
 			COALESCE(SUM(estimated_cost_usd), 0),
@@ -5045,10 +5079,16 @@ type AutopilotMetricsRow struct {
 }
 
 // SaveAutopilotMetrics persists an autopilot metrics snapshot to SQLite.
+//
+// GH-5310: row.SnapshotAt is normalized to UTC at bind time so callers don't
+// each have to remember to do it — PruneAutopilotMetrics's cutoff and
+// GetLatestAutopilotMetrics's ORDER BY snapshot_at both assume the column is
+// uniformly UTC on disk.
 func (s *Store) SaveAutopilotMetrics(row *AutopilotMetricsRow) error {
 	tokensJSON := marshalMapJSON(row.TokensConsumed)
 	costJSON := marshalMapJSON(row.ExecutionCostUSD)
 	execsJSON := marshalMapJSON(row.ExecutionsByResult)
+	snapshotAt := row.SnapshotAt.UTC()
 
 	return s.withRetry("SaveAutopilotMetrics", func() error {
 		_, err := s.db.Exec(`
@@ -5060,7 +5100,7 @@ func (s *Store) SaveAutopilotMetrics(row *AutopilotMetricsRow) error {
 				tokens_consumed_json, execution_cost_usd_json, executions_by_result_json
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`,
-			row.SnapshotAt,
+			snapshotAt,
 			row.IssuesSuccess, row.IssuesFailed, row.IssuesRateLimited,
 			row.PRsMerged, row.PRsFailed, row.PRsConflicting,
 			row.CircuitBreakerTrips, row.APIErrorsTotal, row.APIErrorRate,
@@ -5146,8 +5186,12 @@ func (s *Store) LatestAutopilotMetrics() (*AutopilotMetricsRow, error) {
 // PruneExecutionLogs deletes execution log entries older than the given duration.
 // Returns the number of rows deleted. Runs a WAL checkpoint after a large
 // prune (>1000 rows) to reclaim disk space promptly.
+//
+// GH-5310: cutoff is stamped in UTC — execution_logs.timestamp is now always
+// written in UTC (SaveLogEntry), so a local-zone cutoff would carry a
+// different on-disk text layout and skew which rows compare as "older than".
 func (s *Store) PruneExecutionLogs(olderThan time.Duration) (int64, error) {
-	cutoff := time.Now().Add(-olderThan)
+	cutoff := time.Now().UTC().Add(-olderThan)
 	var result sql.Result
 	err := s.withRetry("PruneExecutionLogs", func() error {
 		var execErr error
@@ -5168,8 +5212,13 @@ func (s *Store) PruneExecutionLogs(olderThan time.Duration) (int64, error) {
 }
 
 // PruneAutopilotMetrics deletes snapshots older than the given duration.
+//
+// GH-5310: cutoff is stamped in UTC — autopilot_metrics.snapshot_at is now
+// always written in UTC (SaveAutopilotMetrics), so a local-zone cutoff would
+// carry a different on-disk text layout and skew which rows compare as
+// "older than".
 func (s *Store) PruneAutopilotMetrics(olderThan time.Duration) (int64, error) {
-	cutoff := time.Now().Add(-olderThan)
+	cutoff := time.Now().UTC().Add(-olderThan)
 	var result sql.Result
 	err := s.withRetry("PruneAutopilotMetrics", func() error {
 		var execErr error
@@ -5253,7 +5302,13 @@ type LogEntry struct {
 }
 
 // SaveLogEntry persists an execution log entry and notifies all subscribers.
+//
+// GH-5310: entry.Timestamp is normalized to UTC before binding (and the
+// caller's struct is updated in place, so subscribers fanned out below see
+// the same value that was persisted). PruneExecutionLogs's cutoff assumes
+// the column is uniformly UTC on disk.
 func (s *Store) SaveLogEntry(entry *LogEntry) error {
+	entry.Timestamp = entry.Timestamp.UTC()
 	err := s.withRetry("SaveLogEntry", func() error {
 		result, err := s.db.Exec(`
 			INSERT INTO execution_logs (execution_id, timestamp, level, message, component)

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -5330,8 +5330,13 @@ func TestPruneExecutionLogs(t *testing.T) {
 	}
 	defer func() { _ = store.Close() }()
 
-	old := time.Now().Add(-2 * time.Hour)
-	recent := time.Now().Add(-10 * time.Minute)
+	// GH-5310: execution_logs.timestamp is always written in UTC (SaveLogEntry
+	// normalizes it at bind time), so these direct inserts — which bypass
+	// SaveLogEntry — must normalize to UTC too, or they simulate a row shape
+	// production can no longer produce and the comparison against
+	// PruneExecutionLogs's UTC cutoff can misjudge on a non-UTC test host.
+	old := time.Now().Add(-2 * time.Hour).UTC()
+	recent := time.Now().Add(-10 * time.Minute).UTC()
 
 	// Insert two old entries and one recent entry directly.
 	_, err = store.db.Exec(`INSERT INTO execution_logs (timestamp, level, message, component) VALUES (?, 'info', 'old1', 'test')`, old)
@@ -6793,5 +6798,137 @@ func TestReclassifySupersededForRearm_DemotesToFailedAndUnblocksRetry(t *testing
 	}
 	if otherExec.Status != "superseded" {
 		t.Errorf("expected the other task's superseded row to remain untouched, got status %q", otherExec.Status)
+	}
+}
+
+// TestGH5310_UTCTimestamps_NonUTCHost is GH-5310's follow-up to the GH-5308
+// reaper/receipts fix: every Go-written DB timestamp in this package must be
+// stamped in UTC, not just the two sites #5309 fixed. Before this fix,
+// executions.created_at (SaveExecution's Go-side fallback and caller-supplied
+// paths), the BriefQuery/since bounds compared against it, execution_logs.timestamp,
+// and autopilot_metrics.snapshot_at were all bound in whatever zone
+// time.Local happened to be — while completed_at (via CURRENT_TIMESTAMP) was
+// always UTC. On a UTC host (CI, the founder box) that mismatch is invisible:
+// local time.Now() and its .UTC() equivalent format identically. Table-driven
+// across a positive (+2) and a negative (-7) offset so the fix isn't pinned
+// to only one side of UTC.
+func TestGH5310_UTCTimestamps_NonUTCHost(t *testing.T) {
+	for _, offset := range []int{2, -7} {
+		t.Run(fmt.Sprintf("offset=%+d", offset), func(t *testing.T) {
+			withFixedLocalOffset(t, offset)
+
+			store, err := NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			now := time.Now() // local, offset by withFixedLocalOffset above
+			completedAt := now
+
+			// SaveExecution: CreatedAt left zero (exercises the Go time.Now()
+			// fallback) and a caller-supplied local CompletedAt — both must
+			// land on disk normalized to UTC.
+			if err := store.SaveExecution(&Execution{
+				ID: "gh5310-exec", TaskID: "GH-5310", ProjectPath: "/p",
+				Status: "completed", CompletedAt: &completedAt, EstimatedCostUSD: 1.00,
+			}); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			// GetExecutionsInPeriod: a +/-1h window around "now" must find the
+			// just-written row.
+			periodRows, err := store.GetExecutionsInPeriod(BriefQuery{
+				Start: now.Add(-1 * time.Hour), End: now.Add(1 * time.Hour),
+			})
+			if err != nil {
+				t.Fatalf("GetExecutionsInPeriod: %v", err)
+			}
+			if len(periodRows) != 1 || periodRows[0].ID != "gh5310-exec" {
+				t.Fatalf("GetExecutionsInPeriod: expected the just-written row inside a +/-1h window, got %d rows: %+v", len(periodRows), periodRows)
+			}
+
+			// GetBriefMetrics: same window must count it.
+			metrics, err := store.GetBriefMetrics(BriefQuery{
+				Start: now.Add(-1 * time.Hour), End: now.Add(1 * time.Hour),
+			})
+			if err != nil {
+				t.Fatalf("GetBriefMetrics: %v", err)
+			}
+			if metrics.TotalTasks != 1 {
+				t.Errorf("GetBriefMetrics: TotalTasks = %d, want 1", metrics.TotalTasks)
+			}
+
+			// GetWindowedStats: since = now - 1h must include it.
+			ws, err := store.GetWindowedStats("", now.Add(-1*time.Hour))
+			if err != nil {
+				t.Fatalf("GetWindowedStats: %v", err)
+			}
+			if ws.AttemptTotal != 1 {
+				t.Errorf("GetWindowedStats: AttemptTotal = %d, want 1", ws.AttemptTotal)
+			}
+
+			// Read-back: created_at and completed_at on this one row must be
+			// within seconds of each other. Pre-fix, created_at was stamped in
+			// the fixed-offset local zone while completed_at came from a
+			// caller-supplied local value too — normalizing only one side (as
+			// #5309 did for the two known sites) leaves this row's own two
+			// columns offset from each other by the full zone difference.
+			exec, err := store.GetExecution("gh5310-exec")
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			if exec.CompletedAt == nil {
+				t.Fatal("expected CompletedAt to be set")
+			}
+			if d := exec.CompletedAt.Sub(exec.CreatedAt); d < -5*time.Second || d > 5*time.Second {
+				t.Errorf("created_at and completed_at differ by %v, want within a few seconds (offset=%+d)", d, offset)
+			}
+
+			// Log cleanup: a fresh entry must survive a 1h prune; a 2h-old one
+			// must not.
+			if err := store.SaveLogEntry(&LogEntry{ExecutionID: "gh5310-exec", Timestamp: now, Level: "info", Message: "fresh", Component: "test"}); err != nil {
+				t.Fatalf("SaveLogEntry (fresh): %v", err)
+			}
+			if err := store.SaveLogEntry(&LogEntry{ExecutionID: "gh5310-exec", Timestamp: now.Add(-2 * time.Hour), Level: "info", Message: "old", Component: "test"}); err != nil {
+				t.Fatalf("SaveLogEntry (old): %v", err)
+			}
+			deletedLogs, err := store.PruneExecutionLogs(time.Hour)
+			if err != nil {
+				t.Fatalf("PruneExecutionLogs: %v", err)
+			}
+			if deletedLogs != 1 {
+				t.Errorf("PruneExecutionLogs: deleted = %d, want 1 (only the 2h-old entry)", deletedLogs)
+			}
+			var remainingLogs int
+			if err := store.db.QueryRow(`SELECT COUNT(*) FROM execution_logs`).Scan(&remainingLogs); err != nil {
+				t.Fatalf("count execution_logs: %v", err)
+			}
+			if remainingLogs != 1 {
+				t.Errorf("remaining execution_logs = %d, want 1 (the fresh entry)", remainingLogs)
+			}
+
+			// Metrics cleanup: same shape, autopilot_metrics.snapshot_at.
+			if err := store.SaveAutopilotMetrics(&AutopilotMetricsRow{SnapshotAt: now}); err != nil {
+				t.Fatalf("SaveAutopilotMetrics (fresh): %v", err)
+			}
+			if err := store.SaveAutopilotMetrics(&AutopilotMetricsRow{SnapshotAt: now.Add(-2 * time.Hour)}); err != nil {
+				t.Fatalf("SaveAutopilotMetrics (old): %v", err)
+			}
+			deletedMetrics, err := store.PruneAutopilotMetrics(time.Hour)
+			if err != nil {
+				t.Fatalf("PruneAutopilotMetrics: %v", err)
+			}
+			if deletedMetrics != 1 {
+				t.Errorf("PruneAutopilotMetrics: deleted = %d, want 1 (only the 2h-old snapshot)", deletedMetrics)
+			}
+			var remainingMetrics int
+			if err := store.db.QueryRow(`SELECT COUNT(*) FROM autopilot_metrics`).Scan(&remainingMetrics); err != nil {
+				t.Fatalf("count autopilot_metrics: %v", err)
+			}
+			if remainingMetrics != 1 {
+				t.Errorf("remaining autopilot_metrics = %d, want 1 (the fresh snapshot)", remainingMetrics)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up from the post-merge review of #5308/PR#5309. That PR fixed the two sites flagged in review (`ReapOrphanedClaims` cutoff, `GetExecutionsForReceipts` window) but left a broader instance of the same class: a row's own columns could still mix zones. `executions.created_at` was written in Go-local time while `executions.completed_at` is written via SQL `CURRENT_TIMESTAMP` (UTC) — nothing queries both today, but any future duration/ordering query would be off by the host's UTC offset. The same split existed independently and unflagged in `sessions`: `started_at` (Go-local) vs `EndSession`'s `ended_at` (`CURRENT_TIMESTAMP`).

- Normalized every Go-written DB timestamp to UTC **at the write boundary**: `SaveExecution` (both `CreatedAt` fallback and caller-supplied `CreatedAt`/`CompletedAt`), `SaveLogEntry`, `SaveAutopilotMetrics`, `GetOrCreateDailySession`.
- Normalized every **read-side bound** compared against those UTC-written columns in the same PR, so main never has a mixed-normalization window: `GetExecutionsInPeriod`, `GetBriefMetrics`, `GetWindowedStats`, `PruneExecutionLogs`, `PruneAutopilotMetrics`.
- Also normalized `internal/executor/worktree.go`'s `PooledWorktree.CreatedAt` (in-memory only, not DB-persisted, but explicitly called out in the task audit for consistency).
- `TestPruneExecutionLogs` seeded rows via a raw `db.Exec(INSERT ...)` that bypassed `SaveLogEntry`'s new normalization — fixed to stamp UTC directly, matching what the real write path now always produces.
- Added `TestGH5310_UTCTimestamps_NonUTCHost`, covering `SaveExecution` + `GetExecutionsInPeriod`/`GetBriefMetrics`/`GetWindowedStats` (±1h window) and log/metrics prune (1h cutoff, fresh-survives/2h-old-deleted) under both a `+2` and a `-7` fixed UTC offset, plus a read-back assertion that `created_at`/`completed_at` land within seconds of each other on one row.

### Review note — `grep -n 'time.Now()' internal/memory/store.go`, remaining hits and why each is not a bare DB bind

- `:723` `createdAt` fallback — normalized via `.UTC()` two lines later before bind.
- `:1204`, `:1219` — already `.UTC()` at bind (pre-existing, correct).
- `:3205` `filterAndSortStale` cutoff — compared in Go against already-parsed `time.Time` values, never bound into SQL; Go time comparisons are location-agnostic (GH-4392 precedent).
- `:3553` `ReapOrphanedClaims` cutoff — already `.UTC()` at bind (#5309).
- `:4167` `today` — formatted into `sessions.date`, an exact-match TEXT key, not a DATETIME range bind; local calendar-day boundary is existing product behavior, out of scope here.
- `:4189` `UnixNano()` — opaque uniqueness suffix in a generated session ID string, not a DB timestamp bind.
- `:5194`, `:5221` — `Prune*` cutoffs, now `.UTC()` (this change).

## Test plan

- [x] `go build ./...`
- [x] `TZ=UTC go test ./internal/memory ./internal/executor -count=1` — green
- [x] `TZ=Europe/Berlin go test ./internal/memory ./internal/executor -count=1` — green
- [x] `TZ=America/Los_Angeles go test ./internal/memory ./internal/executor -count=1` — green
- [x] Mutation-checked: reverting the `SaveExecution` `createdAt.UTC()` normalization and, separately, the `PruneExecutionLogs` cutoff `.UTC()` each independently make `TestGH5310_UTCTimestamps_NonUTCHost` fail at both offsets, then re-verified green after restoring the fix.

## Refs

- #5308 / PR#5309 (reaper + receipts fix; `withFixedLocalOffset` helper).
- Memory: `.agent/knowledge/memories/pitfalls/go-time-cutoff-vs-sqlite-current-timestamp-timezone.md` (updated with this follow-up).