### PR TITLE
GH-5350: fix(executor): in-process decomposer ignores the no-decompose label and splits on acceptance bullets; TUI paints completed subtasks as failed

### DIFF
--- a/internal/executor/decompose.go
+++ b/internal/executor/decompose.go
@@ -137,6 +137,19 @@ func HasNoDecomposePhrase(task *Task) bool {
 	return false
 }
 
+// TaskOptsOutOfDecomposition reports whether task carries the no-decompose
+// label, the [no-plan] keyword, or standalone no-decompose prose — the exact
+// three-way predicate runner.go's epic path (hasNoDecompose) already used to
+// skip planning mode entirely (GH-664/GH-1687/GH-3597). GH-5350: call sites
+// that invoke the in-process decomposer need this SAME predicate evaluated
+// BEFORE calling Decompose(), so they can log the skip explicitly and
+// unconditionally instead of relying solely on Decompose()'s internal label
+// re-check (which only surfaces via ReportableSkip, and only when the task's
+// complexity tier would otherwise have triggered decomposition).
+func TaskOptsOutOfDecomposition(task *Task) bool {
+	return HasLabel(task, NoDecomposeLabel) || HasNoPlanKeyword(task) || HasNoDecomposePhrase(task)
+}
+
 // TaskDecomposer handles breaking complex tasks into smaller subtasks.
 type TaskDecomposer struct {
 	config     *DecomposeConfig
@@ -368,6 +381,49 @@ func (d *TaskDecomposer) SkipLogDetail(result *DecomposeResult) string {
 	}
 }
 
+// acceptanceSectionHeaderPattern matches the H2/H3 headers whose checklist
+// items are verification criteria, not implementation work units (GH-5350):
+// "## Acceptance", "## Acceptance Criteria", "### Done", etc. Mirrors the H2
+// vocabulary the spec validator requires (see
+// .agent/sops/onboarding/new-project-issue-authoring.md Rule 2) — every
+// Pilot-authored issue in this project structures its body as
+// Context/Implementation/Acceptance, so "## Acceptance" is the section
+// analyzeAndSplit must never treat as a decomposition boundary.
+var acceptanceSectionHeaderPattern = regexp.MustCompile(`(?i)^(Acceptance(\s+Criteria)?|Done)\s*$`)
+
+// stripAcceptanceSections removes the body of every "## Acceptance"/"## Done"
+// (H2 or H3) section — from its header through the next H2/H3 header or end
+// of text — so checklist-based decomposition never splits on verification
+// criteria (GH-5350). #5348/#5342 (both no-decompose labelled, but evidence
+// that the same class of body would misfire even without the label) show the
+// in-process decomposer previously exploding a "## Acceptance" checklist into
+// one "prove criterion N" subtask per bullet instead of real implementation
+// steps. Sections outside Acceptance/Done (e.g. "## Implementation") keep
+// their checklist items eligible for Strategy 1 below.
+func stripAcceptanceSections(text string) string {
+	headerLine := regexp.MustCompile(`(?m)^#{2,3}[ \t]+(.*)$`)
+	locs := headerLine.FindAllStringSubmatchIndex(text, -1)
+	if len(locs) == 0 {
+		return text
+	}
+
+	var sb strings.Builder
+	last := 0
+	for i, loc := range locs {
+		headerTitle := strings.TrimSpace(text[loc[2]:loc[3]])
+		sectionEnd := len(text)
+		if i+1 < len(locs) {
+			sectionEnd = locs[i+1][0]
+		}
+		if acceptanceSectionHeaderPattern.MatchString(headerTitle) {
+			sb.WriteString(text[last:loc[0]])
+			last = sectionEnd
+		}
+	}
+	sb.WriteString(text[last:])
+	return sb.String()
+}
+
 // analyzeAndSplit breaks a task into subtasks based on structure analysis.
 //
 // GH-4395: only explicit work-item structure is treated as a decomposition
@@ -383,11 +439,18 @@ func (d *TaskDecomposer) SkipLogDetail(result *DecomposeResult) string {
 // structural-split decision below anymore. A task with prose but no explicit
 // checklist or "## Task N" headers now falls back to no-decompose
 // (SkipReasonNoSplitPoints) rather than guessing at boundaries.
+//
+// GH-5350: Strategy 1 additionally excludes checklist items that live inside
+// "## Acceptance"/"## Done" sections (stripAcceptanceSections) — those are
+// verification criteria, not work units. If the only checklist items in the
+// description are under such a section, Strategy 1 now finds none and falls
+// through to Strategy 2 / no-split, same as if no checklist existed at all.
 func (d *TaskDecomposer) analyzeAndSplit(task *Task) []*Task {
 	desc := task.Description
 
 	// Strategy 1: Checklist / acceptance-criteria items ("- [ ] ..." or "[ ] ...")
-	parts := extractAcceptanceCriteria(desc)
+	// outside any Acceptance/Done section.
+	parts := extractAcceptanceCriteria(stripAcceptanceSections(desc))
 	if len(parts) >= 2 {
 		return d.createSubtasks(task, parts, "criteria")
 	}

--- a/internal/executor/decompose_test.go
+++ b/internal/executor/decompose_test.go
@@ -307,6 +307,13 @@ This migration is critical for the multi-tenant feature.`,
 	}
 }
 
+// TestTaskDecomposer_AcceptanceCriteria previously asserted that a task whose
+// only splittable structure was its "## Acceptance Criteria" checklist
+// decomposed into one subtask per criterion. GH-5350 (2026-09-06/07,
+// GH-5342/GH-5348 incidents) reversed that: acceptance/done checklists are
+// verification criteria, not work units, and must never be used as a split
+// boundary. With no other splittable structure in the body, this task must
+// now report no decomposition.
 func TestTaskDecomposer_AcceptanceCriteria(t *testing.T) {
 	config := &DecomposeConfig{
 		Enabled:             true,
@@ -333,13 +340,16 @@ This is a major rewrite that requires careful planning.`,
 
 	result := decomposer.Decompose(task)
 
-	if !result.Decomposed {
-		t.Errorf("Expected task to be decomposed, reason: %s", result.Reason)
-		return
+	if result.Decomposed {
+		t.Errorf("GH-5350: expected acceptance-only checklist to NOT decompose, got %d subtasks", len(result.Subtasks))
 	}
-
-	if len(result.Subtasks) != 4 {
-		t.Errorf("Expected 4 subtasks, got %d", len(result.Subtasks))
+	if result.SkipReason != SkipReasonNoSplitPoints {
+		t.Errorf("expected SkipReasonNoSplitPoints, got %q (reason: %s)", result.SkipReason, result.Reason)
+	}
+	for _, subtask := range result.Subtasks {
+		if strings.Contains(subtask.Title, "migrated to new router") || strings.Contains(subtask.Title, "OpenAPI spec") {
+			t.Errorf("subtask title %q was derived from an acceptance criterion", subtask.Title)
+		}
 	}
 }
 
@@ -637,11 +647,16 @@ Third body.`,
 // TestTaskDecomposer_GH4390IncidentTimelineDoesNotExplode reproduces the
 // GH-4395 incident directly: #4390's issue body carried a timestamped
 // narrative timeline (two "###" numbered sections full of plain "- " bullets)
-// followed by a real "## Acceptance criteria" checklist. Before the fix, the
-// generic bullet-point strategy matched the narrative bullets first and
-// exploded the timeline into junk subtasks (subtask 1's title was a raw
-// timestamp line). After the fix, only the checklist is a valid split
-// boundary, so decomposition yields one subtask per acceptance criterion.
+// followed by a real "## Acceptance criteria" checklist. Before the GH-4395
+// fix, the generic bullet-point strategy matched the narrative bullets first
+// and exploded the timeline into junk subtasks (subtask 1's title was a raw
+// timestamp line). The GH-4395 fix made the checklist the only valid split
+// boundary, decomposing into one subtask per acceptance criterion — but
+// GH-5350 (2026-09-06/07, GH-5342/GH-5348 incidents) found that acceptance
+// checklists are verification criteria, not work units, and must never be
+// split on either. With the narrative bullets excluded (GH-4395) and the
+// acceptance checklist now also excluded (GH-5350), this body has no
+// remaining split points, so it must not decompose at all.
 func TestTaskDecomposer_GH4390IncidentTimelineDoesNotExplode(t *testing.T) {
 	config := &DecomposeConfig{
 		Enabled:             true,
@@ -680,19 +695,19 @@ func TestTaskDecomposer_GH4390IncidentTimelineDoesNotExplode(t *testing.T) {
 
 	result := decomposer.Decompose(task)
 
-	if !result.Decomposed {
-		t.Fatalf("expected checklist to decompose, reason: %s", result.Reason)
+	if result.Decomposed {
+		t.Fatalf("GH-5350: expected no decomposition (narrative bullets excluded per GH-4395, acceptance checklist excluded per GH-5350), got %d subtasks", len(result.Subtasks))
 	}
-	if len(result.Subtasks) != 4 {
-		t.Fatalf("expected 4 subtasks (one per acceptance criterion), got %d", len(result.Subtasks))
+	if result.SkipReason != SkipReasonNoSplitPoints {
+		t.Fatalf("expected SkipReasonNoSplitPoints, got %q (reason: %s)", result.SkipReason, result.Reason)
 	}
 	for i, subtask := range result.Subtasks {
 		if strings.Contains(subtask.Title, "2026-07-16") || strings.Contains(subtask.Title, "1143") {
 			t.Errorf("subtask %d: title %q looks like a narrative timeline line, not a work item", i, subtask.Title)
 		}
-	}
-	if !strings.Contains(result.Subtasks[0].Title, "RCA comment") {
-		t.Errorf("subtask 0: expected title to reference the first acceptance criterion, got %q", result.Subtasks[0].Title)
+		if strings.Contains(subtask.Title, "RCA comment") {
+			t.Errorf("subtask %d: title %q was derived from an acceptance criterion", i, subtask.Title)
+		}
 	}
 }
 
@@ -1270,5 +1285,115 @@ func TestDecomposedSubtasks_ExecutionEventsJoinParentRow(t *testing.T) {
 	}
 	if qualityGatesCount != len(result.Subtasks) {
 		t.Errorf("got %d quality_gates_passed events, want %d", qualityGatesCount, len(result.Subtasks))
+	}
+}
+
+// TestTaskOptsOutOfDecomposition_AllThreeSignalsRegardlessOfComplexity covers
+// GH-5350 item 1: TaskOptsOutOfDecomposition is the shared predicate that
+// runner.go and dispatcher.go now evaluate BEFORE calling into the
+// decomposer at all, so a task carrying any of the three no-decompose
+// signals (label, [no-plan] keyword, standalone phrase) must opt out
+// regardless of how large/epic its body looks — the predicate must not
+// depend on DetectComplexity or word count.
+func TestTaskOptsOutOfDecomposition_AllThreeSignalsRegardlessOfComplexity(t *testing.T) {
+	epicBody := strings.Repeat("Rework the entire subsystem end to end. ", 200) +
+		"\n\n## Acceptance Criteria\n" +
+		"- [ ] First criterion\n- [ ] Second criterion\n- [ ] Third criterion\n"
+
+	tests := []struct {
+		name string
+		task *Task
+	}{
+		{
+			name: "no-decompose label",
+			task: &Task{ID: "GH-A", Title: "Epic rework", Labels: []string{NoDecomposeLabel}, Description: epicBody},
+		},
+		{
+			name: "no-plan keyword in title",
+			task: &Task{ID: "GH-B", Title: "Epic rework [no-plan]", Description: epicBody},
+		},
+		{
+			name: "standalone no-decompose phrase",
+			task: &Task{ID: "GH-C", Title: "Epic rework", Description: "no-decompose\n\n" + epicBody},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if c := DetectComplexity(tt.task); c != ComplexityEpic && c != ComplexityComplex {
+				t.Fatalf("test body must classify as epic/complex to prove the opt-out isn't just a complexity-gate side effect, got %v", c)
+			}
+			if !TaskOptsOutOfDecomposition(tt.task) {
+				t.Fatalf("TaskOptsOutOfDecomposition() = false, want true for %s", tt.name)
+			}
+
+			decomposer := NewTaskDecomposer(&DecomposeConfig{
+				Enabled:             true,
+				MinComplexity:       "complex",
+				MaxSubtasks:         5,
+				MinDescriptionWords: 10,
+			})
+			result := decomposer.Decompose(tt.task)
+			if result.Decomposed {
+				t.Errorf("Decompose() split a no-decompose task (%s): %s", tt.name, result.Reason)
+			}
+		})
+	}
+
+	normal := &Task{ID: "GH-D", Title: "Epic rework", Description: epicBody}
+	if TaskOptsOutOfDecomposition(normal) {
+		t.Error("TaskOptsOutOfDecomposition() = true for a task with none of the three signals")
+	}
+}
+
+// TestAnalyzeAndSplit_ContextImplementationAcceptance covers GH-5350 item 2:
+// a body shaped exactly like a real Pilot issue (Context / Implementation /
+// Acceptance, the H2 vocabulary new-project-issue-authoring.md Rule 2
+// requires) must, if it decomposes at all, split on the Implementation
+// checklist — never on the Acceptance checklist. This is the literal
+// GH-5348/GH-5342 incident shape (minus the no-decompose label, to prove the
+// structural exclusion holds independently of the label-based opt-out
+// covered above).
+func TestAnalyzeAndSplit_ContextImplementationAcceptance(t *testing.T) {
+	config := &DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 10,
+	}
+	decomposer := NewTaskDecomposer(config)
+
+	task := &Task{
+		ID:    "GH-5350-B",
+		Title: "Add rate limiting to API endpoints",
+		Description: `## Context
+
+The API currently has no rate limiting, which leaves it exposed to abuse
+from misbehaving clients during peak load.
+
+## Implementation
+
+- [ ] Add a token-bucket limiter middleware to the HTTP router
+- [ ] Wire per-client limits from config into the middleware
+- [ ] Return 429 with Retry-After when a client exceeds its bucket
+
+## Acceptance
+
+- [ ] Requests over the configured limit receive HTTP 429
+- [ ] Retry-After header reflects the correct backoff window
+- [ ] Existing endpoints are unaffected below the limit`,
+		ProjectPath: "/test/project",
+	}
+
+	result := decomposer.Decompose(task)
+
+	if result.Decomposed {
+		for i, subtask := range result.Subtasks {
+			if strings.Contains(subtask.Title, "Requests over the configured limit") ||
+				strings.Contains(subtask.Title, "Retry-After header reflects") ||
+				strings.Contains(subtask.Title, "Existing endpoints are unaffected") {
+				t.Errorf("subtask %d: title %q was derived from the Acceptance checklist, not a work item", i, subtask.Title)
+			}
+		}
 	}
 }

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -1308,31 +1308,44 @@ func (d *Dispatcher) QueueTask(ctx context.Context, task *Task) (string, error) 
 
 	// Try decomposition if decomposer is configured
 	if d.decomposer != nil {
-		result := d.decomposer.Decompose(task)
-		if result.Decomposed && len(result.Subtasks) > 1 {
-			return d.queueDecomposedTask(ctx, task, result)
-		}
-		// GH-4271: an epic-classified (or otherwise at/above min_complexity)
-		// task that does NOT enter decomposition previously left zero trace
-		// at this queue-time decision point — see the matching runner.go
-		// Execute() site for the direct-execution-time equivalent. execID
-		// only exists once queueSingleTask creates the executions row below,
-		// so the event write follows it rather than preceding it.
-		if d.decomposer.ReportableSkip(result) {
-			detail := d.decomposer.SkipLogDetail(result)
-			d.log.Info(detail,
+		if TaskOptsOutOfDecomposition(task) {
+			// GH-5350: short-circuit BEFORE calling Decompose() so the skip
+			// is always logged, regardless of complexity tier — mirrors the
+			// same explicit gate/log added to runner.go's Execute()-time
+			// decomposer check. Decompose()'s internal label check only
+			// surfaces via ReportableSkip below, which only fires when the
+			// task's complexity tier would otherwise have triggered
+			// decomposition.
+			d.log.Info("decomposition skipped: no-decompose label",
 				slog.String("task_id", task.ID),
-				slog.String("skip_reason", string(result.SkipReason)),
-				slog.String("complexity", result.Complexity.String()),
 			)
-			execID, err := d.queueSingleTask(ctx, task)
-			if err == nil && execID != "" {
-				// execID == "" with a nil error means queueSingleTask dropped
-				// an ErrClaimLost pickup silently — no executions row exists
-				// here to attach this stage event to (GH-4359).
-				d.recordExecutionEvent(execID, memory.StageDecompositionSkipped, detail)
+		} else {
+			result := d.decomposer.Decompose(task)
+			if result.Decomposed && len(result.Subtasks) > 1 {
+				return d.queueDecomposedTask(ctx, task, result)
 			}
-			return execID, err
+			// GH-4271: an epic-classified (or otherwise at/above min_complexity)
+			// task that does NOT enter decomposition previously left zero trace
+			// at this queue-time decision point — see the matching runner.go
+			// Execute() site for the direct-execution-time equivalent. execID
+			// only exists once queueSingleTask creates the executions row below,
+			// so the event write follows it rather than preceding it.
+			if d.decomposer.ReportableSkip(result) {
+				detail := d.decomposer.SkipLogDetail(result)
+				d.log.Info(detail,
+					slog.String("task_id", task.ID),
+					slog.String("skip_reason", string(result.SkipReason)),
+					slog.String("complexity", result.Complexity.String()),
+				)
+				execID, err := d.queueSingleTask(ctx, task)
+				if err == nil && execID != "" {
+					// execID == "" with a nil error means queueSingleTask dropped
+					// an ErrClaimLost pickup silently — no executions row exists
+					// here to attach this stage event to (GH-4359).
+					d.recordExecutionEvent(execID, memory.StageDecompositionSkipped, detail)
+				}
+				return execID, err
+			}
 		}
 	}
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2989,19 +2989,11 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 
 	// GH-664: Skip epic mode if task has no-decompose label
 	// GH-1687: Also skip if task title or description contains [no-plan] keyword
-	hasNoDecompose := false
-	for _, label := range task.Labels {
-		if strings.EqualFold(label, NoDecomposeLabel) {
-			hasNoDecompose = true
-			break
-		}
-	}
-	if !hasNoDecompose && HasNoPlanKeyword(task) {
-		hasNoDecompose = true
-	}
-	if !hasNoDecompose && HasNoDecomposePhrase(task) {
-		hasNoDecompose = true
-	}
+	// GH-3597: Also skip on standalone no-decompose prose
+	// GH-5350: shared predicate — the in-process decomposer check below
+	// (r.decomposer.Decompose) reuses the SAME hasNoDecompose value so a
+	// no-decompose task never splits via either path.
+	hasNoDecompose := TaskOptsOutOfDecomposition(task)
 
 	// GH-1588: Diagnostic logging for epic detection
 	r.log.Info("Epic detection check",
@@ -3361,30 +3353,44 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	// GH-4052: also gated on hasNoDecompose, which the single-package epic-consolidation
 	// branch above sets — Decompose()'s internal label re-check no-ops today when labels
 	// are dropped (#4050), so the call site must not rely on it alone.
-	if r.decomposer != nil && !hasNoDecompose {
-		result := r.decomposer.Decompose(task)
-		if result.Decomposed && len(result.Subtasks) > 1 {
-			r.log.Info("Task decomposed",
+	if r.decomposer != nil {
+		if hasNoDecompose {
+			// GH-5350: explicit, unconditional trace. Decompose()'s internal
+			// label check (SkipReasonNoDecomposeLabel) only surfaces via
+			// ReportableSkip below, and ReportableSkip only fires when the
+			// task's complexity tier would otherwise have triggered
+			// decomposition — a labelled task below that bar previously
+			// skipped silently. Log it here, unconditionally, the same way
+			// the epic path's "Epic detection check" above always logs
+			// has_no_decompose regardless of complexity.
+			r.log.Info("decomposition skipped: no-decompose label",
 				slog.String("task_id", task.ID),
-				slog.Int("subtask_count", len(result.Subtasks)),
-				slog.String("reason", result.Reason),
 			)
-			return r.executeDecomposedTask(ctx, task, result.Subtasks, executionPath)
-		}
-		// GH-4271: an epic-classified (or otherwise at/above min_complexity)
-		// task that does NOT enter decomposition previously left zero trace —
-		// a canary run gated on min_description_words was indistinguishable
-		// from the TASK-401 defect class without hand-querying
-		// execution_events. Surface it as both a structured log line and an
-		// execution event so `pilot trace` shows why.
-		if r.decomposer.ReportableSkip(result) {
-			detail := r.decomposer.SkipLogDetail(result)
-			r.log.Info(detail,
-				slog.String("task_id", task.ID),
-				slog.String("skip_reason", string(result.SkipReason)),
-				slog.String("complexity", result.Complexity.String()),
-			)
-			r.recordExecutionEvent(task.LogExecutionID(), memory.StageDecompositionSkipped, detail)
+		} else {
+			result := r.decomposer.Decompose(task)
+			if result.Decomposed && len(result.Subtasks) > 1 {
+				r.log.Info("Task decomposed",
+					slog.String("task_id", task.ID),
+					slog.Int("subtask_count", len(result.Subtasks)),
+					slog.String("reason", result.Reason),
+				)
+				return r.executeDecomposedTask(ctx, task, result.Subtasks, executionPath)
+			}
+			// GH-4271: an epic-classified (or otherwise at/above min_complexity)
+			// task that does NOT enter decomposition previously left zero trace —
+			// a canary run gated on min_description_words was indistinguishable
+			// from the TASK-401 defect class without hand-querying
+			// execution_events. Surface it as both a structured log line and an
+			// execution event so `pilot trace` shows why.
+			if r.decomposer.ReportableSkip(result) {
+				detail := r.decomposer.SkipLogDetail(result)
+				r.log.Info(detail,
+					slog.String("task_id", task.ID),
+					slog.String("skip_reason", string(result.SkipReason)),
+					slog.String("complexity", result.Complexity.String()),
+				)
+				r.recordExecutionEvent(task.LogExecutionID(), memory.StageDecompositionSkipped, detail)
+			}
 		}
 	}
 

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -90,6 +90,14 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 		Success: true,
 	}
 
+	// GH-5350: subtask IDs whose own result succeeded, tracked so their PR
+	// link can be backfilled once the parent's PR is known (see below) — a
+	// decomposed subtask's own ExecutionResult.PRUrl is almost always empty
+	// at completion time, since only the FINAL subtask carries CreatePR, and
+	// even that push+PR-create is deferred to finalizeDecomposedParentPR
+	// after every subtask has run.
+	var succeededSubtaskIDs []string
+
 	// Execute each subtask sequentially
 	for i, subtask := range subtasks {
 		subtaskNum := i + 1
@@ -148,6 +156,16 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 			)
 			aggregateResult.Success = false
 			aggregateResult.Error = fmt.Sprintf("subtask %d/%d failed: %v", subtaskNum, totalSubtasks, err)
+			// GH-5350: finalize this subtask's own Monitor entry as failed.
+			// Without this, the entry stays StatusRunning (set by
+			// executeWithOptions' Monitor.Start call) forever — the daemon's
+			// dead-owner reconciliation sweep (ReconcileDeadOwners,
+			// monitor.go) then misclassifies it as an abandoned worker ~30s
+			// later and marks it failed anyway, but with a misleading
+			// "dead-owner" error instead of the real one.
+			if r.monitor != nil {
+				r.monitor.Fail(subtask.ID, err.Error())
+			}
 			break
 		}
 
@@ -167,6 +185,13 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 					slog.Int("total", totalSubtasks),
 					slog.String("reason", subtaskResult.Error),
 				)
+				// GH-5350: no_op is a distinct, non-failure terminal status
+				// (dashboard.QueueStatusNoOp) — must not be left StatusRunning
+				// (→ eventually misread as failed by the dead-owner sweep) nor
+				// finalized as StatusFailed (a genuine failure).
+				if r.monitor != nil {
+					r.monitor.NoOp(subtask.ID, subtaskResult.Error)
+				}
 				continue
 			}
 			r.log.Warn("Subtask failed",
@@ -175,6 +200,12 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 			)
 			aggregateResult.Success = false
 			aggregateResult.Error = fmt.Sprintf("subtask %d/%d failed: %s", subtaskNum, totalSubtasks, subtaskResult.Error)
+			// GH-5350: this subtask's OWN result is the genuine failure —
+			// finalize it as failed with its own error, not the dead-owner
+			// sweep's generic reconciliation message.
+			if r.monitor != nil {
+				r.monitor.Fail(subtask.ID, subtaskResult.Error)
+			}
 			break
 		}
 
@@ -210,6 +241,15 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 			slog.Int("index", subtaskNum),
 			slog.Int("total", totalSubtasks),
 		)
+		// GH-5350: finalize this subtask's own Monitor entry as done, taking
+		// its status from ITS OWN result rather than leaving it StatusRunning
+		// for the dead-owner sweep to misclassify as failed later. subtaskResult.PRUrl
+		// is almost always empty here (see succeededSubtaskIDs' doc comment above) —
+		// backfilled with the parent's real PR link once known, below.
+		if r.monitor != nil {
+			r.monitor.Complete(subtask.ID, subtaskResult.PRUrl)
+		}
+		succeededSubtaskIDs = append(succeededSubtaskIDs, subtask.ID)
 	}
 
 	// TASK-320 B2: every subtask ran without a hard error, but none delivered a
@@ -218,7 +258,14 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 	// so a model that silently refused an explicit spec gets one firm re-prompt.
 	// Never surface an empty error string for this path (acceptance: descriptive).
 	if aggregateResult.Success && aggregateResult.CommitSHA == "" && aggregateResult.PRUrl == "" && len(subtasks) > 0 {
-		r.escalateDecomposedNoOp(ctx, parentTask, subtasks, executionPath, aggregateResult)
+		if r.escalateDecomposedNoOp(ctx, parentTask, subtasks, executionPath, aggregateResult) {
+			// GH-5350: the escalated retry recovered a commit — the final
+			// subtask's Monitor entry (marked NoOp by the original attempt,
+			// above) is now genuinely done. Include it in the PR-link
+			// backfill below the same as any subtask that succeeded on its
+			// first attempt.
+			succeededSubtaskIDs = append(succeededSubtaskIDs, subtasks[len(subtasks)-1].ID)
+		}
 	}
 
 	// GH-4028 / TASK-359 Layer 1: subtasks run with task.Branch cleared (see
@@ -229,6 +276,17 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 	// subtasks (and any no-op escalation) are done.
 	if aggregateResult.Success && parentTask.CreatePR && parentTask.Branch != "" && aggregateResult.PRUrl == "" {
 		r.finalizeDecomposedParentPR(ctx, parentTask, git, aggregateResult)
+	}
+
+	// GH-5350: backfill every successfully-completed subtask's Monitor entry
+	// with the parent's real PR link, now that finalizeDecomposedParentPR (or
+	// a subtask's own inline CreatePR, in the non-worktree/legacy shape) has
+	// resolved it. Dashboard rows for in-process subtasks then show the same
+	// PR the parent's own row links to, instead of no link at all.
+	if r.monitor != nil && aggregateResult.PRUrl != "" {
+		for _, id := range succeededSubtaskIDs {
+			r.monitor.Complete(id, aggregateResult.PRUrl)
+		}
 	}
 
 	aggregateResult.Duration = time.Since(start)
@@ -320,13 +378,15 @@ func aggregateSubtaskCost(agg, sub *ExecutionResult) {
 
 // escalateDecomposedNoOp re-runs the final subtask exactly once with the
 // evidence-backed directive when the whole decomposed task delivered no commit.
-// On recovery it folds the commit/PR into agg; otherwise it sets a descriptive
-// terminal no-op error (never empty). TASK-320 B2.
+// On recovery it folds the commit/PR into agg and returns true; otherwise it
+// sets a descriptive terminal no-op error (never empty) and returns false.
+// TASK-320 B2. The return value lets the caller (GH-5350) know whether to
+// include the final subtask's Monitor entry in the PR-link backfill.
 //
 // This lives at the decomposition layer — it re-invokes executeWithOptions rather
 // than duplicating the ghost-SHA/SHA-harvest logic inside that ~1700-line function
 // (the in-executor variant the task doc flagged as needing a structured refactor).
-func (r *Runner) escalateDecomposedNoOp(ctx context.Context, parentTask *Task, subtasks []*Task, executionPath string, agg *ExecutionResult) {
+func (r *Runner) escalateDecomposedNoOp(ctx context.Context, parentTask *Task, subtasks []*Task, executionPath string, agg *ExecutionResult) bool {
 	final := subtasks[len(subtasks)-1]
 
 	escalated := *final // shallow copy; only value fields below are mutated
@@ -358,7 +418,7 @@ func (r *Runner) escalateDecomposedNoOp(ctx context.Context, parentTask *Task, s
 			slog.String("parent_id", parentTask.ID),
 			slog.String("commit_sha", retryResult.CommitSHA),
 		)
-		return
+		return true
 	}
 
 	if retryResult != nil {
@@ -366,6 +426,7 @@ func (r *Runner) escalateDecomposedNoOp(ctx context.Context, parentTask *Task, s
 	}
 	agg.Success = false
 	agg.Error = fmt.Sprintf("no new commit produced — all %d subtask(s) were no-ops after one escalated retry (task %s)", len(subtasks), parentTask.ID)
+	return false
 }
 
 // finalizeDecomposedParentPR runs the decomposed-parent's push → PR-create →

--- a/internal/executor/runner_decompose_monitor_test.go
+++ b/internal/executor/runner_decompose_monitor_test.go
@@ -52,3 +52,131 @@ func TestExecuteDecomposedTask_RegistersPlannedSubtaskTitle(t *testing.T) {
 		}
 	}
 }
+
+// TestExecuteDecomposedTask_SubtaskStatusTakenFromOwnResult is the GH-5350
+// item-3 regression test: before the fix, executeDecomposedTask started each
+// subtask's Monitor entry (StatusRunning, via executeWithOptions'
+// Monitor.Start) but never finalized it individually. Dispatcher.
+// GetRunningTaskIDs() only tracks top-level dispatched task IDs — never
+// in-process subtask IDs — so every subtask's Monitor entry looked
+// abandoned to ReconcileDeadOwners' dead-owner sweep and was eventually
+// flipped to StatusFailed, even though the daemon log recorded "Subtask
+// completed" for it and the parent finished done with a PR (GH-5348/GH-5342
+// evidence). The dashboard's convertTaskStatesToDisplay
+// (cmd/pilot/commands.go) then rendered every such row as "✗ failed" (red).
+//
+// This proves each subtask's own Monitor status is finalized from its own
+// ExecutionResult as soon as it finishes — done for a delivered commit,
+// no_op for a deliberate no-commit run, failed only for a genuine subtask
+// failure — and that a successfully-completed subtask's PR link is
+// backfilled with the parent's real PR once the parent aggregates it.
+func TestExecuteDecomposedTask_SubtaskStatusTakenFromOwnResult(t *testing.T) {
+	const finalPRUrl = "https://github.com/qf-studio/pilot/pull/9999"
+
+	r := &Runner{
+		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		monitor: NewMonitor(),
+		executeFunc: func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+			switch task.ID {
+			case "GH-5350-1":
+				return &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "aaa111"}, nil
+			case "GH-5350-2":
+				// TASK-320 B2 no-op shape: !Success with Outcome "no_op".
+				return &ExecutionResult{TaskID: task.ID, Success: false, Outcome: "no_op", Error: "no new commit produced"}, nil
+			case "GH-5350-3":
+				return &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "bbb222", PRUrl: finalPRUrl}, nil
+			}
+			t.Fatalf("unexpected subtask ID %s", task.ID)
+			return nil, nil
+		},
+	}
+
+	parent := &Task{ID: "GH-5350", Title: "Add rate limiting to API endpoints", ProjectPath: "/tmp/does-not-matter"}
+	subtasks := []*Task{
+		{ID: "GH-5350-1", Title: "feat(api): add token-bucket middleware", ProjectPath: parent.ProjectPath},
+		{ID: "GH-5350-2", Title: "chore(api): verify existing tests still pass", ProjectPath: parent.ProjectPath},
+		{ID: "GH-5350-3", Title: "feat(api): wire per-client limits from config", ProjectPath: parent.ProjectPath, CreatePR: true},
+	}
+
+	result, err := r.executeDecomposedTask(context.Background(), parent, subtasks, parent.ProjectPath)
+	if err != nil {
+		t.Fatalf("executeDecomposedTask() error = %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("executeDecomposedTask() Success = false, want true (Error: %s)", result.Error)
+	}
+	if result.PRUrl != finalPRUrl {
+		t.Fatalf("aggregate PRUrl = %q, want %q", result.PRUrl, finalPRUrl)
+	}
+
+	wantStatus := map[string]TaskStatus{
+		"GH-5350-1": StatusCompleted,
+		"GH-5350-2": StatusNoOp,
+		"GH-5350-3": StatusCompleted,
+	}
+	for id, want := range wantStatus {
+		state, ok := r.monitor.Get(id)
+		if !ok {
+			t.Fatalf("monitor has no entry for subtask %s", id)
+		}
+		if state.Status != want {
+			t.Errorf("subtask %s: monitor Status = %q, want %q", id, state.Status, want)
+		}
+	}
+
+	// Every subtask whose own result succeeded must inherit the parent's real
+	// PR link once known — not stay linkless (GH-5350 item 3).
+	for _, id := range []string{"GH-5350-1", "GH-5350-3"} {
+		state, _ := r.monitor.Get(id)
+		if state.PRUrl != finalPRUrl {
+			t.Errorf("subtask %s: monitor PRUrl = %q, want backfilled parent PR %q", id, state.PRUrl, finalPRUrl)
+		}
+	}
+
+	// The no-op subtask never delivered a commit — it must not be backfilled
+	// with the parent's PR link, and must stay the non-failure StatusNoOp
+	// terminal state (not silently promoted to done).
+	noOpState, _ := r.monitor.Get("GH-5350-2")
+	if noOpState.PRUrl != "" {
+		t.Errorf("no-op subtask GH-5350-2: monitor PRUrl = %q, want empty", noOpState.PRUrl)
+	}
+}
+
+// TestExecuteDecomposedTask_FailedSubtaskStatusIsFailed proves a subtask
+// that genuinely fails (not the TASK-320 B2 no-op shape) is finalized as
+// StatusFailed with its own error — the counterpart to the done/no_op cases
+// above, so "only a genuine subtask failure shows failed" (GH-5350
+// acceptance criteria) is covered on both sides.
+func TestExecuteDecomposedTask_FailedSubtaskStatusIsFailed(t *testing.T) {
+	r := &Runner{
+		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		monitor: NewMonitor(),
+		executeFunc: func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+			return &ExecutionResult{TaskID: task.ID, Success: false, Error: "quality gate failed: lint"}, nil
+		},
+	}
+
+	parent := &Task{ID: "GH-5350-F", Title: "Add rate limiting to API endpoints", ProjectPath: "/tmp/does-not-matter"}
+	subtasks := []*Task{
+		{ID: "GH-5350-F-1", Title: "feat(api): add token-bucket middleware", ProjectPath: parent.ProjectPath},
+	}
+
+	result, err := r.executeDecomposedTask(context.Background(), parent, subtasks, parent.ProjectPath)
+	if err != nil {
+		t.Fatalf("executeDecomposedTask() error = %v", err)
+	}
+	if result.Success {
+		t.Fatal("executeDecomposedTask() Success = true, want false for a genuinely failed subtask")
+	}
+
+	state, ok := r.monitor.Get("GH-5350-F-1")
+	if !ok {
+		t.Fatal("monitor has no entry for subtask GH-5350-F-1")
+	}
+	if state.Status != StatusFailed {
+		t.Errorf("subtask GH-5350-F-1: monitor Status = %q, want %q", state.Status, StatusFailed)
+	}
+	if state.Error != "quality gate failed: lint" {
+		t.Errorf("subtask GH-5350-F-1: monitor Error = %q, want the subtask's own error", state.Error)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5350.

Closes #5350

## Changes

GitHub Issue GH-5350: fix(executor): in-process decomposer ignores the no-decompose label and splits on acceptance bullets; TUI paints completed subtasks as failed

## Context

The `no-decompose` label is honoured by the epic (GitHub sub-issue) path but not by the in-process LLM decomposer. Evidence from the founder box daemon log, both tasks carrying `no-decompose`:

- GH-5348 (2026-09-07 10:10): `Epic detection check … has_no_decompose=true is_epic=false` followed 12 s later by `Task decomposed … subtask_count=4 reason="decomposed into subtasks"`, then four in-process subtasks GH-5348-1…4 executed sequentially in one worktree.
- GH-5342 (2026-09-06 22:39): same sequence, four subtasks.

In both cases the decomposer split the issue along its `## Acceptance` bullets, so the subtasks were "prove criterion N" units rather than implementation steps. The label exists precisely to prevent this on issues where the operator has already ordered the work.

Second, cosmetic but misleading: the TUI queue panel renders every in-process subtask row as `✗ failed` (red) even though the log records `Subtask completed` for each and the parent finishes `done` with a PR (screenshot 2026-09-07 11:3x: GH-5348 done → #5349, GH-5348-1…4 all "failed"). Operators read this as four failures.

## Implementation

1. In the executor's decomposition decision (the code that logs `Task decomposed … reason="decomposed into subtasks"`), short-circuit when the task carries `no-decompose` (same predicate the epic path uses for `has_no_decompose`). Log one INFO line "decomposition skipped: no-decompose label".
2. Decomposer heuristics: never split on `## Acceptance` / `## Done` bullets; those sections are verification criteria, not work units. If the only splittable structure is the acceptance list, do not decompose.
3. Dashboard: in-process subtask rows take their status from the subtask result (`Subtask completed` → done) and inherit the parent's PR link; a subtask only shows failed when its own result is failed.
4. Tests: task with `no-decompose` → no decomposition regardless of complexity; task whose body has only Context/Implementation/Acceptance sections → decomposition (if any) never yields a subtask titled from an acceptance bullet; dashboard row status mapping unit test.

## Acceptance

- [ ] A `no-decompose` task never logs `Task decomposed`.
- [ ] No subtask title is ever derived from an acceptance/done checklist line.
- [ ] TUI shows in-process subtasks as done when their result is done.