### PR TITLE
fix(dispatch): stalled task re-arm recipe never matched GH-5212's evidence check

### DIFF
--- a/.agent/tasks/gh-5272.md
+++ b/.agent/tasks/gh-5272.md
@@ -1,0 +1,85 @@
+# GH-5272
+
+**Created:** 2026-09-06
+
+## Problem
+
+GitHub Issue GH-5272: fix(dispatch): stalled task cannot be re-armed — stale execution_claims rows win every claim race after pilot-retry-ready
+
+## Context
+
+A task whose last execution ended `stalled` (timeout) cannot be re-dispatched via the documented re-arm path (`pilot-retry-ready` label). Every pickup attempt loses the dispatch claim against its own stale `execution_claims` rows and re-enters repick backoff, indefinitely.
+
+### Timeline / evidence
+
+1. Two executions timed out at the 1h cap: `77f7265f… status=failed` (09:57Z), `a1c3aaeb… status=stalled` (10:58Z). Daemon posted the hard-cap comment and labeled `pilot-blocked`.
+2. Operator re-armed per the bot's own instructions: removed `pilot-blocked`, added `pilot-retry-ready`. Label transitioned to `pilot-retry-1` — retry controller accepted it.
+3. From then on, an endless loop (daemon.log):
+```
+13:41:51 dispatch claim lost — task already owned by another dispatch channel or already terminal, dropping duplicate pickup  task_id=GH-493
+13:41:51 repick storm: claim-lost/terminal drop recurring — not counted toward repick hard cap  claim_lost_drops=11
+13:41:52 Unwound pilot-in-progress label after dropped dispatch pickup
+13:47:02 skip reason: repick-backoff cooldown …  backoff_remaining=10m49s
+13:58:23 (backoff expired → same claim-lost again)  claim_lost_drops=12 → fresh backoff
+```
+4. Ledger state at that point: `execution_claims` still held rows for `GH-493` generation 0 AND generation 1, each bound to the two terminal executions. `SELECT * FROM execution_claims WHERE task_id='GH-493'` → 2 rows; latest execution `status='stalled'`.
+5. **Operator surgery resolved it**: `UPDATE executions SET status='failed' WHERE id='a1c3aaeb…' AND status='stalled'; DELETE FROM execution_claims WHERE task_id='GH-493';` — next cycle dispatched normally.
+
+### Expected
+
+The `pilot-retry-ready` re-arm path should release/supersede stale claims for terminal executions (and treat `stalled` as terminal-retryable like `failed`), so a retry can claim generation N+1 without operator surgery.
+
+### Notes
+
+- The SDK poller's `"Skipping re-dispatch — completed execution exists"` line fires for this task even though no completed execution exists (both terminal rows are failed/stalled) — separately misleading, already half-acknowledged by the adjacent dispatch log line.
+- Claim rows for long-completed tasks (e.g. GH-4931/4938 from 08-18) also persist in `execution_claims` — if claims are never GC'd, any stalled task likely reproduces this.
+
+
+## Implementation — verify first, then fix (operator triage 2026-09-06)
+
+Four claim-ledger fixes landed after this report: #5274 (reap row-less claims), #5306 (reaper runs post-boot, not only at startup), #5309 (reaper cutoff timezone), #5311 (UTC timestamps). None of them targets this exact shape — claims bound to TERMINAL executions at generation 0 and 1 that still win the claim race — so:
+
+1. Reproduce on current main in a unit test: two terminal executions (`failed`, then `stalled`) each holding a claim at generations 0 and 1; a `pilot-retry-ready` re-arm must produce a successful claim at generation 2. If the test passes on main, one of the later fixes covered it: keep the test as a regression guard, note which fix closed it, and close this issue.
+2. If it fails: `nextRetryGeneration` must advance past the highest terminal-bound generation (both `failed` and `stalled` are terminal), and the claim insert must not lose to claims whose owning execution is terminal. Fix in `internal/executor/dispatcher.go` / `internal/memory/store.go` where the claim race is decided; keep the dead-owner semantics from the earlier fixes intact.
+3. Either way: the "claim lost" WARN must include the blocking claim's generation and the owning execution's status, so the next incident is diagnosable from the log alone.
+
+## Acceptance
+
+- [x] Regression test from step 1 exists and is green on main (either proving the bug is already fixed, or proving the fix). `TestDispatcher_NextRetryGeneration_AdvancesPastFailedThenStalledClaims` passes on main unmodified — GH-4372's dead-owner carve-out already advances past the highest terminal-bound generation (both `failed` and `stalled` count) and grants generation+1. The narrow claim-race scenario the issue describes was already fixed.
+- [x] Existing claim/reaper tests green. `go test ./...` is green.
+- [x] The "dispatch claim lost" WARN carries the blocking claim generation and the owning execution status. `dispatcher.go`'s `blockingClaimLogAttrs` adds `blocking_claim_generation`/`blocking_execution_status` to both "dispatch claim lost" log sites.
+
+### Root cause actually found (not the claim ledger)
+
+The claim-race logic itself was never the bug. Tracing the GH-493 incident's
+exact log timeline to its actual mechanism: `cmd/pilot/rearm_stalled.go`'s
+GH-5212 re-arm probe (`tryRearmStalled`/`sweepStalledRearm`) already existed
+to clear the stale `repick_backoff` hard-cap counter on a genuine re-arm, but
+had two gaps that both happen to match the bot's own documented recipe
+exactly:
+
+1. `sweepStalledRearm` only listed issues carrying `pilot-blocked` — but the
+   posted recipe removes `pilot-blocked` in the same edit that adds
+   `pilot-retry-ready`, so the re-armed issue had already dropped out of the
+   only candidate query by the time any sweep pass could see it.
+2. `tryRearmStalled`'s evidence check (`latestRearmEvent`) only recognized a
+   labeled/reopened event for the base `pilot` trigger label — which the
+   documented recipe never touches at all (it only touches `pilot-blocked`/
+   `pilot-retry-ready`).
+
+Fixed both: the sweep now lists all open issues and matches on
+`pilot-blocked` OR any of `pilot-retry-ready`/`pilot-retry-1`/`pilot-retry-2`;
+`tryRearmStalled` now also accepts a labeled event for that same label family
+as re-arm evidence. See `cmd/pilot/gh5272_stalled_rearm_test.go` for the
+end-to-end reproduction of the exact incident recipe.
+
+A dispatcher-side fix (inferring re-arm from claim state alone inside
+`beginWithGenerationRetry`) was attempted and reverted — it broke
+`TestDispatcher_BeginWithGenerationRetry_HardCapIsIdempotent`, an existing
+invariant that the dispatcher must never self-declare a re-arm without
+external (GitHub-side) evidence. See
+`TestDispatcher_BeginWithGenerationRetry_HardCapEscalatedTaskStaysDroppedWithoutExternalRearm`
+for why that layer must stay dumb.
+
+## Acceptance Criteria
+

--- a/cmd/pilot/gh5272_stalled_rearm_test.go
+++ b/cmd/pilot/gh5272_stalled_rearm_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestTryRearmStalled_PilotRetryReadyLabelAfterStall_Rearms is GH-5272's
+// acceptance test: the exact documented re-arm recipe from
+// surfaceStalledIssue's own posted comment —
+// `gh issue edit N --remove-label pilot-blocked --add-label pilot-retry-ready`
+// — never touches the base trigger label ("pilot") at all. Before GH-5272,
+// tryRearmStalled's evidence check (latestRearmEvent scoped to the trigger
+// label only) could never recognize this as a re-arm gesture, so the GH-493
+// incident's stale hard-cap counter was never cleared by anything.
+func TestTryRearmStalled_PilotRetryReadyLabelAfterStall_Rearms(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+	rearmTime := stallTime.Add(30 * time.Minute)
+
+	var blockedLabelRemoveAttempted bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/493" && r.Method == http.MethodGet:
+			// pilot-blocked already removed, pilot-retry-ready added — the
+			// base "pilot" trigger label was never touched.
+			_ = json.NewEncoder(w).Encode(&github.Issue{
+				Number: 493, State: "open",
+				Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelRetryReady}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/493/events" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]*github.IssueEvent{
+				{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+				{Event: "labeled", CreatedAt: stallTime, Label: &github.Label{Name: github.LabelBlocked}},
+				{Event: "unlabeled", CreatedAt: rearmTime, Label: &github.Label{Name: github.LabelBlocked}},
+				{Event: "labeled", CreatedAt: rearmTime, Label: &github.Label{Name: github.LabelRetryReady}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/493/labels/"+github.LabelBlocked && r.Method == http.MethodDelete:
+			// Best-effort cleanup of an already-absent label — GitHub 404s
+			// this in practice; tryRearmStalled treats any error here as
+			// non-fatal (logged, not returned), so respond accordingly.
+			blockedLabelRemoveAttempted = true
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-493", "/project-gh-493-incident"
+	seedStalledRow(t, store, "exec-gh493-stalled", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rearmed {
+		t.Fatal("expected rearmed=true — a pilot-retry-ready labeled event postdates the stall on an open, pilot-labeled issue")
+	}
+	if !blockedLabelRemoveAttempted {
+		t.Error("expected a best-effort pilot-blocked label removal attempt")
+	}
+
+	exec, err := store.GetExecution("exec-gh493-stalled")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected the stalled row to be reclassified to status=failed, got %q", exec.Status)
+	}
+
+	if gated, _ := repickBackoff.gateStatus(key); gated {
+		t.Error("expected repick backoff (and the persisted hard-cap counter it proxies) to be cleared on a successful re-arm, not left gated")
+	}
+}
+
+// TestSweepStalledRearm_RetryReadyLabelWithoutBlocked_DiscoversAndRearms is
+// GH-5272's sweep-level acceptance test: sweepStalledRearm's candidate query
+// used to list ONLY pilot-blocked issues, which the documented re-arm recipe
+// removes in the same edit that adds pilot-retry-ready — so by the time any
+// sweep pass ran, the re-armed issue had already dropped out of the
+// candidate list entirely and tryRearmStalled was never even called.
+func TestSweepStalledRearm_RetryReadyLabelWithoutBlocked_DiscoversAndRearms(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+	rearmTime := stallTime.Add(30 * time.Minute)
+
+	var listCalls, removeCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodGet:
+			listCalls++
+			if p := r.URL.Query().Get("page"); p != "1" && p != "" {
+				_ = json.NewEncoder(w).Encode([]*github.Issue{})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]*github.Issue{
+				// No pilot-blocked label — the operator already removed it
+				// per the bot's own recipe. Only pilot-retry-ready remains.
+				{Number: 493, State: "open", Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelRetryReady}}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/493" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(&github.Issue{
+				Number: 493, State: "open",
+				Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelRetryReady}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/493/events" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]*github.IssueEvent{
+				{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+				{Event: "labeled", CreatedAt: rearmTime, Label: &github.Label{Name: github.LabelRetryReady}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/493/labels/"+github.LabelBlocked && r.Method == http.MethodDelete:
+			removeCalls++
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-493", "/project-gh-493-sweep"
+	seedStalledRow(t, store, "exec-gh493-sweep", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	checker.sweepStalledRearm(context.Background(), projectPath)
+
+	if listCalls == 0 {
+		t.Fatal("expected sweepStalledRearm to list open issues")
+	}
+	if removeCalls != 1 {
+		t.Errorf("expected exactly 1 pilot-blocked label removal attempt, got %d", removeCalls)
+	}
+
+	exec, err := store.GetExecution("exec-gh493-sweep")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status=failed after sweep-driven reclassify, got %q (GH-5272 candidate-discovery gap reproduced if still stalled)", exec.Status)
+	}
+}

--- a/cmd/pilot/rearm_canceled.go
+++ b/cmd/pilot/rearm_canceled.go
@@ -72,7 +72,7 @@ func (c terminalCompletionChecker) tryRearmCanceled(taskID, projectPath, backoff
 	if err != nil {
 		return false, fmt.Errorf("listing issue #%d events: %w", issueNum, err)
 	}
-	rearmEvent := latestRearmEvent(events, c.triggerLabel, *exec.CompletedAt)
+	rearmEvent := latestRearmEvent(events, *exec.CompletedAt, c.triggerLabel)
 	if rearmEvent == nil {
 		// Open + labeled, but nothing in the timeline shows that state was
 		// reached AFTER the cancel — e.g. the label was already there before
@@ -92,13 +92,20 @@ func (c terminalCompletionChecker) tryRearmCanceled(taskID, projectPath, backoff
 }
 
 // latestRearmEvent scans events (as returned by ListIssueEvents, oldest
-// first) for the most recent "reopened" event, or "labeled" event naming
-// label, whose CreatedAt is strictly after since (the cancel timestamp).
-// Either event type alone is sufficient evidence of a deliberate operator
-// gesture post-cancel — the caller separately confirms the issue is
-// currently open AND labeled, so this only needs to establish that one of
-// those two state changes happened after the cancel, not both.
-func latestRearmEvent(events []*github.IssueEvent, label string, since time.Time) *github.IssueEvent {
+// first) for the most recent "reopened" event, or "labeled" event naming any
+// of labels, whose CreatedAt is strictly after since (the terminal-state
+// timestamp). Either event type alone is sufficient evidence of a deliberate
+// operator gesture post-terminal-state — the caller separately confirms
+// whatever "currently open (+labeled)" state it requires, so this only needs
+// to establish that one of those state changes happened after the terminal
+// timestamp, not both.
+//
+// labels is variadic so tryRearmStalled (GH-5272) can accept re-arm evidence
+// from any label in the pilot-retry-ready/-1/-2 family, on top of the base
+// trigger label tryRearmCanceled/tryRearmSuperseded pass alone — see
+// tryRearmStalled's doc comment for why a stalled task's documented re-arm
+// recipe never touches the base trigger label at all.
+func latestRearmEvent(events []*github.IssueEvent, since time.Time, labels ...string) *github.IssueEvent {
 	var latest *github.IssueEvent
 	for _, ev := range events {
 		if ev == nil || !ev.CreatedAt.After(since) {
@@ -107,7 +114,7 @@ func latestRearmEvent(events []*github.IssueEvent, label string, since time.Time
 		switch ev.Event {
 		case "reopened":
 		case "labeled":
-			if ev.Label == nil || !strings.EqualFold(ev.Label.Name, label) {
+			if ev.Label == nil || !containsLabelFold(labels, ev.Label.Name) {
 				continue
 			}
 		default:
@@ -118,4 +125,14 @@ func latestRearmEvent(events []*github.IssueEvent, label string, since time.Time
 		}
 	}
 	return latest
+}
+
+// containsLabelFold reports whether name matches any of labels, case-insensitively.
+func containsLabelFold(labels []string, name string) bool {
+	for _, l := range labels {
+		if strings.EqualFold(l, name) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/pilot/rearm_stalled.go
+++ b/cmd/pilot/rearm_stalled.go
@@ -15,6 +15,28 @@ import (
 // by rearmProbeTimeout) it triggers within that pass.
 const stalledRearmSweepTimeout = 60 * time.Second
 
+// retryReadyRearmLabels (GH-5272) are the labels — beyond the base trigger
+// label — whose "labeled" event counts as re-arm evidence for a stalled
+// task_id: the retry-ready label an operator adds per surfaceStalledIssue's
+// own instructions, plus the two rungs the vendored SDK poller's own
+// retry-budget ladder advances it through (shouldRetryRetryReadyIssue in
+// studio-sdk/sdk/integrations/github/poller.go) before this probe's next
+// sweep pass gets a chance to run. pilot-retry-exhausted is deliberately
+// excluded — that label means the SDK itself decided the retry budget is
+// spent, and this probe must not fight that call.
+var retryReadyRearmLabels = []string{github.LabelRetryReady, github.LabelRetry1, github.LabelRetry2}
+
+// isRetryReadyLabeled reports whether issue currently carries any label in
+// retryReadyRearmLabels.
+func isRetryReadyLabeled(issue *github.Issue) bool {
+	for _, l := range retryReadyRearmLabels {
+		if github.HasLabel(issue, l) {
+			return true
+		}
+	}
+	return false
+}
+
 // tryRearmStalled is GH-5212's re-arm probe for stalled rows — GH-5139's
 // operator-cancel re-arm pattern extended to the escalate-and-hold path
 // (repick hard cap / identical-failure streak, escalateStalledTask in
@@ -22,6 +44,19 @@ const stalledRearmSweepTimeout = 60 * time.Second
 // timestamped after the stall re-admits the task_id through the ordinary
 // retry path — before this, nothing ever checked for that, so a hosted
 // tenant whose task stalled on a since-fixed cause had no product lever.
+//
+// GH-5272: surfaceStalledIssue's own posted comment tells the operator to
+// run `--remove-label pilot-blocked --add-label pilot-retry-ready` — a
+// mutation that never touches the base trigger label at all. Before GH-5272,
+// latestRearmEvent only recognized a labeled/reopened event for the trigger
+// label, so the exact recipe the bot itself hands out could never satisfy
+// this probe's evidence check even once sweepStalledRearm found the issue.
+// retryReadyRearmLabels below is passed alongside the trigger label so a
+// labeled event for pilot-retry-ready/-1/-2 (the SDK's own retry-budget
+// ladder, which advances pilot-retry-ready forward within a poll tick or two
+// — see studio-sdk's shouldRetryRetryReadyIssue) counts as evidence too, not
+// just the current label snapshot (which may already have moved past
+// pilot-retry-ready by the time this probe runs).
 //
 // Deliberately NOT reachable via terminalCompletionChecker.HasCompletedExecution
 // (GH-5139's own call site, next to tryRearmCanceled) for two independent
@@ -68,8 +103,11 @@ func (c terminalCompletionChecker) tryRearmStalled(taskID, projectPath, backoffK
 		return false, fmt.Errorf("fetching issue #%d: %w", issueNum, err)
 	}
 	if issue.State != "open" || !github.HasLabel(issue, c.triggerLabel) {
-		// Re-arm requires BOTH open and (still/again) carrying the trigger
-		// label right now — mirrors tryRearmCanceled's same requirement.
+		// Re-arm requires BOTH open and (still/again) carrying the base
+		// trigger label right now — mirrors tryRearmCanceled's same
+		// requirement. The base trigger label ("pilot") is never touched by
+		// the documented stalled re-arm recipe (remove pilot-blocked, add
+		// pilot-retry-ready), so this check is unaffected by GH-5272.
 		return false, nil
 	}
 
@@ -77,10 +115,12 @@ func (c terminalCompletionChecker) tryRearmStalled(taskID, projectPath, backoffK
 	if err != nil {
 		return false, fmt.Errorf("listing issue #%d events: %w", issueNum, err)
 	}
-	rearmEvent := latestRearmEvent(events, c.triggerLabel, *exec.CompletedAt)
+	rearmEvent := latestRearmEvent(events, *exec.CompletedAt, append([]string{c.triggerLabel}, retryReadyRearmLabels...)...)
 	if rearmEvent == nil {
 		// Open + labeled, but nothing in the timeline shows that state was
-		// reached AFTER the stall — not a deliberate re-arm gesture.
+		// reached AFTER the stall (neither a base-label relabel/reopen NOR a
+		// pilot-retry-ready/-1/-2 label add) — not a deliberate re-arm
+		// gesture.
 		return false, nil
 	}
 
@@ -112,36 +152,54 @@ func (c terminalCompletionChecker) tryRearmStalled(taskID, projectPath, backoffK
 }
 
 // sweepStalledRearm scans repoOwner/repoName for open issues currently
-// carrying pilot-blocked and, for each one backed by a stalled execution row
-// under projectPath, probes for post-stall re-arm evidence via
-// tryRearmStalled. See tryRearmStalled's doc comment for why this scan
-// exists instead of a hook inside the SDK's admission chokepoint.
+// carrying pilot-blocked OR any pilot-retry-ready/-1/-2 label and, for each
+// one backed by a stalled execution row under projectPath, probes for
+// post-stall re-arm evidence via tryRearmStalled. See tryRearmStalled's doc
+// comment for why this scan exists instead of a hook inside the SDK's
+// admission chokepoint.
+//
+// GH-5272: originally scanned pilot-blocked only, on the assumption that a
+// stalled issue stays pilot-blocked until this sweep clears it. But
+// surfaceStalledIssue's own posted comment instructs the operator to REMOVE
+// pilot-blocked in the very same edit that adds pilot-retry-ready — so by
+// the time any sweep pass ran, the issue had already dropped out of a
+// pilot-blocked-only candidate list, and the recipe the bot itself hands out
+// could never reach tryRearmStalled at all. Listing all open issues (no
+// server-side label filter — ListIssues already fetches every open issue
+// and filters in Go, so this costs nothing extra) and filtering here for
+// EITHER label family closes that gap without widening what tryRearmStalled
+// itself accepts as evidence.
 //
 // Per-issue throttling reuses the exact repickBackoff window/key
 // (repickBackoffKey(projectPath, taskID)) GH-4469's HasCompletedExecution
-// gate and GH-5139's tryRearmCanceled already use — a pilot-blocked issue
-// with no re-arm evidence yet must not pay for a GetIssue+ListIssueEvents
-// call on every sweep pass. gateStatus is consulted before ListIssues even
-// runs is not possible (ListIssues has to run first to discover which
-// issues are pilot-blocked at all), but every individual probe past that
-// point is gated, so a quiet backlog of blocked issues costs one list call
-// per sweep interval and nothing more.
+// gate and GH-5139's tryRearmCanceled already use — a candidate issue with
+// no re-arm evidence yet must not pay for a GetIssue+ListIssueEvents call on
+// every sweep pass. gateStatus can't be consulted before ListIssues runs
+// (ListIssues has to run first to discover which issues are candidates at
+// all), but every individual probe past that point is gated, so a quiet
+// backlog of blocked/retry-ready issues costs one list call per sweep
+// interval and nothing more.
 func (c terminalCompletionChecker) sweepStalledRearm(ctx context.Context, projectPath string) {
 	if c.ghClient == nil {
 		return
 	}
 
 	issues, err := c.ghClient.ListIssues(ctx, c.repoOwner, c.repoName, &github.ListIssuesOptions{
-		Labels: []string{github.LabelBlocked},
-		State:  github.StateOpen,
+		State: github.StateOpen,
 	})
 	if err != nil {
-		logging.WithComponent("dispatch").Warn("GH-5212: stalled re-arm sweep failed to list pilot-blocked issues",
+		logging.WithComponent("dispatch").Warn("GH-5212: stalled re-arm sweep failed to list open issues",
 			slog.String("repo", c.repoOwner+"/"+c.repoName), slog.Any("error", err))
 		return
 	}
 
 	for _, issue := range issues {
+		if !github.HasLabel(issue, github.LabelBlocked) && !isRetryReadyLabeled(issue) {
+			// Neither escalated-and-held nor mid-re-arm — not a candidate
+			// this sweep needs to spend a probe on.
+			continue
+		}
+
 		taskID := fmt.Sprintf("GH-%d", issue.Number)
 		backoffKey := repickBackoffKey(projectPath, taskID)
 
@@ -157,8 +215,9 @@ func (c terminalCompletionChecker) sweepStalledRearm(ctx context.Context, projec
 		}
 		if !found {
 			// pilot-blocked from a different cause (e.g. GH-2402 deterministic
-			// title-guard escalation) or belongs to another project sharing
-			// this repo — nothing for this probe to evaluate.
+			// title-guard escalation), a retry-ready label on a task that was
+			// never stalled, or belongs to another project sharing this repo —
+			// nothing for this probe to evaluate.
 			continue
 		}
 

--- a/cmd/pilot/rearm_superseded.go
+++ b/cmd/pilot/rearm_superseded.go
@@ -70,7 +70,7 @@ func (c terminalCompletionChecker) tryRearmSuperseded(taskID, projectPath, backo
 	if err != nil {
 		return false, fmt.Errorf("listing issue #%d events: %w", issueNum, err)
 	}
-	rearmEvent := latestRearmEvent(events, c.triggerLabel, *exec.CompletedAt)
+	rearmEvent := latestRearmEvent(events, *exec.CompletedAt, c.triggerLabel)
 	if rearmEvent == nil {
 		// Open + labeled, but nothing in the timeline shows that state was
 		// reached AFTER the supersede — e.g. the label was already there

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -2517,6 +2517,27 @@ func (d *Dispatcher) surfaceStalledIssue(task *Task, reason string) {
 	}
 }
 
+// blockingClaimLogAttrs returns slog attributes describing the claim that
+// caused a "dispatch claim lost" drop — the blocking claim's generation and
+// the status of the execution it is bound to — so an incident shaped like
+// GH-493's (stale claims bound to terminal executions winning every claim
+// race, with the log giving no clue why) is diagnosable from the log alone
+// instead of requiring a direct execution_claims/executions query (GH-5272
+// acceptance criterion 3). Best-effort: a lookup failure or a since-vanished
+// claim yields no extra attributes rather than failing the drop log itself.
+func (d *Dispatcher) blockingClaimLogAttrs(taskID, projectPath string) []any {
+	gen, execID, found, err := d.store.LatestClaimGeneration(taskID, projectPath)
+	if err != nil || !found {
+		return nil
+	}
+	attrs := []any{slog.Int("blocking_claim_generation", gen)}
+	exec, err := d.store.GetExecution(execID)
+	if err != nil {
+		return attrs
+	}
+	return append(attrs, slog.String("blocking_execution_status", exec.Status))
+}
+
 // queueDecomposedTask handles queuing a decomposed task and its subtasks.
 // The parent task is marked as "decomposed" and subtasks are queued in order.
 func (d *Dispatcher) queueDecomposedTask(ctx context.Context, parent *Task, result *DecomposeResult) (string, error) {
@@ -2542,8 +2563,10 @@ func (d *Dispatcher) queueDecomposedTask(ctx context.Context, parent *Task, resu
 		// either FK-787 (no executions row to reference) or start a
 		// genuine duplicate run.
 		d.log.Info("dispatch claim lost — decomposed parent already owned by another dispatch channel or already terminal, dropping duplicate pickup",
-			slog.String("task_id", parent.ID),
-			slog.String("project", parent.ProjectPath),
+			append([]any{
+				slog.String("task_id", parent.ID),
+				slog.String("project", parent.ProjectPath),
+			}, d.blockingClaimLogAttrs(parent.ID, parent.ProjectPath)...)...,
 		)
 		return "", nil
 	}
@@ -2607,8 +2630,10 @@ func (d *Dispatcher) queueSingleTask(ctx context.Context, task *Task) (string, e
 		// exactly like an already-handled task, not a failure to log or
 		// retry.
 		d.log.Info("dispatch claim lost — task already owned by another dispatch channel or already terminal, dropping duplicate pickup",
-			slog.String("task_id", task.ID),
-			slog.String("project", task.ProjectPath),
+			append([]any{
+				slog.String("task_id", task.ID),
+				slog.String("project", task.ProjectPath),
+			}, d.blockingClaimLogAttrs(task.ID, task.ProjectPath)...)...,
 		)
 		return "", nil
 	}

--- a/internal/executor/gh5272_stalled_rearm_test.go
+++ b/internal/executor/gh5272_stalled_rearm_test.go
@@ -1,0 +1,259 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDispatcher_NextRetryGeneration_AdvancesPastFailedThenStalledClaims is
+// the GH-5272 acceptance-test step 1: two terminal executions (a "failed" row
+// at generation 0, then a "stalled" row at generation 1 — the exact shape
+// GH-493 reproduced: two 1h hard-timeout kills in a row) must not permanently
+// occupy the claim ledger. nextRetryGeneration is expected to advance past
+// the highest terminal-bound generation (both "failed" and "stalled" count as
+// terminal per isTerminalExecutionStatus) and beginWithGenerationRetry must
+// turn that into a genuine generation-2 claim — the pilot-retry-ready re-arm
+// path's actual dispatch mechanism.
+//
+// This passes on main: the claim-race logic itself (LatestClaimGeneration +
+// nextRetryGeneration + ClaimExecution) already does the right thing here —
+// GH-4372's dead-owner carve-out already treats a stalled claim as
+// terminal-not-done and hands out generation+1. Kept as a regression guard;
+// see TestDispatcher_BeginWithGenerationRetry_HardCapEscalatedTaskCanReArm
+// below for the actual GH-5272 defect, which lives one layer up in the
+// persisted repick-backoff hard-cap counter, not in the claim ledger itself.
+func TestDispatcher_NextRetryGeneration_AdvancesPastFailedThenStalledClaims(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	taskID, projectPath := "GH-493", "/project-gh-493"
+
+	// Generation 0: a real execution that ran and hit the 1h hard-timeout
+	// cap, recorded as "failed" (mirrors 77f7265f from the incident).
+	gen0Task := &Task{ID: taskID, ProjectPath: projectPath}
+	execID0, err := NewExecutionLifecycle(store).Begin(gen0Task, ExecStatusRunning, 0)
+	if err != nil {
+		t.Fatalf("setup: generation 0 Begin failed: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(execID0, string(ExecStatusFailed), "execution exceeded 1h hard cap"); err != nil {
+		t.Fatalf("setup: failed to mark generation 0 as failed: %v", err)
+	}
+
+	// Generation 1: the retry also ran and hit the same 1h hard-timeout cap,
+	// this time recorded as "stalled" by the watchdog (mirrors a1c3aaeb).
+	gen1Task := &Task{ID: taskID, ProjectPath: projectPath}
+	execID1, err := NewExecutionLifecycle(store).Begin(gen1Task, ExecStatusRunning, 1)
+	if err != nil {
+		t.Fatalf("setup: generation 1 Begin failed: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(execID1, string(ExecStatusStalled), "execution exceeded 1h hard cap"); err != nil {
+		t.Fatalf("setup: failed to mark generation 1 as stalled: %v", err)
+	}
+
+	dispatcher := NewDispatcher(store, NewRunner(), nil)
+
+	gen, retry, err := dispatcher.nextRetryGeneration(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("nextRetryGeneration: %v", err)
+	}
+	if !retry {
+		t.Fatal("expected retry=true — neither a failed nor a stalled row is a live owner or a done task")
+	}
+	if gen != 2 {
+		t.Errorf("expected nextRetryGeneration to advance past the highest terminal-bound generation (1) to 2, got %d", gen)
+	}
+
+	// The pilot-retry-ready re-arm path's actual dispatch mechanism: the next
+	// poller pickup for the same task_id.
+	freshTask := &Task{ID: taskID, ProjectPath: projectPath}
+	execID, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry: %v", err)
+	}
+	if execID == "" {
+		t.Fatal("expected the pilot-retry-ready re-arm to claim generation 2, got empty execID (claim-lost loop reproduced)")
+	}
+
+	genCheck, execCheck, found, err := store.LatestClaimGeneration(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestClaimGeneration: %v", err)
+	}
+	if !found || genCheck != 2 {
+		t.Errorf("expected latest claim generation 2, found=%v got=%d", found, genCheck)
+	}
+	if execCheck != execID {
+		t.Errorf("expected the generation 2 claim to reference %q, got %q", execID, execCheck)
+	}
+}
+
+// TestDispatcher_BeginWithGenerationRetry_HardCapEscalatedTaskStaysDroppedWithoutExternalRearm
+// documents the actual defect behind the GH-493 incident and where its fix
+// does NOT belong. Once a task trips the repick hard cap
+// (dispatcherRepickHardCap) and is escalated-and-held
+// (stallTaskAfterRepickHardCap marks its claim "stalled" and persists the
+// consecutive-drops counter at/above the cap), beginWithGenerationRetry must
+// keep dropping every subsequent pickup attempt on its own — it has no
+// GitHub-label visibility, so it cannot tell a genuine pilot-retry-ready
+// re-arm apart from an ordinary poll tick that re-offers the same wedged
+// task_id. TestDispatcher_BeginWithGenerationRetry_HardCapIsIdempotent
+// already covers exactly this invariant for the "nothing external happened"
+// case; this test is the GH-5272 sibling proving it holds even with the
+// exact GH-493 end state (claimed execution failed, then escalated to
+// stalled, persisted hard-cap counter) reproduced directly.
+//
+// The actual fix lives one layer up, in cmd/pilot's terminalCompletionChecker
+// (rearm_stalled.go's tryRearmStalled/sweepStalledRearm, GH-5212's re-arm
+// probe extended by GH-5272) — the only place with GitHub API access to
+// confirm a genuine post-stall pilot-retry-ready label add or issue reopen
+// happened. That probe's two GH-5272 fixes are exercised by
+// cmd/pilot/gh5272_stalled_rearm_test.go:
+//  1. sweepStalledRearm's candidate query no longer requires pilot-blocked —
+//     the bot's own posted re-arm recipe removes that label in the same edit
+//     that adds pilot-retry-ready, so a pilot-blocked-only query missed
+//     every issue an operator had just re-armed correctly.
+//  2. tryRearmStalled's re-arm evidence check now also accepts a labeled
+//     event for pilot-retry-ready/-1/-2 (not just the base trigger label),
+//     since the documented recipe never touches the base label at all.
+//
+// Once tryRearmStalled confirms re-arm evidence, it demotes the stalled row
+// to failed (store.ReclassifyStalledForRearm — verified below to correctly
+// unblock the ordinary retry path with no dispatcher-side bypass needed) and
+// calls repickBackoff.recordSuccess, which clears the exact persisted
+// consecutive-drops counter this test proves beginWithGenerationRetry cannot
+// clear on its own.
+func TestDispatcher_BeginWithGenerationRetry_HardCapEscalatedTaskStaysDroppedWithoutExternalRearm(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// SourceAdapter left empty (not "github") so stallTaskAfterRepickHardCap's
+	// surfaceStalledIssue step skips shelling out to the gh CLI entirely —
+	// mirrors TestDispatcher_StallTaskAfterRepickHardCap_NonGitHubTaskSkipsGHCLI.
+	// The escalation-and-hard-cap-counter mechanics under test are identical
+	// either way.
+	taskID, projectPath := "GH-493", "/project-gh-493-hardcap"
+	task := &Task{ID: taskID, ProjectPath: projectPath}
+
+	dispatcher := NewDispatcher(store, NewRunner(), nil)
+	var buf bytes.Buffer
+	dispatcher.log = slog.New(slog.NewTextHandler(&buf, nil))
+	key := repickBackoffKey(projectPath, taskID)
+
+	// Reproduce the GH-493 end state directly: a claimed execution and a
+	// persisted repick-backoff counter already at the hard cap, then drive
+	// the actual escalation path (stallTaskAfterRepickHardCap) exactly as
+	// beginWithGenerationRetry's hard-cap branch would — this is what
+	// happened to GH-493 before the two terminal executions the issue's
+	// timeline calls out explicitly.
+	execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("setup Begin: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(execID, string(ExecStatusFailed), "boom"); err != nil {
+		t.Fatalf("setup: failed to mark execution failed: %v", err)
+	}
+	if err := dispatcher.SetRepickBackoffState(key, dispatcherRepickHardCap, time.Now().Add(-time.Minute)); err != nil {
+		t.Fatalf("setup SetRepickBackoffState: %v", err)
+	}
+	dispatcher.stallTaskAfterRepickHardCap(task, 0, dispatcherRepickHardCap)
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != string(ExecStatusStalled) {
+		t.Fatalf("expected the hard-cap escalation to mark the claimed execution stalled, got %q", exec.Status)
+	}
+	if !strings.Contains(exec.Error, "repick backoff hard cap reached") {
+		t.Fatalf("expected the hard-cap escalation reason on the claimed execution, got %q", exec.Error)
+	}
+
+	consecutiveDrops, _, found, err := dispatcher.RepickBackoffState(key)
+	if err != nil {
+		t.Fatalf("RepickBackoffState: %v", err)
+	}
+	if !found || consecutiveDrops < dispatcherRepickHardCap {
+		t.Fatalf("expected the persisted hard-cap counter to remain at/above the cap after escalation, found=%v got=%d", found, consecutiveDrops)
+	}
+
+	// Simulate an ordinary poller pickup with NO external re-arm signal
+	// available to this layer (no GitHub label was checked, no operator
+	// action occurred) — beginWithGenerationRetry must stay dropped, exactly
+	// like TestDispatcher_BeginWithGenerationRetry_HardCapIsIdempotent
+	// requires. Inferring a re-arm from claim state alone here would be
+	// unsafe — see that test's own doc comment.
+	buf.Reset()
+	rearmedTask := &Task{ID: taskID, ProjectPath: projectPath}
+	execID, err = dispatcher.beginWithGenerationRetry(rearmedTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry: %v", err)
+	}
+	if execID != "" {
+		t.Fatalf("expected the pickup to stay dropped with no external re-arm evidence, got execID=%q", execID)
+	}
+
+	// Now apply exactly what tryRearmStalled does once it confirms GitHub-side
+	// re-arm evidence (store.ReclassifyStalledForRearm + repickBackoff's
+	// ClearRepickBackoffState, proxied here directly since this package has
+	// no GitHub client) — proving those two calls are a sufficient, correct
+	// unblock with no bypass of beginWithGenerationRetry's own invariants.
+	if err := store.ReclassifyStalledForRearm(taskID, projectPath, "test: simulated GH-5272 re-arm"); err != nil {
+		t.Fatalf("ReclassifyStalledForRearm: %v", err)
+	}
+	if err := dispatcher.ClearRepickBackoffState(key); err != nil {
+		t.Fatalf("ClearRepickBackoffState: %v", err)
+	}
+
+	buf.Reset()
+	execID, err = dispatcher.beginWithGenerationRetry(rearmedTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry after simulated re-arm: %v", err)
+	}
+	if execID == "" {
+		t.Fatalf("expected the simulated re-arm to claim a fresh generation, got dropped pickup: log=%s", buf.String())
+	}
+}
+
+// TestDispatcher_QueueSingleTask_ClaimLostLogsBlockingClaimDetails is the
+// GH-5272 acceptance-test step 3 regression test: the "dispatch claim lost"
+// drop log must carry the blocking claim's generation and the owning
+// execution's status, so an incident like GH-493's can be diagnosed from the
+// log alone instead of requiring a direct SQL query against execution_claims.
+func TestDispatcher_QueueSingleTask_ClaimLostLogsBlockingClaimDetails(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	taskID, projectPath := "GH-5272-LOGFIELDS", "/project-gh-5272-logfields"
+
+	liveTask := &Task{ID: taskID, ProjectPath: projectPath}
+	if _, err := NewExecutionLifecycle(store).Begin(liveTask, ExecStatusRunning, 0); err != nil {
+		t.Fatalf("setup: winning Begin failed: %v", err)
+	}
+
+	dispatcher := NewDispatcher(store, NewRunner(), nil)
+	var buf bytes.Buffer
+	dispatcher.log = slog.New(slog.NewTextHandler(&buf, nil))
+
+	dupTask := &Task{ID: taskID, ProjectPath: projectPath}
+	execID, err := dispatcher.queueSingleTask(context.Background(), dupTask)
+	if err != nil {
+		t.Fatalf("expected the duplicate pickup against a live owner to drop silently, got error: %v", err)
+	}
+	if execID != "" {
+		t.Errorf("expected empty execID for a live-owner duplicate pickup, got %q", execID)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "dispatch claim lost") {
+		t.Fatalf("expected a log noting the dropped claim, got: %s", logged)
+	}
+	if !strings.Contains(logged, "blocking_claim_generation=0") {
+		t.Errorf("expected the claim-lost log to carry the blocking claim's generation, got: %s", logged)
+	}
+	if !strings.Contains(logged, "blocking_execution_status=running") {
+		t.Errorf("expected the claim-lost log to carry the owning execution's status, got: %s", logged)
+	}
+}


### PR DESCRIPTION
## Summary

GH-5272: a task whose last execution ended `stalled` could not be re-dispatched via the documented `pilot-retry-ready` re-arm path — every pickup attempt lost the claim race and re-entered repick backoff indefinitely, requiring operator SQL surgery to recover (see GH-493 incident timeline in `.agent/tasks/gh-5272.md`).

**Root cause was not the claim ledger.** `nextRetryGeneration`'s dead-owner carve-out (GH-4372) already advances past claims bound to terminal (`failed`/`stalled`) executions correctly — verified with a new regression test that passes unmodified on main. The actual defect was in GH-5212's `tryRearmStalled`/`sweepStalledRearm` mechanism (`cmd/pilot/rearm_stalled.go`), which already existed to clear the stale persisted `repick_backoff` hard-cap counter on a genuine re-arm, but had two gaps that both happen to exactly match the bot's own documented re-arm recipe (`gh issue edit N --remove-label pilot-blocked --add-label pilot-retry-ready`):

1. `sweepStalledRearm`'s candidate query only listed issues still carrying `pilot-blocked` — but the recipe removes that label in the same edit that adds `pilot-retry-ready`, so the re-armed issue had already dropped out of the only candidate query by the time any sweep pass could see it.
2. `tryRearmStalled`'s evidence check (`latestRearmEvent`) only recognized a labeled/reopened event for the base `pilot` trigger label — which the recipe never touches at all.

## Changes

- `cmd/pilot/rearm_stalled.go`: sweep now lists all open issues and matches on `pilot-blocked` OR any of `pilot-retry-ready`/`pilot-retry-1`/`pilot-retry-2`; `tryRearmStalled`'s evidence check now also accepts a labeled event for that same label family.
- `cmd/pilot/rearm_canceled.go`: extended `latestRearmEvent` to accept variadic labels (used by the above); updated its own and `rearm_superseded.go`'s call sites.
- `internal/executor/dispatcher.go`: "dispatch claim lost" WARN logs now include `blocking_claim_generation` and `blocking_execution_status` so a future incident of this shape is diagnosable from the log alone (acceptance criterion 3).
- New regression tests: `internal/executor/gh5272_stalled_rearm_test.go` (dispatcher-layer, including a test proving `beginWithGenerationRetry` must never self-infer a re-arm without external GitHub-side evidence) and `cmd/pilot/gh5272_stalled_rearm_test.go` (end-to-end reproduction of the exact GH-493 recipe at both the single-issue and sweep level).
- `.agent/tasks/gh-5272.md`: documents the investigation and root cause.

A dispatcher-side fix (inferring re-arm from claim state alone) was attempted and reverted — it broke `TestDispatcher_BeginWithGenerationRetry_HardCapIsIdempotent`, an existing invariant that the dispatcher must never self-declare a re-arm without external evidence.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` green (no regressions)
- [x] New regression tests cover both the claim-race scenario (already fixed on main) and the actual GH-5212 evidence/discovery gaps (fixed here)