### PR TITLE
GH-5337: fix(autopilot): handleReviewRequested cutoff must use the GitHub PR CreatedAt (GH-5266 re-adoption blind spot) + warm bot-login cache + case-insensitive bot pattern

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2863,7 +2863,7 @@ func (c *Controller) ProcessPR(ctx context.Context, prNumber int, ghPR *github.P
 	case StagePostMergeCI:
 		err = c.handlePostMergeCI(ctx, prState)
 	case StageReviewRequested:
-		err = c.handleReviewRequested(ctx, prState)
+		err = c.handleReviewRequested(ctx, prState, ghPR)
 	case StageReleasing:
 		err = c.handleReleasing(ctx, prState)
 	case StageFailed:
@@ -4110,13 +4110,45 @@ func (c *Controller) spawnReviewIssue(ctx context.Context, prState *PRState, rev
 	return issueNum, err
 }
 
+// reviewFilterEmptyEscalateThreshold bounds how many consecutive
+// empty-after-filter passes handleReviewRequested tolerates before
+// escalating (GH-5337). A single empty pass can be a legitimate transient —
+// e.g. a bot-only CHANGES_REQUESTED review that isTrustedReviewer correctly
+// excludes, with no human feedback (yet) alongside it — so escalating on the
+// very first occurrence would fire on that ordinary case too. Repeated empty
+// passes across ticks, though, mean the same review state is being
+// re-evaluated every poll with nothing ever going to unblock it: no revision
+// issue is ever created, the stage never advances, and (before this
+// existed) nothing ever surfaced that to a human.
+const reviewFilterEmptyEscalateThreshold = 3
+
 // handleReviewRequested processes a PR that received "changes requested" review feedback.
 // It fetches reviews and comments, checks iteration limits, creates a revision issue,
 // learns from the review, then closes the PR and deletes the branch.
-func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState) error {
+//
+// ghPR is the caller's already-fetched live PR object (may be nil — see
+// reviewCutoff) and is threaded through from ProcessPR (GH-5337) so the
+// review-hold cutoff used here matches the one hasChangesRequested used to
+// decide this PR belongs in StageReviewRequested in the first place. Before
+// this, handleReviewRequested anchored solely on prState.CreatedAt, which
+// the reconciler's orphan-PR re-adoption (and OnPRCreated) always stamps to
+// time.Now() — so a PR re-adopted after a restart with a standing
+// CHANGES_REQUESTED review predating it could have hasChangesRequested (which
+// already preferred ghPR.CreatedAt) correctly flip the stage, only for this
+// handler to filter that very review out on its own, later cutoff, land on
+// the empty-after-filter branch below, and leave the PR stuck in
+// StageReviewRequested indefinitely — refetching every tick, no revision
+// issue, no escalation, the GH-5266 blind spot reopened one hop downstream.
+func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState, ghPR *github.PullRequest) error {
 	c.log.Info("handleReviewRequested: processing review feedback",
 		"pr", prState.PRNumber,
 	)
+
+	// GH-5337: warm cachedBotLogin here too, in case this stage is entered
+	// via the webhook path (OnReviewRequested) or resumed cold after a
+	// restart before hasChangesRequested's polling gate ever ran in this
+	// process.
+	c.getBotLogin(ctx)
 
 	// Fetch reviews and comments
 	reviews, err := c.ghClient.ListPullRequestReviews(ctx, c.owner, c.repo, prState.PRNumber)
@@ -4138,8 +4170,12 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 	// APPROVED, bot/self-review noise, and unrelated commenters' line notes.
 	// triggeringReviewers mirrors hasChangesRequested's latest-state-per-
 	// trusted-reviewer logic (GH-5266 cutoff + COMMENTED-does-not-supersede
-	// rule) so the two paths agree on who is actually blocking.
-	triggers := c.triggeringReviewers(reviews, prState.CreatedAt)
+	// rule) so the two paths agree on who is actually blocking. GH-5337: the
+	// cutoff itself is now derived identically to hasChangesRequested's (via
+	// reviewCutoff), not prState.CreatedAt directly — see the doc comment
+	// above.
+	cutoff := reviewCutoff(prState, ghPR)
+	triggers := c.triggeringReviewers(reviews, cutoff)
 
 	triggeringReviews := make([]*github.PullRequestReview, 0, len(reviews))
 	for _, r := range reviews {
@@ -4156,13 +4192,29 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 	}
 
 	if len(triggeringReviews) == 0 && len(triggeringComments) == 0 {
+		prState.ReviewFilterEmptyPasses++
 		c.log.Info("no triggering reviewer feedback survived filtering — skipping empty review issue",
 			"pr", prState.PRNumber,
 			"reviews_fetched", len(reviews),
 			"comments_fetched", len(comments),
+			"empty_passes", prState.ReviewFilterEmptyPasses,
 		)
+		// GH-5337: unconditionally returning nil here left a PR silently
+		// stuck in StageReviewRequested forever whenever every pass came up
+		// empty (e.g. a cutoff/filtering disagreement, or every review being
+		// bot/self-authored) — refetched every tick with no revision issue
+		// and no visibility. Escalate once this has happened
+		// reviewFilterEmptyEscalateThreshold times in a row so a genuinely
+		// stuck PR surfaces to a human instead of parking invisibly.
+		if prState.ReviewFilterEmptyPasses >= reviewFilterEmptyEscalateThreshold {
+			reason := fmt.Sprintf("review feedback empty after reviewer-trust filtering %d consecutive times", prState.ReviewFilterEmptyPasses)
+			comment := "Automated review processing repeatedly found no triggering reviewer feedback survives filtering on this PR — holding for manual review instead of leaving it stuck in review-requested."
+			c.escalateAndHold(ctx, prState, reason, []string{labelNeedsHuman}, comment)
+			c.metrics.RecordPRFailed()
+		}
 		return nil
 	}
+	prState.ReviewFilterEmptyPasses = 0
 
 	// Check iteration limit
 	iteration := 0
@@ -4315,9 +4367,12 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 // with no context.Context to thread through for an on-demand
 // getBotLogin(ctx) call. If the cache hasn't been populated yet, the bot-self
 // check is simply skipped for that call — the "[bot]"/"-bot" suffix check
-// still applies.
+// still applies. GH-5337: the suffix check is matched case-insensitively
+// (e.g. "Foo-Bot", "x[BOT]") since GitHub logins are case-insensitive and the
+// naming convention is not guaranteed to be lowercase.
 func (c *Controller) isTrustedReviewer(login string) bool {
-	if strings.Contains(login, "[bot]") || strings.HasSuffix(login, "-bot") {
+	lower := strings.ToLower(login)
+	if strings.Contains(lower, "[bot]") || strings.HasSuffix(lower, "-bot") {
 		return false
 	}
 	c.mu.RLock()
@@ -4329,20 +4384,40 @@ func (c *Controller) isTrustedReviewer(login string) bool {
 	return true
 }
 
-// triggeringReviewers returns the set of trusted reviewer logins whose latest
-// review since cutoff is CHANGES_REQUESTED — the identities actually
-// responsible for the state that drove (or is keeping) this PR in
-// StageReviewRequested. GH-5328: handleReviewRequested uses this to scope the
-// revision-issue body to only the feedback that triggered this run, instead
-// of every review/comment ever left on the PR.
-//
-// This mirrors hasChangesRequested's latest-state-per-trusted-reviewer logic
-// exactly (same GH-5266 cutoff semantics, same COMMENTED-does-not-supersede-
-// CHANGES_REQUESTED rule) so the two paths always agree on who is blocking —
-// duplicated rather than shared because hasChangesRequested fetches its own
-// reviews and returns a bool, while this needs the caller's already-fetched
-// reviews slice and the identities themselves.
-func (c *Controller) triggeringReviewers(reviews []*github.PullRequestReview, cutoff time.Time) map[string]bool {
+// reviewCutoff resolves the review-hold cutoff timestamp for a PR: it prefers
+// the GitHub PR's own, durable CreatedAt (GH-5266) and falls back to
+// prState.CreatedAt only when ghPR is nil or its CreatedAt fails to parse.
+// prState.CreatedAt is stamped to time.Now() by both OnPRCreated (fresh
+// registration) and the reconciler's orphan-PR re-adoption sweep, so on its
+// own it is never a safe cutoff once a restart is possible — a standing
+// review submitted before the restart would look "older than tracking" the
+// instant the PR is re-adopted. GH-5337: shared by hasChangesRequested (the
+// entry gate that flips a PR into StageReviewRequested) and
+// handleReviewRequested (the handler that acts on that same stage) so the
+// two can never derive different cutoffs from the same PR — the original
+// bug had handleReviewRequested anchor on prState.CreatedAt alone, so it
+// could filter out the very review that had just made the polling gate flip
+// the stage, land on the empty-after-filter branch, and leave the PR stuck
+// in StageReviewRequested indefinitely.
+func reviewCutoff(prState *PRState, ghPR *github.PullRequest) time.Time {
+	cutoff := prState.CreatedAt
+	if ghPR != nil && ghPR.CreatedAt != "" {
+		if parsed, err := time.Parse(time.RFC3339, ghPR.CreatedAt); err == nil {
+			cutoff = parsed
+		}
+	}
+	return cutoff
+}
+
+// latestTrustedReviewStates returns, per trusted reviewer login
+// (isTrustedReviewer), that reviewer's latest review state among reviews
+// submitted at or after cutoff. Applies the GH-5266 rule that a
+// CHANGES_REQUESTED state is only superseded by a fresh APPROVED or an
+// explicit DISMISSED — never by a COMMENTED, which GitHub's own review model
+// does not treat as clearing a standing change request. GH-5337: extracted
+// out of triggeringReviewers and hasChangesRequested, which previously
+// duplicated this exact loop, so the two callers cannot desync.
+func (c *Controller) latestTrustedReviewStates(reviews []*github.PullRequestReview, cutoff time.Time) map[string]string {
 	latestState := make(map[string]string)
 	for _, r := range reviews {
 		if !c.isTrustedReviewer(r.User.Login) {
@@ -4361,6 +4436,22 @@ func (c *Controller) triggeringReviewers(reviews []*github.PullRequestReview, cu
 		}
 		latestState[r.User.Login] = r.State
 	}
+	return latestState
+}
+
+// triggeringReviewers returns the set of trusted reviewer logins whose latest
+// review since cutoff is CHANGES_REQUESTED — the identities actually
+// responsible for the state that drove (or is keeping) this PR in
+// StageReviewRequested. GH-5328: handleReviewRequested uses this to scope the
+// revision-issue body to only the feedback that triggered this run, instead
+// of every review/comment ever left on the PR.
+//
+// This mirrors hasChangesRequested's latest-state-per-trusted-reviewer logic
+// exactly (same GH-5266 cutoff semantics, same COMMENTED-does-not-supersede-
+// CHANGES_REQUESTED rule) via the shared latestTrustedReviewStates helper
+// (GH-5337) so the two paths always agree on who is blocking.
+func (c *Controller) triggeringReviewers(reviews []*github.PullRequestReview, cutoff time.Time) map[string]bool {
+	latestState := c.latestTrustedReviewStates(reviews, cutoff)
 
 	triggers := make(map[string]bool)
 	for login, state := range latestState {
@@ -4390,49 +4481,33 @@ func (c *Controller) triggeringReviewers(reviews []*github.PullRequestReview, cu
 // its CreatedAt fails to parse, preserving the original no-permanent-park
 // intent (never hold on a review that predates the PR itself) in that
 // degraded case.
+//
+// GH-5337: also warms c.cachedBotLogin (via getBotLogin) on every call. This
+// is the entry gate evaluated on every polling tick for every
+// review-trigger-eligible PR, so it is the earliest, most reliable point to
+// populate the cache — previously the only warm-up was an unrelated side
+// path (getBotLogin inside notifyExternalClose, only reached on an external
+// PR close), so isTrustedReviewer's own-login half of the predicate could
+// stay dormant for a process's entire lifetime.
 func (c *Controller) hasChangesRequested(ctx context.Context, prState *PRState, ghPR *github.PullRequest) bool {
+	c.getBotLogin(ctx)
+
 	reviews, err := c.ghClient.ListPullRequestReviews(ctx, c.owner, c.repo, prState.PRNumber)
 	if err != nil {
 		c.log.Warn("failed to fetch reviews for changes_requested check", "pr", prState.PRNumber, "error", err)
 		return false
 	}
 
-	cutoff := prState.CreatedAt
-	if ghPR != nil && ghPR.CreatedAt != "" {
-		if parsed, perr := time.Parse(time.RFC3339, ghPR.CreatedAt); perr == nil {
-			cutoff = parsed
-		}
-	}
+	cutoff := reviewCutoff(prState, ghPR)
 
-	// Track latest review state per user (only non-bot users). GH-5266 (N2
-	// from the PR#5264 review): a plain "last review wins" map let a later
-	// COMMENTED review from the same reviewer silently clear a standing
+	// Track latest review state per trusted reviewer. GH-5266 (N2 from the
+	// PR#5264 review): a plain "last review wins" map let a later COMMENTED
+	// review from the same reviewer silently clear a standing
 	// CHANGES_REQUESTED — GitHub's own review model does not treat a
 	// comment-only review as superseding a change request, only a fresh
-	// APPROVED or an explicit DISMISSED does. So once a user's latest
-	// recorded state is CHANGES_REQUESTED, only APPROVED/DISMISSED are
-	// allowed to overwrite it; COMMENTED (or any other state) is ignored.
-	latestState := make(map[string]string)
-	for _, r := range reviews {
-		// GH-5326: skip bot reviews (self-review or other automation) via the
-		// shared isTrustedReviewer predicate.
-		if !c.isTrustedReviewer(r.User.Login) {
-			continue
-		}
-
-		// Only consider reviews submitted after the PR entered tracking
-		if r.SubmittedAt != "" && !cutoff.IsZero() {
-			submittedAt, err := time.Parse(time.RFC3339, r.SubmittedAt)
-			if err == nil && submittedAt.Before(cutoff) {
-				continue
-			}
-		}
-
-		if latestState[r.User.Login] == "CHANGES_REQUESTED" && r.State != "APPROVED" && r.State != "DISMISSED" {
-			continue
-		}
-		latestState[r.User.Login] = r.State
-	}
+	// APPROVED or an explicit DISMISSED does. GH-5337: extracted into
+	// latestTrustedReviewStates, shared with triggeringReviewers.
+	latestState := c.latestTrustedReviewStates(reviews, cutoff)
 
 	for _, state := range latestState {
 		if state == "CHANGES_REQUESTED" {
@@ -5668,6 +5743,15 @@ func (c *Controller) recoverStaleParentIssues(ctx context.Context) {
 
 // Start runs one-time startup recovery sweeps. Call before the main Run loop.
 func (c *Controller) Start(ctx context.Context) {
+	// GH-5337: warm cachedBotLogin at startup so isTrustedReviewer's
+	// own-login half is live from the controller's very first review-gate
+	// evaluation, rather than staying dormant (string-pattern-only) until
+	// notifyExternalClose's unrelated external-PR-close path happens to
+	// populate it first. Best-effort: getBotLogin already logs and returns
+	// "" on failure, which isTrustedReviewer treats as "skip the self-check"
+	// (fail open) exactly as before this warm-up existed.
+	c.getBotLogin(ctx)
+
 	c.recoverStaleParentIssues(ctx)
 	// GH-3990: claim any scope releases left pending (or re-drive any left
 	// 'releasing' with no live carrier) by a daemon restart.

--- a/internal/autopilot/gh4841_test.go
+++ b/internal/autopilot/gh4841_test.go
@@ -254,7 +254,7 @@ func TestGH4841_ReviewRequestedCrashWindow_RetryNotArmedAfterRestart(t *testing.
 	controllerA := NewController(cfg, ghClient, nil, "owner", "repo")
 	controllerA.SetStateStore(store)
 
-	if err := controllerA.handleReviewRequested(context.Background(), seedPR); err != nil {
+	if err := controllerA.handleReviewRequested(context.Background(), seedPR, nil); err != nil {
 		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
 	}
 	if !issueCreated {

--- a/internal/autopilot/gh4856_test.go
+++ b/internal/autopilot/gh4856_test.go
@@ -102,7 +102,7 @@ func TestHandleReviewRequested_CreateIssueErrors_EscalatesInsteadOfClosing(t *te
 	}
 
 	// First tick: CreatePilotIssue fails transiently.
-	if err := c.handleReviewRequested(context.Background(), prState); err != nil {
+	if err := c.handleReviewRequested(context.Background(), prState, nil); err != nil {
 		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
 	}
 
@@ -142,7 +142,7 @@ func TestHandleReviewRequested_CreateIssueErrors_EscalatesInsteadOfClosing(t *te
 	prState.Stage = StageReviewRequested
 	prState.Error = ""
 
-	if err := c.handleReviewRequested(context.Background(), prState); err != nil {
+	if err := c.handleReviewRequested(context.Background(), prState, nil); err != nil {
 		t.Fatalf("handleReviewRequested (retry) returned unexpected error: %v", err)
 	}
 

--- a/internal/autopilot/gh4860_test.go
+++ b/internal/autopilot/gh4860_test.go
@@ -103,7 +103,7 @@ func TestHandleReviewRequested_SeededClaimWithoutRecord_EscalatesAndHolds(t *tes
 		t.Fatalf("seed ClaimSpawnedFix failed: %v", err)
 	}
 
-	if err := c.handleReviewRequested(context.Background(), prState); err != nil {
+	if err := c.handleReviewRequested(context.Background(), prState, nil); err != nil {
 		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
 	}
 

--- a/internal/autopilot/gh5228_test.go
+++ b/internal/autopilot/gh5228_test.go
@@ -48,6 +48,8 @@ func TestReviewTriggerReviewerTrust_WebhookPollingParity(t *testing.T) {
 		{"dash-bot suffix rejected", "ci-bot", false},
 		{"own login rejected (identity, exact case)", "pilot-bot", false},
 		{"own login rejected (identity, case-insensitive)", "Pilot-Bot", false},
+		{"dash-bot suffix rejected (mixed case, GH-5337)", "Foo-Bot", false},
+		{"bracket-bot suffix rejected (mixed case, GH-5337)", "x[BOT]", false},
 		{"human reviewer accepted", "alice", true},
 	}
 
@@ -340,7 +342,7 @@ func TestReviewFeedbackBody_OnlyFirstHumanTriggeringReviewer(t *testing.T) {
 		CreatedAt:  time.Now().Add(-1 * time.Hour),
 	}
 
-	if err := c.handleReviewRequested(context.Background(), prState); err != nil {
+	if err := c.handleReviewRequested(context.Background(), prState, nil); err != nil {
 		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
 	}
 

--- a/internal/autopilot/gh5328_test.go
+++ b/internal/autopilot/gh5328_test.go
@@ -87,7 +87,7 @@ func TestGH5328_HandleReviewRequested_FiltersToTriggeringReviewer(t *testing.T) 
 		CreatedAt:  time.Now().Add(-2 * time.Hour),
 	}
 
-	if err := c.handleReviewRequested(context.Background(), prState); err != nil {
+	if err := c.handleReviewRequested(context.Background(), prState, nil); err != nil {
 		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
 	}
 
@@ -162,7 +162,7 @@ func TestGH5328_HandleReviewRequested_EmptyAfterFilter_SkipsIssueCreation(t *tes
 		CreatedAt:  time.Now().Add(-2 * time.Hour),
 	}
 
-	if err := c.handleReviewRequested(context.Background(), prState); err != nil {
+	if err := c.handleReviewRequested(context.Background(), prState, nil); err != nil {
 		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
 	}
 

--- a/internal/autopilot/gh5337_test.go
+++ b/internal/autopilot/gh5337_test.go
@@ -1,0 +1,264 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-5337 (TASK-493 post-merge review follow-up, defect 1): handleReviewRequested
+// anchored its reviewer cutoff on prState.CreatedAt directly, reopening the
+// GH-5266 blind spot one hop downstream of hasChangesRequested's fix. Both the
+// polling gate (hasChangesRequested) and the merge-time guard already prefer
+// the GitHub PR's own, durable CreatedAt over prState.CreatedAt (which
+// OnPRCreated/the reconciler's re-adoption sweep always stamp to time.Now()).
+// This test reproduces the full failure sequence end to end: adopt a PR whose
+// prState.CreatedAt lands after a standing CHANGES_REQUESTED review, let the
+// polling gate flip the stage (as it already correctly does), and assert
+// handleReviewRequested — running immediately after in the same tick — still
+// sees that review as triggering and creates the revision issue, instead of
+// filtering it out and landing on the empty-after-filter branch.
+func TestGH5337_ReAdoptedPR_HandleReviewRequestedUsesGitHubCreatedAt(t *testing.T) {
+	var issueCreated bool
+	var issueBody string
+	var prClosed bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/5337" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:    5337,
+				State:     "open",
+				HTMLURL:   "https://github.com/owner/repo/pull/5337",
+				Head:      github.PRRef{SHA: "sha5337"},
+				Base:      github.PRRef{Ref: "main"},
+				CreatedAt: "2026-08-01T00:00:00Z", // real, durable PR creation time
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/5337/reviews":
+			// Standing review: submitted after the PR's real creation, but
+			// before prState.CreatedAt (stamped to time.Now() by the
+			// re-adoption this test simulates via OnPRCreated).
+			resp := []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "reviewer"}, Body: "please fix this", State: "CHANGES_REQUESTED", SubmittedAt: "2026-08-15T00:00:00Z"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/5337/comments":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			issueBody = body["body"]
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 950}))
+
+		case r.URL.Path == "/repos/owner/repo/pulls/5337" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.ReviewFeedback = &ReviewFeedbackConfig{Enabled: true, MaxIterations: 3}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+
+	// Simulate re-adoption: OnPRCreated always stamps CreatedAt to time.Now(),
+	// long after the standing review above but the PR itself already exists
+	// on GitHub with an earlier CreatedAt.
+	c.OnPRCreated(5337, "https://github.com/owner/repo/pull/5337", 700, "sha5337", "pilot/GH-700", "")
+	pr, ok := c.GetPRState(5337)
+	if !ok {
+		t.Fatal("PR should be tracked")
+	}
+	pr.mu.Lock()
+	pr.Stage = StageWaitingCI
+	pr.mu.Unlock()
+
+	// One polling tick: hasChangesRequested must flip the stage (GH-5266,
+	// already correct), and ProcessPR's subsequent handleReviewRequested call
+	// in the same tick must not filter the same review back out (GH-5337).
+	c.processAllPRs(context.Background())
+
+	if !issueCreated {
+		t.Fatal("expected handleReviewRequested to create a revision issue for the standing review — it must not be filtered out by a prState.CreatedAt-anchored cutoff (GH-5337)")
+	}
+	if !prClosed {
+		t.Error("expected the PR to be closed once the revision issue was created")
+	}
+	if issueBody == "" || !strings.Contains(issueBody, "please fix this") {
+		t.Errorf("issue body = %q, want it to contain the standing review's body", issueBody)
+	}
+
+	got, ok := c.GetPRState(5337)
+	if !ok {
+		t.Fatal("PR should still be tracked (escalateAndHold/close paths keep it tracked until externally observed closed)")
+	}
+	got.mu.Lock()
+	defer got.mu.Unlock()
+	if got.Stage != StageFailed {
+		t.Errorf("stage = %s, want %s (handleReviewRequested's healthy hand-off terminal state)", got.Stage, StageFailed)
+	}
+	if got.ReviewFilterEmptyPasses != 0 {
+		t.Errorf("ReviewFilterEmptyPasses = %d, want 0 — this pass found triggering feedback, it must not count as empty", got.ReviewFilterEmptyPasses)
+	}
+}
+
+// TestGH5337_HandleReviewRequested_RepeatedEmptyAfterFilter_Escalates covers
+// defect 1's second half: a single empty-after-filter pass must stay quiet
+// (matches gh5328_test.go's existing
+// TestGH5328_HandleReviewRequested_EmptyAfterFilter_SkipsIssueCreation), but
+// once the same PR racks up reviewFilterEmptyEscalateThreshold consecutive
+// empty passes, handleReviewRequested must escalate via escalateAndHold
+// (pilot-needs-human label, StageFailed) instead of leaving the PR parked in
+// StageReviewRequested forever with no visibility.
+func TestGH5337_HandleReviewRequested_RepeatedEmptyAfterFilter_Escalates(t *testing.T) {
+	var labelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/5338/reviews":
+			// Every review is bot-authored — untrusted, filtered out on every pass.
+			resp := []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "ci-review[bot]"}, Body: "bot-changes-requested", State: "CHANGES_REQUESTED", SubmittedAt: time.Now().Add(-time.Minute).Format(time.RFC3339)},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/5338/comments":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues/700/labels" && r.Method == http.MethodPost:
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			labelsAdded = append(labelsAdded, body.Labels...)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.ReviewFeedback = &ReviewFeedbackConfig{Enabled: true, MaxIterations: 3}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+
+	prState := &PRState{
+		PRNumber:    5338,
+		IssueNumber: 700,
+		BranchName:  "pilot/GH-700",
+		Stage:       StageReviewRequested,
+		CreatedAt:   time.Now().Add(-2 * time.Hour),
+	}
+
+	for i := 1; i < reviewFilterEmptyEscalateThreshold; i++ {
+		if err := c.handleReviewRequested(context.Background(), prState, nil); err != nil {
+			t.Fatalf("pass %d: handleReviewRequested returned unexpected error: %v", i, err)
+		}
+		if prState.Stage != StageReviewRequested {
+			t.Fatalf("pass %d: stage = %s, want %s (must not escalate before the threshold)", i, prState.Stage, StageReviewRequested)
+		}
+		if len(labelsAdded) != 0 {
+			t.Fatalf("pass %d: labels added = %v, want none before the threshold", i, labelsAdded)
+		}
+	}
+
+	// Final pass crosses the threshold.
+	if err := c.handleReviewRequested(context.Background(), prState, nil); err != nil {
+		t.Fatalf("final pass: handleReviewRequested returned unexpected error: %v", err)
+	}
+
+	if prState.Stage != StageFailed {
+		t.Errorf("stage = %s, want %s (escalated and held)", prState.Stage, StageFailed)
+	}
+	found := false
+	for _, l := range labelsAdded {
+		if l == labelNeedsHuman {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected %q label on the issue after repeated empty passes, got labels: %v", labelNeedsHuman, labelsAdded)
+	}
+}
+
+// TestGH5337_IsTrustedReviewer_OwnLoginRejected_WithoutExternalClose covers
+// defect 2: isTrustedReviewer's own-login check previously stayed dormant
+// (string-pattern-only) for a controller's entire process lifetime unless
+// notifyExternalClose's unrelated external-PR-close path happened to warm
+// cachedBotLogin first. hasChangesRequested now warms it directly (and
+// Start does too) — this test drives a freshly constructed controller
+// through hasChangesRequested only, with no external close anywhere in the
+// scenario, and asserts the own-login half of isTrustedReviewer is already
+// live afterward.
+func TestGH5337_IsTrustedReviewer_OwnLoginRejected_WithoutExternalClose(t *testing.T) {
+	// Deliberately does not match the "[bot]"/"-bot" suffix pattern, so the
+	// only way isTrustedReviewer can reject it is via the cached-identity
+	// check this test exercises.
+	const botLogin = "quantflow-pilot-svc"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/user":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, github.User{Login: botLogin}))
+		case "/repos/owner/repo/pulls/9001/reviews":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	// Sanity: nothing has warmed the cache yet on a freshly constructed
+	// controller — the own-login half of isTrustedReviewer is dormant.
+	if !c.isTrustedReviewer(botLogin) {
+		t.Fatal("precondition failed: own login should not yet be rejectable before any warm-up")
+	}
+
+	prState := &PRState{PRNumber: 9001, CreatedAt: time.Now().Add(-time.Hour)}
+	c.hasChangesRequested(context.Background(), prState, nil)
+
+	if c.isTrustedReviewer(botLogin) {
+		t.Error("isTrustedReviewer should reject the controller's own login once hasChangesRequested has warmed cachedBotLogin — no external PR close ever happened in this scenario")
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1105,6 +1105,16 @@ type PRState struct {
 	// issue relabel — while every other read that same minute showed it
 	// still open).
 	ClosedReadCount int
+	// ReviewFilterEmptyPasses tracks consecutive handleReviewRequested calls
+	// (GH-5337) that found no triggering reviewer feedback after
+	// isTrustedReviewer/cutoff filtering — whether because nothing was
+	// fetched at all or because everything fetched was filtered out (bot,
+	// self-review, or predates the cutoff). Reset to 0 the moment a pass
+	// finds triggering feedback. In-memory only: once it reaches
+	// reviewFilterEmptyEscalateThreshold, handleReviewRequested escalates via
+	// escalateAndHold instead of silently returning nil and leaving the PR
+	// stuck in StageReviewRequested forever.
+	ReviewFilterEmptyPasses int
 	// PersistFailureCount tracks consecutive SavePRState errors for this PR
 	// (e.g. a schema/ON CONFLICT mismatch on an adopted or otherwise
 	// irregular row). Reset to 0 on a successful persist. In-memory only:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5337.

Closes #5337

## Changes

GitHub Issue GH-5337: fix(autopilot): handleReviewRequested cutoff must use the GitHub PR CreatedAt (GH-5266 re-adoption blind spot) + warm bot-login cache + case-insensitive bot pattern

## Context

Post-merge review of TASK-493 (PR #5331, #5332, #5333, #5334; shipped v2.273.0) — verdict APPROVE-w-notes, one HIGH defect and two smaller ones to fix together. Line numbers refer to `internal/autopilot/controller.go` on main at 580b4ddd.

## Defect 1 (HIGH): `handleReviewRequested` anchors the reviewer cutoff on `prState.CreatedAt`, re-opening the GH-5266 blind spot

Line 4141: `triggers := c.triggeringReviewers(reviews, prState.CreatedAt)`.

The entry gates (`hasChangesRequested` ~4400-4405 and the polling gate ~8969) anchor on the GitHub PR's `CreatedAt` precisely because the reconciler re-adopts orphan PRs through `OnPRCreated`, which stamps `prState.CreatedAt = time.Now()` (~2588, adoption ~8212). Failure path after a daemon restart with a standing CHANGES_REQUESTED review:

1. reconciler re-adopts the PR, `prState.CreatedAt` = now
2. polling gate sees the review (GitHub cutoff) and flips the PR to `StageReviewRequested`
3. `handleReviewRequested` filters that same review out (its cutoff is later than the review), hits the empty-after-filter guard (~4160-4166) and returns nil with the stage unchanged
4. the PR sits in `StageReviewRequested` forever, refetching every tick, no revision issue, no escalation

Fix: thread the GitHub PR object from `ProcessPR` (~2866 already holds it) into `handleReviewRequested` and derive the cutoff exactly as `hasChangesRequested` does. On empty-after-filter, do not return silently: escalate via `escalateAndHold` after N consecutive empty passes (or immediately), so a stuck PR becomes visible. Extract the "latest review state per reviewer" logic shared by `triggeringReviewers` (~4346-4371) and `hasChangesRequested` (~4417-4433) into one helper so the two cannot desync.

## Defect 2 (MEDIUM): own-login identity check is dormant until an unrelated side path warms the cache

`isTrustedReviewer` (~4319) reads only `c.cachedBotLogin` (~4324); the only warm-up is `getBotLogin` inside `notifyExternalClose` (~9611). Until an external PR close happens in the process lifetime, the identity half of the predicate is a no-op and only the string pattern applies. Fix: warm the cache at controller start (or lazily in `hasChangesRequested`, which has a ctx). Empty login must keep failing open (skip the self-check), as it does today.

## Defect 3 (LOW): `[bot]` / `-bot` pattern check is case-sensitive

~4320. Spec said case-insensitive on the login. Use `strings.ToLower` before the pattern check. Add `Foo-Bot` and `x[BOT]` to the parity table in `gh5228_test.go`.

## Out of scope

- Learning loop (`LearnFromReview`, ~4218-4240) still ingests unfiltered reviews/comments. Separate decision; not in this issue.

## Acceptance

- Regression test: adopt a PR via `OnPRCreated` with `CreatedAt` after an existing CHANGES_REQUESTED review; polling flips the stage; `handleReviewRequested` creates the revision issue (not empty-after-filter).
- Test: repeated empty-after-filter escalates (label `pilot-needs-human`), PR does not stay in `StageReviewRequested` indefinitely.
- Test: `isTrustedReviewer` rejects the own login on a freshly constructed controller without any external close having happened.
- Test: `Foo-Bot` and `x[BOT]` rejected.
- `gh5266_test.go` unchanged and green; existing GH-5228/5327/5328 tests green.