### PR TITLE
GH-5326: feat(review-triggers): add shared trusted-reviewer predicate

### DIFF
--- a/.agent/tasks/gh-5326.md
+++ b/.agent/tasks/gh-5326.md
@@ -1,0 +1,10 @@
+# GH-5326
+
+**Created:** 2026-09-06
+
+## Problem
+
+In controller.go, add `isTrustedReviewer(login string) bool` — returns false when login matches the bot login (case-insensitive) or a `[bot]`/`-bot` suffix pattern, true otherwise. Replace the inline pattern used in `hasChangesRequested` (~line 4258) with this predicate, and add the check to `OnReviewRequested` (~line 2712) before the state transition. Preserve the GH-5266 cutoff logic and the rule that COMMENTED does not supersede CHANGES_REQUESTED.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2714,6 +2714,17 @@ func (c *Controller) OnReviewRequested(prNumber int, action, state, reviewer str
 		return
 	}
 
+	// GH-5326: ignore changes_requested from bot/self reviewers — only a
+	// trusted human reviewer's request should be able to drive the pipeline
+	// into StageReviewRequested.
+	if !c.isTrustedReviewer(reviewer) {
+		c.log.Info("ignoring changes_requested from untrusted reviewer",
+			"pr", prNumber,
+			"reviewer", reviewer,
+		)
+		return
+	}
+
 	// Check if review feedback handling is enabled
 	if c.config.ReviewFeedback == nil || !c.config.ReviewFeedback.Enabled {
 		c.log.Info("review feedback handling disabled, ignoring changes_requested",
@@ -4211,6 +4222,36 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 	return nil
 }
 
+// isTrustedReviewer reports whether login belongs to a human reviewer whose
+// review state should be able to gate the pipeline (via hasChangesRequested)
+// or trigger the OnReviewRequested changes_requested transition. It returns
+// false for the authenticated Pilot bot itself — matched case-insensitively
+// against the cached login from getBotLogin, since GitHub login comparisons
+// are case-insensitive — and for any other automation account following
+// GitHub's "[bot]" suffix convention or the "-bot" naming convention. All
+// other logins are treated as trusted. GH-5326: this replaces the ad hoc
+// "[bot]"/"-bot" check that was previously duplicated at both call sites and
+// extends it to also exclude self-reviews from the Pilot bot's own login.
+//
+// Only the already-cached bot login is consulted (no network fetch): this
+// predicate is called from OnReviewRequested, a synchronous webhook handler
+// with no context.Context to thread through for an on-demand
+// getBotLogin(ctx) call. If the cache hasn't been populated yet, the bot-self
+// check is simply skipped for that call — the "[bot]"/"-bot" suffix check
+// still applies.
+func (c *Controller) isTrustedReviewer(login string) bool {
+	if strings.Contains(login, "[bot]") || strings.HasSuffix(login, "-bot") {
+		return false
+	}
+	c.mu.RLock()
+	botLogin := c.cachedBotLogin
+	c.mu.RUnlock()
+	if botLogin != "" && strings.EqualFold(login, botLogin) {
+		return false
+	}
+	return true
+}
+
 // hasChangesRequested checks if a PR has unresolved "changes requested" reviews.
 // It filters out bot reviews and only considers reviews submitted after the PR
 // was created.
@@ -4254,8 +4295,9 @@ func (c *Controller) hasChangesRequested(ctx context.Context, prState *PRState, 
 	// allowed to overwrite it; COMMENTED (or any other state) is ignored.
 	latestState := make(map[string]string)
 	for _, r := range reviews {
-		// Skip bot reviews (self-review)
-		if strings.Contains(r.User.Login, "[bot]") || strings.HasSuffix(r.User.Login, "-bot") {
+		// GH-5326: skip bot reviews (self-review or other automation) via the
+		// shared isTrustedReviewer predicate.
+		if !c.isTrustedReviewer(r.User.Login) {
 			continue
 		}
 

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6810,6 +6810,68 @@ func TestController_OnReviewRequested_UntrackedPR(t *testing.T) {
 	}
 }
 
+func TestController_IsTrustedReviewer(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.cachedBotLogin = "pilot-bot"
+
+	tests := []struct {
+		name  string
+		login string
+		want  bool
+	}{
+		{"bracket bot suffix", "dependabot[bot]", false},
+		{"dash bot suffix", "ci-bot", false},
+		{"matches cached bot login exact case", "pilot-bot", false},
+		{"matches cached bot login case-insensitive", "Pilot-Bot", false},
+		{"human reviewer", "alice", true},
+		{"human reviewer resembling bot substring but not suffix", "robot-wrangler", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.isTrustedReviewer(tt.login); got != tt.want {
+				t.Errorf("isTrustedReviewer(%q) = %v, want %v", tt.login, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestController_OnReviewRequested_IgnoresBotReviewer(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	cfg.ReviewFeedback = &ReviewFeedbackConfig{Enabled: true, MaxIterations: 3}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.cachedBotLogin = "pilot-bot"
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", "")
+
+	// A "[bot]" suffixed reviewer must not drive the PR into review_requested.
+	c.OnReviewRequested(42, "submitted", "changes_requested", "dependabot[bot]")
+	pr, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("PR should be tracked")
+	}
+	if pr.Stage == StageReviewRequested {
+		t.Error("stage should NOT be review_requested for a [bot]-suffixed reviewer")
+	}
+
+	// The Pilot bot's own login (case-insensitive) must also be ignored.
+	c.OnReviewRequested(42, "submitted", "changes_requested", "Pilot-Bot")
+	pr, _ = c.GetPRState(42)
+	if pr.Stage == StageReviewRequested {
+		t.Error("stage should NOT be review_requested for the bot's own (cached) login")
+	}
+
+	// A trusted human reviewer should still drive the transition.
+	c.OnReviewRequested(42, "submitted", "changes_requested", "alice")
+	pr, _ = c.GetPRState(42)
+	if pr.Stage != StageReviewRequested {
+		t.Errorf("stage = %v, want %v for a trusted human reviewer", pr.Stage, StageReviewRequested)
+	}
+}
+
 func TestController_HasChangesRequested_FilterByTime(t *testing.T) {
 	// Reviews submitted before PR tracking should be ignored
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5326.

Closes #5326

## Changes

In controller.go, add `isTrustedReviewer(login string) bool` — returns false when login matches the bot login (case-insensitive) or a `[bot]`/`-bot` suffix pattern, true otherwise. Replace the inline pattern used in `hasChangesRequested` (~line 4258) with this predicate, and add the check to `OnReviewRequested` (~line 2712) before the state transition. Preserve the GH-5266 cutoff logic and the rule that COMMENTED does not supersede CHANGES_REQUESTED.