### PR TITLE
fix(docs): add missing /getting-started index page

### DIFF
--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -5,6 +5,7 @@ const BASE = 'https://pilot.quantflow.studio'
 // Static priority map — high-traffic pages get higher priority
 const PRIORITY: Record<string, number> = {
   '': 1.0,
+  '/getting-started': 0.9,
   '/getting-started/prerequisites': 0.9,
   '/getting-started/quickstart': 0.9,
   '/getting-started/installation': 0.9,
@@ -17,6 +18,7 @@ const PRIORITY: Record<string, number> = {
 
 const ROUTES = [
   '',
+  '/getting-started',
   '/getting-started/prerequisites',
   '/getting-started/installation',
   '/getting-started/quickstart',

--- a/docs/content/getting-started/_meta.js
+++ b/docs/content/getting-started/_meta.js
@@ -1,4 +1,5 @@
 export default {
+  index: "Overview",
   prerequisites: "Prerequisites",
   installation: "Installation",
   quickstart: "Quick Start",

--- a/docs/content/getting-started/index.mdx
+++ b/docs/content/getting-started/index.mdx
@@ -1,0 +1,37 @@
+import { Callout } from 'nextra/components'
+
+# Getting Started
+
+Everything you need to go from zero to your first Pilot-generated pull request.
+
+## Requirements
+
+To run Pilot, you need:
+
+| Requirement | Description |
+|-------------|-------------|
+| **Claude Code CLI** | Or alternative backend (Qwen Code, OpenCode) — see [Execution Backends](/concepts/execution-backends) |
+| **ANTHROPIC_API_KEY** | API key for Claude (or equivalent for your backend) |
+| **GITHUB_TOKEN** | Or equivalent for your PM adapter (GitLab, Azure DevOps, Linear, Jira) |
+| **Network access** | Outbound to GitHub/GitLab API + Anthropic API |
+
+## Steps
+
+Follow these guides in order:
+
+| Step | Guide | Description |
+|------|-------|-------------|
+| 1 | [Prerequisites](/getting-started/prerequisites) | Install Claude Code and set up a Git hosting token |
+| 2 | [Quick Start](/getting-started/quickstart) | Install Pilot and ship your first PR in 10 minutes |
+| 3 | [Installation](/getting-started/installation) | Detailed install methods — curl script, Homebrew, from source |
+| 4 | [Configuration](/getting-started/configuration) | Full `config.yaml` reference — auth, adapters, environment variables |
+
+<Callout type="info">
+New to Pilot? Start with [Prerequisites](/getting-started/prerequisites), then follow the [Quick Start](/getting-started/quickstart) guide to get a working setup end to end.
+</Callout>
+
+## Next Steps
+
+- [Deployment](/deployment) — Run Pilot in production (Docker, Kubernetes, cloud)
+- [Context Intelligence](/navigator) — Reduce token usage with structured context
+- [Autopilot](/features/autopilot) — Automatic CI monitoring and merge


### PR DESCRIPTION
## Summary
- Adds `docs/content/getting-started/index.mdx`, following the existing `index.mdx` + `_meta.js` convention used by `deployment/` and `navigator/`, fixing the `/getting-started` 404
- Links prerequisites -> quickstart -> installation -> configuration in order
- Adds `index: "Overview"` to `docs/content/getting-started/_meta.js`
- Adds `/getting-started` to `docs/app/sitemap.ts` (`ROUTES` and `PRIORITY`), which enumerates routes explicitly

## Test plan
- [x] `npm run build` in `docs/` completes successfully
- [x] `.next/server/app/getting-started.html` is generated (previously 404)
- [x] `/getting-started` route confirmed in build output