### PR TITLE
GH-5328: feat(review-triggers): restrict review feedback issue body to human trigger reviewer

### DIFF
--- a/.agent/tasks/gh-5328.md
+++ b/.agent/tasks/gh-5328.md
@@ -1,0 +1,10 @@
+# GH-5328
+
+**Created:** 2026-09-06
+
+## Problem
+
+In `handleReviewRequested` (~line 4059) in feedback_loop.go, compute the triggering reviewer login(s) — trusted reviewers whose latest review since the cutoff is CHANGES_REQUESTED. Filter `ListPullRequestReviews` results to those reviewers plus CHANGES_REQUESTED, and filter `GetPullRequestComments` to those same reviewers. Keep `formatReviewFeedback` (feedback_loop.go:759-796) as a pure grouper with all filtering done by the caller. If filtering produces an empty result, log and skip issue creation instead of filing an empty issue. Leave the TASK-473 claim-before-create flow untouched.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -4087,6 +4087,40 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 		// Non-fatal: proceed with reviews only
 	}
 
+	// GH-5328: scope the revision-issue body to the reviewer(s) who actually
+	// drove this PR into StageReviewRequested, not every review/comment ever
+	// left on the PR. Without this, formatReviewFeedback (a pure grouper —
+	// all filtering now happens here, at the caller) mixed in stale
+	// CHANGES_REQUESTED reviews the reviewer later superseded with an
+	// APPROVED, bot/self-review noise, and unrelated commenters' line notes.
+	// triggeringReviewers mirrors hasChangesRequested's latest-state-per-
+	// trusted-reviewer logic (GH-5266 cutoff + COMMENTED-does-not-supersede
+	// rule) so the two paths agree on who is actually blocking.
+	triggers := c.triggeringReviewers(reviews, prState.CreatedAt)
+
+	triggeringReviews := make([]*github.PullRequestReview, 0, len(reviews))
+	for _, r := range reviews {
+		if triggers[r.User.Login] && r.State == "CHANGES_REQUESTED" {
+			triggeringReviews = append(triggeringReviews, r)
+		}
+	}
+
+	triggeringComments := make([]*github.PRReviewComment, 0, len(comments))
+	for _, cm := range comments {
+		if triggers[cm.User.Login] {
+			triggeringComments = append(triggeringComments, cm)
+		}
+	}
+
+	if len(triggeringReviews) == 0 && len(triggeringComments) == 0 {
+		c.log.Info("no triggering reviewer feedback survived filtering — skipping empty review issue",
+			"pr", prState.PRNumber,
+			"reviews_fetched", len(reviews),
+			"comments_fetched", len(comments),
+		)
+		return nil
+	}
+
 	// Check iteration limit
 	iteration := 0
 	if prState.IssueNumber > 0 && c.config.ReviewFeedback != nil && c.config.ReviewFeedback.MaxIterations > 0 {
@@ -4134,7 +4168,7 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 	// spawnReviewIssue rather than calling feedbackLoop.CreateReviewIssue
 	// directly, so prState.TerminalLabel is designated the moment the issue
 	// exists — strictly before the ClosePullRequest call below.
-	issueNum, err := c.spawnReviewIssue(ctx, prState, reviews, comments, iteration+1)
+	issueNum, err := c.spawnReviewIssue(ctx, prState, triggeringReviews, triggeringComments, iteration+1)
 	// GH-4856/GH-4459: the PR must never be closed unless the revision issue
 	// actually cleared preflight admission — CreateReviewIssue's dedup guard
 	// can legitimately return (0, nil) when a claim is in flight but not yet
@@ -4250,6 +4284,48 @@ func (c *Controller) isTrustedReviewer(login string) bool {
 		return false
 	}
 	return true
+}
+
+// triggeringReviewers returns the set of trusted reviewer logins whose latest
+// review since cutoff is CHANGES_REQUESTED — the identities actually
+// responsible for the state that drove (or is keeping) this PR in
+// StageReviewRequested. GH-5328: handleReviewRequested uses this to scope the
+// revision-issue body to only the feedback that triggered this run, instead
+// of every review/comment ever left on the PR.
+//
+// This mirrors hasChangesRequested's latest-state-per-trusted-reviewer logic
+// exactly (same GH-5266 cutoff semantics, same COMMENTED-does-not-supersede-
+// CHANGES_REQUESTED rule) so the two paths always agree on who is blocking —
+// duplicated rather than shared because hasChangesRequested fetches its own
+// reviews and returns a bool, while this needs the caller's already-fetched
+// reviews slice and the identities themselves.
+func (c *Controller) triggeringReviewers(reviews []*github.PullRequestReview, cutoff time.Time) map[string]bool {
+	latestState := make(map[string]string)
+	for _, r := range reviews {
+		if !c.isTrustedReviewer(r.User.Login) {
+			continue
+		}
+
+		if r.SubmittedAt != "" && !cutoff.IsZero() {
+			submittedAt, err := time.Parse(time.RFC3339, r.SubmittedAt)
+			if err == nil && submittedAt.Before(cutoff) {
+				continue
+			}
+		}
+
+		if latestState[r.User.Login] == "CHANGES_REQUESTED" && r.State != "APPROVED" && r.State != "DISMISSED" {
+			continue
+		}
+		latestState[r.User.Login] = r.State
+	}
+
+	triggers := make(map[string]bool)
+	for login, state := range latestState {
+		if state == "CHANGES_REQUESTED" {
+			triggers[login] = true
+		}
+	}
+	return triggers
 }
 
 // hasChangesRequested checks if a PR has unresolved "changes requested" reviews.

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6509,7 +6509,12 @@ func TestController_HandleReviewRequested_CreatesIssue(t *testing.T) {
 		switch {
 		case r.URL.Path == "/repos/owner/repo/pulls/42/reviews":
 			resp := []*github.PullRequestReview{
-				{ID: 1, User: github.User{Login: "alice"}, Body: "Fix the nil check", State: "CHANGES_REQUESTED", SubmittedAt: "2026-03-05T10:00:00Z"},
+				// GH-5328: SubmittedAt must be after the PR's CreatedAt cutoff
+				// (OnPRCreated below stamps CreatedAt = time.Now()), or
+				// handleReviewRequested's triggeringReviewers filter — which
+				// mirrors hasChangesRequested's cutoff rule — excludes it and
+				// no revision issue is created.
+				{ID: 1, User: github.User{Login: "alice"}, Body: "Fix the nil check", State: "CHANGES_REQUESTED", SubmittedAt: time.Now().Add(time.Minute).Format(time.RFC3339)},
 			}
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(mustJSON(t, resp))

--- a/internal/autopilot/gh5328_test.go
+++ b/internal/autopilot/gh5328_test.go
@@ -1,0 +1,178 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-5328: handleReviewRequested used to hand formatReviewFeedback every
+// review/comment ever left on the PR — including stale CHANGES_REQUESTED
+// reviews the reviewer later superseded with an APPROVED, bot noise, and
+// other reviewers' unrelated comments. These tests cover the fix: the
+// revision-issue body must be scoped to only the trusted reviewer(s) whose
+// latest review since the PR's CreatedAt cutoff is CHANGES_REQUESTED, and
+// issue creation must be skipped entirely (not filed empty) when filtering
+// leaves nothing.
+
+// TestGH5328_HandleReviewRequested_FiltersToTriggeringReviewer covers the
+// non-empty case: alice's live CHANGES_REQUESTED review/comment must survive
+// into the issue body, while bob's stale CHANGES_REQUESTED (superseded by his
+// own later APPROVED) and carol's unrelated COMMENTED-only feedback must not.
+func TestGH5328_HandleReviewRequested_FiltersToTriggeringReviewer(t *testing.T) {
+	var issueBody string
+	issueCreated := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/501/reviews":
+			resp := []*github.PullRequestReview{
+				// bob requested changes first, then approved — his latest
+				// state is APPROVED, so he must not trigger or appear.
+				{ID: 1, User: github.User{Login: "bob"}, Body: "bob-changes-requested-stale", State: "CHANGES_REQUESTED", SubmittedAt: time.Now().Add(-time.Hour).Format(time.RFC3339)},
+				{ID: 2, User: github.User{Login: "bob"}, Body: "", State: "APPROVED", SubmittedAt: time.Now().Add(-30 * time.Minute).Format(time.RFC3339)},
+				// carol only ever commented — never blocking.
+				{ID: 3, User: github.User{Login: "carol"}, Body: "carol-just-commented", State: "COMMENTED", SubmittedAt: time.Now().Add(-20 * time.Minute).Format(time.RFC3339)},
+				// alice is the live, current CHANGES_REQUESTED review.
+				{ID: 4, User: github.User{Login: "alice"}, Body: "alice-live-changes-requested", State: "CHANGES_REQUESTED", SubmittedAt: time.Now().Add(-10 * time.Minute).Format(time.RFC3339)},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/501/comments":
+			resp := []*github.PRReviewComment{
+				{ID: 10, Body: "alice-line-comment", Path: "foo.go", Line: 5, User: github.User{Login: "alice"}},
+				{ID: 11, Body: "carol-line-comment", Path: "bar.go", Line: 9, User: github.User{Login: "carol"}},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			issueBody = body["body"]
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 900}))
+		case r.URL.Path == "/repos/owner/repo/pulls/501" && r.Method == http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.ReviewFeedback = &ReviewFeedbackConfig{Enabled: true, MaxIterations: 3}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+
+	prState := &PRState{
+		PRNumber:   501,
+		BranchName: "pilot/GH-501",
+		Stage:      StageReviewRequested,
+		CreatedAt:  time.Now().Add(-2 * time.Hour),
+	}
+
+	if err := c.handleReviewRequested(context.Background(), prState); err != nil {
+		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
+	}
+
+	if !issueCreated {
+		t.Fatal("expected a revision issue to be created for alice's live CHANGES_REQUESTED review")
+	}
+
+	if !strings.Contains(issueBody, "alice-live-changes-requested") {
+		t.Error("issue body must contain alice's live review body")
+	}
+	if !strings.Contains(issueBody, "alice-line-comment") {
+		t.Error("issue body must contain alice's line comment")
+	}
+	if strings.Contains(issueBody, "bob-changes-requested-stale") {
+		t.Error("issue body must NOT contain bob's stale CHANGES_REQUESTED review — he later approved")
+	}
+	if strings.Contains(issueBody, "carol-just-commented") {
+		t.Error("issue body must NOT contain carol's COMMENTED-only review — she never requested changes")
+	}
+	if strings.Contains(issueBody, "carol-line-comment") {
+		t.Error("issue body must NOT contain carol's line comment — she is not a triggering reviewer")
+	}
+}
+
+// TestGH5328_HandleReviewRequested_EmptyAfterFilter_SkipsIssueCreation covers
+// the empty case: every review is bot-authored (untrusted), so
+// triggeringReviewers filters everything out — no issue must be filed, and
+// the PR must be left alone (not closed) rather than churning an empty issue.
+func TestGH5328_HandleReviewRequested_EmptyAfterFilter_SkipsIssueCreation(t *testing.T) {
+	issueCreated := false
+	prClosed := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/502/reviews":
+			resp := []*github.PullRequestReview{
+				// bot-authored CHANGES_REQUESTED — untrusted, must be excluded.
+				{ID: 1, User: github.User{Login: "ci-review[bot]"}, Body: "bot-changes-requested", State: "CHANGES_REQUESTED", SubmittedAt: time.Now().Add(-time.Minute).Format(time.RFC3339)},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/502/comments":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 901}))
+		case r.URL.Path == "/repos/owner/repo/pulls/502" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.ReviewFeedback = &ReviewFeedbackConfig{Enabled: true, MaxIterations: 3}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+
+	prState := &PRState{
+		PRNumber:   502,
+		BranchName: "pilot/GH-502",
+		Stage:      StageReviewRequested,
+		CreatedAt:  time.Now().Add(-2 * time.Hour),
+	}
+
+	if err := c.handleReviewRequested(context.Background(), prState); err != nil {
+		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
+	}
+
+	if issueCreated {
+		t.Error("expected no revision issue to be created when filtering leaves no triggering reviewer feedback")
+	}
+	if prClosed {
+		t.Error("expected the PR to be left open when no issue was created (not silently closed with no follow-up)")
+	}
+	if prState.Stage != StageReviewRequested {
+		t.Errorf("stage = %s, want %s (should be left untouched, not escalated, when there's nothing to act on)", prState.Stage, StageReviewRequested)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5328.

Closes #5328

## Changes

In `handleReviewRequested` (~line 4059) in feedback_loop.go, compute the triggering reviewer login(s) — trusted reviewers whose latest review since the cutoff is CHANGES_REQUESTED. Filter `ListPullRequestReviews` results to those reviewers plus CHANGES_REQUESTED, and filter `GetPullRequestComments` to those same reviewers. Keep `formatReviewFeedback` (feedback_loop.go:759-796) as a pure grouper with all filtering done by the caller. If filtering produces an empty result, log and skip issue creation instead of filing an empty issue. Leave the TASK-473 claim-before-create flow untouched.