### PR TITLE
GH-5327: feat(review-triggers): add stage eligibility guard for review triggers

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2728,6 +2728,15 @@ func (c *Controller) OnReviewRequested(prNumber int, action, state, reviewer str
 	// c.mu has since been released, so taking prState.mu here keeps the no-deadlock
 	// invariant (prState.mu before c.mu, never the reverse).
 	prState.mu.Lock()
+	if !reviewTriggerEligible(prState.Stage) {
+		c.log.Debug("review trigger rejected: stage not eligible",
+			"pr", prNumber,
+			"stage", prState.Stage,
+			"reviewer", reviewer,
+		)
+		prState.mu.Unlock()
+		return
+	}
 	c.log.Warn("Changes requested on PR, transitioning to review_requested stage",
 		"pr", prNumber,
 		"reviewer", reviewer,
@@ -2736,6 +2745,40 @@ func (c *Controller) OnReviewRequested(prNumber int, action, state, reviewer str
 	prState.Stage = StageReviewRequested
 	c.persistPRState(prState)
 	prState.mu.Unlock()
+}
+
+// reviewTriggerEligible reports whether a PR at the given stage may be
+// transitioned to StageReviewRequested in response to a changes_requested
+// review — via either the webhook path (OnReviewRequested) or the
+// polling-mode hasChangesRequested check below. GH-5327: this is an
+// include-list, not an exclude-list, so a stage this switch doesn't
+// recognize (e.g. a new PRStage added later without updating this
+// function) fails closed and is rejected rather than silently treated as
+// eligible.
+//
+// Verified against every PRStage defined in types.go:
+//   - StagePRCreated, StageWaitingCI, StageCIPassed, StageCIFailed: eligible.
+//     The PR is still mid-pipeline, before any approval/merge/release
+//     decision has been made, so routing it to StageReviewRequested is safe.
+//   - StageAwaitApproval: excluded. A human approval decision is already
+//     in flight; rerouting here would race SetApprovalDecision.
+//   - StageMerging: excluded. handleMerging already holds merges on
+//     hasChangesRequested itself (#5264/#5269) — that is a hold check, not
+//     a transition, and is untouched by this guard.
+//   - StageReleasing, StageMerged, StagePostMergeCI: excluded (terminal —
+//     the PR has already landed on the default branch; review feedback can
+//     no longer change its content).
+//   - StageReviewRequested: excluded. Already there; re-triggering is a
+//     no-op at best.
+//   - StageFailed: excluded (terminal failure; ProcessPR treats it as a
+//     dead end).
+func reviewTriggerEligible(stage PRStage) bool {
+	switch stage {
+	case StagePRCreated, StageWaitingCI, StageCIPassed, StageCIFailed:
+		return true
+	default:
+		return false
+	}
 }
 
 // ProcessPR processes a single PR through the state machine.
@@ -8796,8 +8839,9 @@ func (c *Controller) processAllPRs(ctx context.Context) {
 			c.redriveFailedPRForBaseRetarget(ctx, pr, ghPR)
 
 			// Detect changes_requested reviews in polling mode (webhook mode uses OnReviewRequested).
-			// Only check PRs that haven't already been transitioned to review_requested.
-			if pr.Stage != StageReviewRequested && pr.Stage != StageFailed &&
+			// GH-5327: reviewTriggerEligible replaces the old two-stage exclusion with
+			// the same include-list guard OnReviewRequested uses.
+			if reviewTriggerEligible(pr.Stage) &&
 				c.config.ReviewFeedback != nil && c.config.ReviewFeedback.Enabled {
 				// GH-5266: ghPR is the same live fetch used above for
 				// checkExternalMergeOrClose/reAdoptHeldRebasePR — reuse it so the

--- a/internal/autopilot/gh5327_test.go
+++ b/internal/autopilot/gh5327_test.go
@@ -1,0 +1,93 @@
+package autopilot
+
+import (
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestReviewTriggerEligible_TableDriven is GH-5327: reviewTriggerEligible
+// replaces the old ad-hoc two-stage exclusion (StageReviewRequested,
+// StageFailed) with an include-list that fails closed. Every PRStage
+// defined in types.go must be covered here so an unrecognized future stage
+// (simulated below via an unexported literal) is proven to reject, not
+// silently pass through as eligible.
+func TestReviewTriggerEligible_TableDriven(t *testing.T) {
+	tests := []struct {
+		stage PRStage
+		want  bool
+	}{
+		{StagePRCreated, true},
+		{StageWaitingCI, true},
+		{StageCIPassed, true},
+		{StageCIFailed, true},
+		{StageAwaitApproval, false},
+		{StageMerging, false},
+		{StageMerged, false},
+		{StagePostMergeCI, false},
+		{StageReleasing, false},
+		{StageReviewRequested, false},
+		{StageFailed, false},
+		{PRStage("some_future_stage"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.stage), func(t *testing.T) {
+			if got := reviewTriggerEligible(tt.stage); got != tt.want {
+				t.Errorf("reviewTriggerEligible(%q) = %v, want %v", tt.stage, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestOnReviewRequested_StageGuard_TableDriven verifies OnReviewRequested's
+// webhook path applies the same reviewTriggerEligible guard: a PR sitting in
+// an ineligible stage (e.g. StageAwaitApproval or StageMerging) must not be
+// yanked into StageReviewRequested by a changes_requested review, while a PR
+// in an eligible stage still transitions as before.
+func TestOnReviewRequested_StageGuard_TableDriven(t *testing.T) {
+	tests := []struct {
+		name       string
+		startStage PRStage
+		wantStage  PRStage
+	}{
+		{"eligible stage still transitions", StageWaitingCI, StageReviewRequested},
+		{"awaiting approval rejects the transition", StageAwaitApproval, StageAwaitApproval},
+		{"merging rejects the transition", StageMerging, StageMerging},
+		{"releasing rejects the transition", StageReleasing, StageReleasing},
+		{"already review_requested rejects the transition", StageReviewRequested, StageReviewRequested},
+		{"failed rejects the transition", StageFailed, StageFailed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.ReviewFeedback = &ReviewFeedbackConfig{Enabled: true, MaxIterations: 3}
+			ghClient := github.NewClient(testutil.FakeGitHubToken)
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", "")
+			pr, ok := c.GetPRState(42)
+			if !ok {
+				t.Fatalf("expected PR to be tracked")
+			}
+			pr.mu.Lock()
+			pr.Stage = tt.startStage
+			pr.mu.Unlock()
+
+			c.OnReviewRequested(42, "submitted", "changes_requested", "reviewer1")
+
+			pr, ok = c.GetPRState(42)
+			if !ok {
+				t.Fatalf("expected PR to remain tracked")
+			}
+			pr.mu.Lock()
+			gotStage := pr.Stage
+			pr.mu.Unlock()
+			if gotStage != tt.wantStage {
+				t.Errorf("stage = %q, want %q", gotStage, tt.wantStage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5327.

Closes #5327

## Changes

Add `reviewTriggerEligible(stage) bool` in controller.go as an include-list that fails closed on unrecognized stages — excluding StageAwaitApproval, StageReviewRequested, StageFailed, StageMerging, StageReleasing, and terminal stages. Verify the exact stage set against the stage enum and document the reasoning in a comment. Apply this guard before the webhook transition (~line 2733) and use it to replace the two-stage exclusion in the polling path (~lines 8799-8800). Log rejections at debug level (pr/stage/reviewer) without inline comments, per the TASK-486 pattern. Do not alter `handleMerging`'s use of `hasChangesRequested` for hold checks (#5264/#5269), since that is a hold check, not a transition.