### PR TITLE
GH-5312: docs: dual-push docs sync to GitHub qf-studio/pilot-docs alongside GitLab (migration step 1)

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,4 +1,14 @@
-name: Sync Docs to GitLab
+name: Sync Docs (GitLab + GitHub)
+
+# Docs deploy pipeline is migrating off GitLab (quant-flow/pilot-docs) to
+# GitHub (qf-studio/pilot-docs). During the transition this workflow
+# dual-pushes docs/ to both remotes: GitLab keeps deploying
+# pilot.quantflow.studio until the AWS deploy target exists; GitHub
+# receives the same content + prod tag so its GHCR image build
+# (qf-studio/pilot-docs .github/workflows/build.yml, sourced from
+# docs/.github/workflows/build.yml here) runs. Both legs are independent
+# steps — a failure in one does not hide a failure in the other, and the
+# job fails if either fails. Drop the GitLab leg once the AWS leg lands.
 
 on:
   push:
@@ -25,6 +35,7 @@ jobs:
           ssh-keyscan -t ed25519 gitlab.com >> ~/.ssh/known_hosts
 
       - name: Sync docs/ to GitLab
+        id: gitlab_sync
         run: |
           WORK=$(mktemp -d)
           git clone git@gitlab.com:quant-flow/pilot-docs.git "$WORK"
@@ -66,6 +77,8 @@ jobs:
             git tag "$DEPLOY_TAG"
             git push origin "$DEPLOY_TAG"
             echo "Tagged ${DEPLOY_TAG} to trigger deploy"
+            # Shared with the GitHub leg so the same tag lands on both remotes
+            echo "deploy_tag=${DEPLOY_TAG}" >> "$GITHUB_OUTPUT"
 
             # Prune old prod-* tags on GitLab, keeping the newest 10 (SOP
             # gitlab-space-reclaim.md Step 3) — never the tag just pushed.
@@ -80,6 +93,77 @@ jobs:
               | sort -V | head -n -10 \
               | while read -r t; do
                   echo "Pruning stale GitLab tag: ${t}"
+                  git push origin ":refs/tags/${t}" || true
+                done || true
+          fi
+
+      - name: Check GitHub PAT
+        id: has_pat
+        if: always()
+        env:
+          HAS_PAT: ${{ secrets.PILOT_DOCS_PAT != '' }}
+        run: |
+          echo "has_pat=$HAS_PAT" >> "$GITHUB_OUTPUT"
+          if [ "$HAS_PAT" != "true" ]; then
+            echo "::warning::PILOT_DOCS_PAT not set — skipping GitHub docs sync leg (qf-studio/pilot-docs)"
+          fi
+
+      - name: Sync docs/ to GitHub
+        id: github_sync
+        if: always() && steps.has_pat.outputs.has_pat == 'true'
+        env:
+          PILOT_DOCS_PAT: ${{ secrets.PILOT_DOCS_PAT }}
+          DEPLOY_TAG: ${{ steps.gitlab_sync.outputs.deploy_tag }}
+        run: |
+          WORK=$(mktemp -d)
+          git clone "https://x-access-token:${PILOT_DOCS_PAT}@github.com/qf-studio/pilot-docs.git" "$WORK"
+
+          # Preserve GitHub-target-only infrastructure files (Dockerfile may
+          # diverge from the GitLab target's docker/ over time)
+          BACKUP=$(mktemp -d)
+          [ -d "$WORK/docker" ] && cp -a "$WORK/docker" "$BACKUP/docker"
+
+          # Remove old content (except .git), copy fresh docs
+          find "$WORK" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+          cp -a docs/. "$WORK"/
+
+          # Remove dirs that should never be synced to GitHub
+          rm -rf "$WORK/.next" "$WORK/node_modules" "$WORK/.idea" "$WORK/~"
+
+          # Restore GitHub-target-only infrastructure files
+          [ -d "$BACKUP/docker" ] && rm -rf "$WORK/docker" && cp -a "$BACKUP/docker" "$WORK/docker"
+
+          cd "$WORK"
+          git config user.name "Pilot CI"
+          git config user.email "ci@quantflow.studio"
+          git add -A
+
+          # Push content if there are changes
+          if git diff --cached --quiet; then
+            echo "No changes to sync"
+          else
+            git commit -m "sync: docs from pilot@${GITHUB_SHA::7}"
+            git push origin main
+          fi
+
+          # Push the same unique prod tag the GitLab leg used, so both
+          # remotes deploy/build off an identical tag. If the GitLab leg
+          # didn't run/didn't produce a tag (no v* tag found), skip.
+          if [ -n "$DEPLOY_TAG" ]; then
+            git tag "$DEPLOY_TAG"
+            git push origin "$DEPLOY_TAG"
+            echo "Tagged ${DEPLOY_TAG} to trigger GitHub image build"
+
+            # Prune old prod-* tags on GitHub, keeping the newest 10 — never
+            # the tag just pushed. Same `|| true` rationale as the GitLab
+            # leg: grep -v exits 1 when it filters out every line (e.g. the
+            # first sync, before 10 old tags exist).
+            git ls-remote --tags origin 'refs/tags/prod-*' \
+              | awk -F/ '{print $3}' \
+              | grep -v "^${DEPLOY_TAG}\$" \
+              | sort -V | head -n -10 \
+              | while read -r t; do
+                  echo "Pruning stale GitHub tag: ${t}"
                   git push origin ":refs/tags/${t}" || true
                 done || true
           fi

--- a/docs/.dockerignore
+++ b/docs/.dockerignore
@@ -1,6 +1,7 @@
 node_modules
 .next
 .git
+.github
 .gitignore
 Dockerfile
 .dockerignore

--- a/docs/.github/workflows/build.yml
+++ b/docs/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+name: Build image
+
+# Builds the docs site image and pushes it to GHCR on every main push and on
+# prod-* tags (same tag contract the GitLab pipeline used). The deploy leg is
+# intentionally absent: the AWS target is owned by infra (Nelya) and will be
+# added once the hosting shape / registry / trigger are agreed.
+#
+# Source of truth for this file is qf-studio/pilot docs/.github/workflows/ —
+# sync-docs.yml replaces this repo's tree from there on every docs change.
+
+on:
+  push:
+    branches: [main]
+    tags: ['prod-*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/qf-studio/pilot-docs
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          build-args: NODE_ENV=production
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5312.

Closes #5312

## Changes

GitHub Issue GH-5312: docs: dual-push docs sync to GitHub qf-studio/pilot-docs alongside GitLab (migration step 1)

## What

The docs repo is moving from GitLab (quant-flow/pilot-docs) to GitHub (https://github.com/qf-studio/pilot-docs — created 2026-09-04, full history mirrored, HEAD ba193a0, plus a seed commit 8233e2c adding the GHCR build workflow). During the transition the docs sync must push to **both** remotes: GitLab keeps deploying pilot.quantflow.studio until the AWS deploy target exists; GitHub receives the same content + prod tag so its image build runs.

Make these changes:

1. In `.github/workflows/sync-docs.yml`, keep the existing GitLab leg unchanged and add a GitHub leg that does the same content sync into a clone of https://github.com/qf-studio/pilot-docs over HTTPS, authenticated with the existing PILOT_DOCS_PAT secret (x-access-token basic auth). Same carve-out for the target's docker/ directory, same commit message format, same unique prod-X.Y.Z-<ts> tag push, same prune-to-newest-10 of stale prod-* tags. No force pushes.
2. The GitHub leg must be skipped with a ::warning when PILOT_DOCS_PAT is empty, using the env HAS_PAT pattern already used in docs-version-sync.yml (secrets.* is illegal inside step-level if: — parse-time rejection). The GitLab leg must still run in that case.
3. Both legs run independently; the job fails if either leg fails (a GitHub failure must not hide a GitLab failure and vice versa). Use separate steps, not one shell block.
4. Add a new file at docs/.github/workflows/build.yml with content identical to the file already on qf-studio/pilot-docs main at commit 8233e2c (path .github/workflows/build.yml there). Reason: the sync replaces the target tree wholesale (everything except .git and docker/), so the workflow must originate from docs/ or the next sync deletes it from GitHub.
5. Add .github to `docs/.dockerignore` so the image build does not copy it.
6. Rename the workflow display name to "Sync Docs (GitLab + GitHub)" and update its header comment to describe the transition.

## Acceptance Criteria

- [ ] A workflow_dispatch run pushes identical content to both remotes; the main tree on each remote equals docs/ (minus the docker/ carve-out).
- [ ] The same prod-X.Y.Z-<ts> tag lands on both remotes; the GitHub "Build image" workflow runs on it.
- [ ] With PILOT_DOCS_PAT unset, the GitLab leg still completes and the log shows the ::warning for the skipped GitHub leg.
- [ ] Stale prod-* tags are pruned on both remotes, never the tag just pushed.
- [ ] No git push --force anywhere.
- [ ] docs/.github/workflows/build.yml matches the seeded file on qf-studio/pilot-docs byte for byte.

## Operator step (not for Pilot)

PILOT_DOCS_PAT is a fine-grained PAT currently scoped to qf-studio/pilot only. The founder must extend it to qf-studio/pilot-docs with Contents read/write and Workflows read/write (the sync pushes a workflow file). Until then the GitHub leg warns and skips. Deploy keys are disabled by org policy, which is why the PAT path is used.

## Files to Modify

- `.github/workflows/sync-docs.yml`
- docs/.github/workflows/build.yml (new)
- `docs/.dockerignore`

## Refs

- Reference: `.agent/system/references/reference_docs_deploy_pipeline.md` (current chain)
- GitHub repo: https://github.com/qf-studio/pilot-docs
- AWS deploy leg is tracked with infra (Nelya) in Slack #infrastructure; out of scope here.

## Complexity Hint

simple

## Planned Steps (execute all in sequence)

- Step 1: **feat(sync-docs): add GitHub dual-push leg with seeded build workflow and dockerignore entry** — Update `.github/workflows/sync-docs.yml` to add a second, independent sync leg targeting `https://github.com/qf-studio/pilot-docs` over HTTPS using `PILOT_DOCS_PAT` (x-access-token basic auth), mirroring the GitLab leg's behavior: same content sync with the `docker/` carve-out, same commit message format, same unique `prod-X.Y.Z-<ts>` tag, same prune-to-newest-10 of stale `prod-*` tags, no `--force`. Guard the GitHub leg with the `HAS_PAT` env pattern from `docs-version-sync.yml` (emit `::warning` and skip when unset — `secrets.*` is illegal in step-level `if:`); the GitLab leg must still run in that case. Legs must be separate steps so a failure in one cannot hide a failure in the other, and the job fails if either fails. Rename the workflow's display name to `Sync Docs (GitLab + GitHub)` and refresh the header comment to describe the transition. Add `docs/.github/workflows/build.yml` as a new file whose contents match byte-for-byte the file at path `.github/workflows/build.yml` on `qf-studio/pilot-docs` main at commit `8233e2c` (fetch it before writing; the wholesale sync would otherwise delete it from the GitHub target on the next run). Add `.github` to `docs/.dockerignore` so the image build does not copy the workflow directory. Verify with a `workflow_dispatch` run that both remotes receive identical content (minus `docker/`), the same prod tag lands on both, and the GitHub "Build image" workflow triggers on the tag.
