### PR TITLE
GH-5344: fix(executor): effort classifier sends CLAUDE_CODE_OAUTH_TOKEN as x-api-key — 401 on every task since 08-23, direct mode never runs

### DIFF
--- a/internal/executor/anthropic_auth.go
+++ b/internal/executor/anthropic_auth.go
@@ -1,0 +1,63 @@
+package executor
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// anthropicAPIStatusError carries the HTTP status code from a non-200
+// Anthropic Messages API response so callers can distinguish, e.g., a 401
+// (bad/rejected credential) from a transient 5xx without string-matching
+// the error text.
+type anthropicAPIStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *anthropicAPIStatusError) Error() string {
+	return fmt.Sprintf("API returned %d: %s", e.StatusCode, e.Body)
+}
+
+// anthropicOAuthBetaHeader is required by the Anthropic Messages API when
+// authenticating with a Claude Code subscription OAuth token instead of a
+// real API key.
+const anthropicOAuthBetaHeader = "oauth-2025-04-20"
+
+// isAnthropicOAuthToken reports whether key is a Claude Code subscription
+// OAuth token (e.g. "sk-ant-oat01-...") rather than an Anthropic API key
+// (e.g. "sk-ant-api03-..."). Both share the "sk-ant-" prefix, so the two
+// must be told apart by the segment that follows it.
+//
+// GH-5344: the effort classifier and the direct Anthropic backend both used
+// to treat every "sk-ant-" value as an API key and send it via x-api-key.
+// OAuth tokens rejected that header with 401 "API key is invalid" on every
+// call — direct mode never worked on hosts where only
+// CLAUDE_CODE_OAUTH_TOKEN is set (the founder box).
+func isAnthropicOAuthToken(key string) bool {
+	rest := strings.TrimPrefix(key, "sk-ant-")
+	if rest == key {
+		// No "sk-ant-" prefix at all — not an Anthropic-issued credential
+		// of either kind (e.g. a bare bearer token from a proxy).
+		return false
+	}
+	return !strings.HasPrefix(rest, "api")
+}
+
+// setAnthropicAuthHeaders sets the appropriate authentication header(s) on
+// req for apiKey, distinguishing Anthropic API keys from Claude Code OAuth
+// tokens:
+//   - "sk-ant-api..." (API key)         -> x-api-key
+//   - "sk-ant-oat..." (OAuth token)      -> Authorization: Bearer + anthropic-beta
+//   - anything else (e.g. proxy tokens) -> Authorization: Bearer
+func setAnthropicAuthHeaders(req *http.Request, apiKey string) {
+	switch {
+	case isAnthropicOAuthToken(apiKey):
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		req.Header.Set("anthropic-beta", anthropicOAuthBetaHeader)
+	case strings.HasPrefix(apiKey, "sk-ant-"):
+		req.Header.Set("x-api-key", apiKey)
+	default:
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+}

--- a/internal/executor/anthropic_auth_test.go
+++ b/internal/executor/anthropic_auth_test.go
@@ -1,0 +1,73 @@
+package executor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsAnthropicOAuthToken(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{"oauth token", "sk-ant-oat01-abc123", true},
+		{"api key", "sk-ant-api03-abc123", false},
+		{"bare sk-ant- prefix, no api segment", "sk-ant-somethingelse", true},
+		{"non anthropic bearer token", "some-proxy-token", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAnthropicOAuthToken(tt.key); got != tt.want {
+				t.Errorf("isAnthropicOAuthToken(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetAnthropicAuthHeaders(t *testing.T) {
+	tests := []struct {
+		name           string
+		apiKey         string
+		wantXAPIKey    string
+		wantAuth       string
+		wantBetaHeader string
+	}{
+		{
+			name:        "API key uses x-api-key",
+			apiKey:      "sk-ant-api03-abc123",
+			wantXAPIKey: "sk-ant-api03-abc123",
+		},
+		{
+			name:           "OAuth token uses Authorization Bearer + beta header",
+			apiKey:         "sk-ant-oat01-abc123",
+			wantAuth:       "Bearer sk-ant-oat01-abc123",
+			wantBetaHeader: anthropicOAuthBetaHeader,
+		},
+		{
+			name:     "non sk-ant- token uses Authorization Bearer",
+			apiKey:   "some-proxy-token",
+			wantAuth: "Bearer some-proxy-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+			setAnthropicAuthHeaders(req, tt.apiKey)
+
+			if got := req.Header.Get("x-api-key"); got != tt.wantXAPIKey {
+				t.Errorf("x-api-key = %q, want %q", got, tt.wantXAPIKey)
+			}
+			if got := req.Header.Get("Authorization"); got != tt.wantAuth {
+				t.Errorf("Authorization = %q, want %q", got, tt.wantAuth)
+			}
+			if got := req.Header.Get("anthropic-beta"); got != tt.wantBetaHeader {
+				t.Errorf("anthropic-beta = %q, want %q", got, tt.wantBetaHeader)
+			}
+		})
+	}
+}

--- a/internal/executor/backend_anthropic.go
+++ b/internal/executor/backend_anthropic.go
@@ -345,14 +345,12 @@ func (b *AnthropicBackend) callAPI(ctx context.Context, req *apiRequest) (*apiRe
 		httpReq.Header.Set("anthropic-version", anthropicAPIVersion)
 		httpReq.Header.Set("Accept", "text/event-stream")
 
-		// All sk-ant-* tokens (API keys AND OAuth) use x-api-key header.
-		// This matches effort_classifier.go behavior — OAuth tokens work
-		// with x-api-key but NOT with Authorization: Bearer.
-		if strings.HasPrefix(b.apiKey, "sk-ant-") {
-			httpReq.Header.Set("x-api-key", b.apiKey)
-		} else {
-			httpReq.Header.Set("Authorization", "Bearer "+b.apiKey)
-		}
+		// GH-5344: OAuth tokens (sk-ant-oat...) and API keys (sk-ant-api...)
+		// share the "sk-ant-" prefix but require different auth headers —
+		// sending an OAuth token via x-api-key gets a 401 "API key is
+		// invalid". setAnthropicAuthHeaders tells them apart and adds the
+		// anthropic-beta header OAuth needs.
+		setAnthropicAuthHeaders(httpReq, b.apiKey)
 
 		resp, err := http.DefaultClient.Do(httpReq)
 		if err != nil {

--- a/internal/executor/effort_classifier.go
+++ b/internal/executor/effort_classifier.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -12,6 +13,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/qf-studio/pilot/internal/logging"
@@ -34,6 +36,12 @@ type EffortClassifier struct {
 	useStructuredOutput bool
 	apiKey              string // Anthropic API key or OAuth token for direct API mode
 	apiURL              string // API endpoint URL (default: https://api.anthropic.com/v1/messages)
+
+	// directModeDisabled latches true once an OAuth-token direct call has
+	// been rejected with 401. GH-5344: a token that the Messages API won't
+	// accept isn't going to start working mid-process — remembering this
+	// avoids paying a failing HTTPS round trip on every subsequent task.
+	directModeDisabled atomic.Bool
 
 	// cmdRunner is the function that executes the claude command (subprocess mode).
 	// Can be overridden for testing.
@@ -144,9 +152,18 @@ func (c *EffortClassifier) Classify(ctx context.Context, task *Task) string {
 	// Try direct API call first (lightweight, ~1MB vs ~300MB subprocess)
 	var result string
 	var err error
-	if c.apiKey != "" {
+	if c.apiKey != "" && !c.directModeDisabled.Load() {
 		result, err = c.classifyViaAPI(ctx, task)
 		if err != nil {
+			var statusErr *anthropicAPIStatusError
+			if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusUnauthorized && isAnthropicOAuthToken(c.apiKey) {
+				// GH-5344: an OAuth token that the Messages API rejects once
+				// will reject every subsequent call too — stop paying for a
+				// failing round trip per task.
+				if c.directModeDisabled.CompareAndSwap(false, true) {
+					c.log.Info("direct classifier disabled: token rejected")
+				}
+			}
 			c.log.Warn("Direct API classification failed, trying subprocess",
 				slog.String("task_id", task.ID),
 				slog.Any("error", err),
@@ -241,13 +258,7 @@ func (c *EffortClassifier) classifyViaAPI(ctx context.Context, task *Task) (stri
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("anthropic-version", "2023-06-01")
-
-	// Try OAuth token as API key
-	if strings.HasPrefix(c.apiKey, "sk-ant-") {
-		req.Header.Set("x-api-key", c.apiKey)
-	} else {
-		req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	}
+	setAnthropicAuthHeaders(req, c.apiKey)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -261,7 +272,10 @@ func (c *EffortClassifier) classifyViaAPI(ctx context.Context, task *Task) (stri
 	}
 
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("API returned %d: %s", resp.StatusCode, string(respBody[:min(len(respBody), 200)]))
+		return "", &anthropicAPIStatusError{
+			StatusCode: resp.StatusCode,
+			Body:       string(respBody[:min(len(respBody), 200)]),
+		}
 	}
 
 	var apiResp anthropicResponse

--- a/internal/executor/effort_classifier_test.go
+++ b/internal/executor/effort_classifier_test.go
@@ -3,7 +3,13 @@ package executor
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/logging"
 )
 
 // mockEffortRunner creates a test runner that returns canned effort JSON.
@@ -230,6 +236,152 @@ func TestEffortClassifier_TaskWithoutID(t *testing.T) {
 	// Without ID, should call subprocess twice (no caching)
 	if callCount != 2 {
 		t.Errorf("expected 2 subprocess calls (no cache without ID), got %d", callCount)
+	}
+}
+
+// newTestEffortClassifier builds a classifier pointed at a local test
+// server, bypassing NewEffortClassifier's env-based key discovery so tests
+// are hermetic regardless of the ambient environment.
+func newTestEffortClassifier(t *testing.T, serverURL, apiKey string, runner func(ctx context.Context, args ...string) ([]byte, error)) *EffortClassifier {
+	t.Helper()
+	return &EffortClassifier{
+		model:     "claude-haiku-4-5-20251001",
+		apiURL:    serverURL,
+		apiKey:    apiKey,
+		timeout:   5 * time.Second,
+		log:       logging.WithComponent("effort-classifier-test"),
+		cache:     make(map[string]string),
+		cmdRunner: runner,
+	}
+}
+
+func TestEffortClassifier_OAuthTokenUsesBearerAndBetaHeader(t *testing.T) {
+	var gotXAPIKey, gotAuth, gotBeta string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotXAPIKey = r.Header.Get("x-api-key")
+		gotAuth = r.Header.Get("Authorization")
+		gotBeta = r.Header.Get("anthropic-beta")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"{\"effort\":\"low\",\"reason\":\"n/a\"}"}]}`))
+	}))
+	defer srv.Close()
+
+	classifier := newTestEffortClassifier(t, srv.URL, "sk-ant-oat01-test-oauth-token", mockEffortRunner("medium", "should not be used"))
+	task := &Task{ID: "GH-600", Title: "t", Description: "d"}
+
+	result := classifier.Classify(context.Background(), task)
+	if result != "low" {
+		t.Fatalf("expected direct API result 'low', got %q", result)
+	}
+	if gotXAPIKey != "" {
+		t.Errorf("x-api-key should be empty for OAuth token, got %q", gotXAPIKey)
+	}
+	if gotAuth != "Bearer sk-ant-oat01-test-oauth-token" {
+		t.Errorf("Authorization = %q, want Bearer sk-ant-oat01-test-oauth-token", gotAuth)
+	}
+	if gotBeta != anthropicOAuthBetaHeader {
+		t.Errorf("anthropic-beta = %q, want %q", gotBeta, anthropicOAuthBetaHeader)
+	}
+}
+
+func TestEffortClassifier_APIKeyUsesXAPIKeyHeader(t *testing.T) {
+	var gotXAPIKey, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotXAPIKey = r.Header.Get("x-api-key")
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"{\"effort\":\"low\",\"reason\":\"n/a\"}"}]}`))
+	}))
+	defer srv.Close()
+
+	classifier := newTestEffortClassifier(t, srv.URL, "sk-ant-api03-test-key", mockEffortRunner("medium", "should not be used"))
+	task := &Task{ID: "GH-601", Title: "t", Description: "d"}
+
+	result := classifier.Classify(context.Background(), task)
+	if result != "low" {
+		t.Fatalf("expected direct API result 'low', got %q", result)
+	}
+	if gotXAPIKey != "sk-ant-api03-test-key" {
+		t.Errorf("x-api-key = %q, want sk-ant-api03-test-key", gotXAPIKey)
+	}
+	if gotAuth != "" {
+		t.Errorf("Authorization should be empty for API key, got %q", gotAuth)
+	}
+}
+
+func TestEffortClassifier_OAuth401DisablesDirectModeForSubsequentCalls(t *testing.T) {
+	var apiHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&apiHits, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"type":"authentication_error","message":"API key is invalid"}}`))
+	}))
+	defer srv.Close()
+
+	var subprocessHits int32
+	runner := func(ctx context.Context, args ...string) ([]byte, error) {
+		atomic.AddInt32(&subprocessHits, 1)
+		return []byte(`{"effort":"low","reason":"n/a"}`), nil
+	}
+
+	classifier := newTestEffortClassifier(t, srv.URL, "sk-ant-oat01-test-oauth-token", runner)
+
+	task1 := &Task{ID: "GH-700", Title: "t1", Description: "d1"}
+	if result := classifier.Classify(context.Background(), task1); result != "low" {
+		t.Fatalf("expected subprocess fallback result 'low', got %q", result)
+	}
+	if got := atomic.LoadInt32(&apiHits); got != 1 {
+		t.Fatalf("expected 1 API hit after first call, got %d", got)
+	}
+	if got := atomic.LoadInt32(&subprocessHits); got != 1 {
+		t.Fatalf("expected 1 subprocess call after first call, got %d", got)
+	}
+	if !classifier.directModeDisabled.Load() {
+		t.Fatal("expected directModeDisabled to be true after a 401 on an OAuth token")
+	}
+
+	// Second call, different task (so cache doesn't short-circuit): direct
+	// mode must be skipped entirely — no second failing round trip.
+	task2 := &Task{ID: "GH-701", Title: "t2", Description: "d2"}
+	if result := classifier.Classify(context.Background(), task2); result != "low" {
+		t.Fatalf("expected subprocess fallback result 'low', got %q", result)
+	}
+	if got := atomic.LoadInt32(&apiHits); got != 1 {
+		t.Fatalf("expected direct mode to stay disabled (still 1 API hit), got %d", got)
+	}
+	if got := atomic.LoadInt32(&subprocessHits); got != 2 {
+		t.Fatalf("expected 2 subprocess calls total, got %d", got)
+	}
+}
+
+func TestEffortClassifier_APIKey401DoesNotDisableDirectMode(t *testing.T) {
+	// A rejected API key (not an OAuth token) is not the "OAuth token can
+	// never work" case this latch targets — direct mode should keep being
+	// attempted (e.g. a misconfigured key could be fixed via env reload in
+	// a longer-lived process, and non-OAuth 401s aren't guaranteed to be
+	// permanent in the same way).
+	var apiHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&apiHits, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"type":"authentication_error","message":"API key is invalid"}}`))
+	}))
+	defer srv.Close()
+
+	runner := mockEffortRunner("low", "n/a")
+	classifier := newTestEffortClassifier(t, srv.URL, "sk-ant-api03-bad-key", runner)
+
+	task1 := &Task{ID: "GH-702", Title: "t1", Description: "d1"}
+	classifier.Classify(context.Background(), task1)
+
+	task2 := &Task{ID: "GH-703", Title: "t2", Description: "d2"}
+	classifier.Classify(context.Background(), task2)
+
+	if got := atomic.LoadInt32(&apiHits); got != 2 {
+		t.Errorf("expected direct mode to still be attempted for a rejected API key, got %d hits", got)
+	}
+	if classifier.directModeDisabled.Load() {
+		t.Error("directModeDisabled should not latch for a non-OAuth token 401")
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5344.

Closes #5344

## Changes

GitHub Issue GH-5344: fix(executor): effort classifier sends CLAUDE_CODE_OAUTH_TOKEN as x-api-key — 401 on every task since 08-23, direct mode never runs

## Context

The effort classifier's direct-API mode has failed with HTTP 401 `API key is invalid` on every classification since 2026-08-23 (164 hits in today's daemon log alone), then falls back to the `claude --print` subprocess. Functionally harmless, but every task pays a failing HTTPS round trip and a WARN, and the direct mode that was built to be cheaper never runs.

Root cause in `internal/executor/effort_classifier.go`:

- Key discovery (~line 91) falls through `PILOT_CLASSIFIER_API_KEY` → `ANTHROPIC_API_KEY` → `ANTHROPIC_AUTH_TOKEN` → `CLAUDE_CODE_OAUTH_TOKEN`. On the founder box only `CLAUDE_CODE_OAUTH_TOKEN` is set (Claude Code subscription OAuth token, prefix `sk-ant-oat…`, length 108).
- Header selection (~lines 246-250): `if strings.HasPrefix(c.apiKey, "sk-ant-") { x-api-key } else { Authorization: Bearer }`. OAuth tokens also start with `sk-ant-` (`sk-ant-oat01-…`), so the OAuth token is sent as an API key → 401.

## Implementation

1. Distinguish token kinds by prefix: `sk-ant-oat` (and any `sk-ant-` token whose next segment is not `api`) is OAuth → send `Authorization: Bearer <token>` plus the `anthropic-beta: oauth-2025-04-20` header; `sk-ant-api…` → `x-api-key`. Keep the current behaviour for non-`sk-ant-` values.
2. If an OAuth token is rejected (401) once, remember it for the process lifetime and skip direct mode thereafter (log once at INFO "direct classifier disabled: token rejected"), so a token that cannot be used for the Messages API does not cost a failing call per task.
3. Apply the same header logic to any other direct Anthropic caller that uses the same discovery list (check `internal/executor/backend_anthropic.go` ~59 and `internal/executor/preflight.go` ~176; only change them if they share the bug).
4. Tests: table test for header selection by token kind; test that a 401 disables direct mode for subsequent calls.

## Acceptance

- [ ] With only `CLAUDE_CODE_OAUTH_TOKEN` set, the direct call either succeeds (Bearer + beta header) or is attempted once and then skipped; no repeated 401 WARNs.
- [ ] With `PILOT_CLASSIFIER_API_KEY` or `ANTHROPIC_API_KEY` set to an API key, `x-api-key` is used (unchanged).
- [ ] Existing classifier tests green.