### PR TITLE
GH-5354: fix(monitor): in-process decomposition subtasks are painted failed mid-run by the dead-owner sweep — no executions row, ID not in the live set

### DIFF
--- a/.agent/tasks/gh-5354.md
+++ b/.agent/tasks/gh-5354.md
@@ -1,0 +1,37 @@
+# GH-5354
+
+**Created:** 2026-09-07
+
+## Problem
+
+GitHub Issue GH-5354: fix(monitor): in-process decomposition subtasks are painted failed mid-run by the dead-owner sweep — no executions row, ID not in the live set
+
+## Problem
+
+Post-merge review of PR #5352 (issue #5350). The PR fixed the terminal state of subtask rows (each subtask now finalizes its own Monitor entry and the PR link is backfilled), but a subtask still renders red for the whole time it is running:
+
+- `internal/executor/runner_decompose.go` (~133) creates the subtask Monitor entry as `StatusRunning`.
+- `internal/executor/monitor.go` (~655-675) reconciles running entries: the subtask ID is never in `Dispatcher.GetRunningTaskIDs` (the worker tracks the parent ID), and subtasks have no `executions` row (GH-4032), so `executionRecentlyProgressed` returns `ErrNoRows` → false.
+- After the 30 s grace the autopilot sweep (`internal/autopilot/controller.go` ~1131) flips the entry to `StatusFailed` with the "reconciled: dead-owner" reason. The `Complete()` added by #5352 only repairs it once the subtask ends.
+
+Failure scenario: a 20-minute subtask shows as failed in the TUI for roughly 19.5 minutes, then turns green. Operators read it as a real failure (this is exactly what the #5350 report described).
+
+## Fix
+
+Pick one, prefer the first:
+1. Exclude entries that have a parent execution (in-process subtasks) from the dead-owner reconciliation, treating the parent's liveness as theirs.
+2. Or include in-process subtask IDs in the live set returned to the monitor (the runner knows which subtask it is executing).
+
+## Tests
+
+- Monitor test: subtask entry `StatusRunning` with a live parent, no executions row, past the grace window → must remain `StatusRunning`.
+- Existing `runner_decompose_monitor_test.go` stays green.
+
+## Acceptance
+
+- [ ] A running in-process subtask is never flipped to failed by the reconciliation sweep while its parent is live.
+- [ ] Subtask whose parent is genuinely dead still gets reconciled to failed.
+- [ ] Widen `acceptanceSectionHeaderPattern` in `internal/executor/decompose.go` to also cover `## Checklist`, `## Verification`, `## Definition of Done` (note from the same review; small, same area).
+
+## Acceptance Criteria
+

--- a/internal/executor/decompose.go
+++ b/internal/executor/decompose.go
@@ -383,13 +383,17 @@ func (d *TaskDecomposer) SkipLogDetail(result *DecomposeResult) string {
 
 // acceptanceSectionHeaderPattern matches the H2/H3 headers whose checklist
 // items are verification criteria, not implementation work units (GH-5350):
-// "## Acceptance", "## Acceptance Criteria", "### Done", etc. Mirrors the H2
+// "## Acceptance", "## Acceptance Criteria", "### Done", "## Checklist",
+// "## Verification", "## Definition of Done", etc. GH-5354: widened beyond
+// the original Acceptance/Done pair — the same misfire the #5350 fix
+// addressed applies just as much to these headers, which show up in
+// Pilot-authored issues just as often as "## Acceptance" does. Mirrors the H2
 // vocabulary the spec validator requires (see
 // .agent/sops/onboarding/new-project-issue-authoring.md Rule 2) — every
 // Pilot-authored issue in this project structures its body as
-// Context/Implementation/Acceptance, so "## Acceptance" is the section
-// analyzeAndSplit must never treat as a decomposition boundary.
-var acceptanceSectionHeaderPattern = regexp.MustCompile(`(?i)^(Acceptance(\s+Criteria)?|Done)\s*$`)
+// Context/Implementation/Acceptance, so none of these headers are sections
+// analyzeAndSplit should ever treat as a decomposition boundary.
+var acceptanceSectionHeaderPattern = regexp.MustCompile(`(?i)^(Acceptance(\s+Criteria)?|Done|Checklist|Verification|Definition\s+of\s+Done)\s*$`)
 
 // stripAcceptanceSections removes the body of every "## Acceptance"/"## Done"
 // (H2 or H3) section — from its header through the next H2/H3 header or end

--- a/internal/executor/decompose_test.go
+++ b/internal/executor/decompose_test.go
@@ -1397,3 +1397,68 @@ from misbehaving clients during peak load.
 		}
 	}
 }
+
+// TestAcceptanceSectionHeaderPattern_GH5354 covers the GH-5354 review note:
+// acceptanceSectionHeaderPattern must also treat "## Checklist",
+// "## Verification", and "## Definition of Done" as verification-criteria
+// headers — the same class of section "## Acceptance"/"## Acceptance
+// Criteria"/"## Done" already covers (GH-5350) — instead of letting
+// analyzeAndSplit decompose on them.
+func TestAcceptanceSectionHeaderPattern_GH5354(t *testing.T) {
+	matches := []string{
+		"Acceptance",
+		"Acceptance Criteria",
+		"Done",
+		"Checklist",
+		"Verification",
+		"Definition of Done",
+		"definition of done",
+	}
+	for _, title := range matches {
+		if !acceptanceSectionHeaderPattern.MatchString(title) {
+			t.Errorf("acceptanceSectionHeaderPattern should match header %q", title)
+		}
+	}
+
+	nonMatches := []string{
+		"Implementation",
+		"Context",
+		"Checklist Items",
+	}
+	for _, title := range nonMatches {
+		if acceptanceSectionHeaderPattern.MatchString(title) {
+			t.Errorf("acceptanceSectionHeaderPattern should not match header %q", title)
+		}
+	}
+}
+
+// TestStripAcceptanceSections_WidenedHeaders_GH5354 checks the widened
+// pattern actually feeds through stripAcceptanceSections end-to-end: a body
+// with "## Verification" and "## Definition of Done" checklists must not
+// leak those bullets into the implementation checklist analyzeAndSplit
+// extracts.
+func TestStripAcceptanceSections_WidenedHeaders_GH5354(t *testing.T) {
+	body := `## Implementation
+
+- [ ] Add the widget
+
+## Verification
+
+- [ ] Widget renders correctly
+
+## Definition of Done
+
+- [ ] Reviewed and merged`
+
+	stripped := stripAcceptanceSections(body)
+
+	if strings.Contains(stripped, "Widget renders correctly") {
+		t.Error("stripAcceptanceSections left the Verification checklist body in place")
+	}
+	if strings.Contains(stripped, "Reviewed and merged") {
+		t.Error("stripAcceptanceSections left the Definition of Done checklist body in place")
+	}
+	if !strings.Contains(stripped, "Add the widget") {
+		t.Error("stripAcceptanceSections should not touch the Implementation checklist")
+	}
+}

--- a/internal/executor/monitor.go
+++ b/internal/executor/monitor.go
@@ -45,6 +45,15 @@ type TaskState struct {
 	IssueURL    string
 	ProjectPath string // Resolved project directory for this task (GH-2167)
 	ProjectName string // Short project name for display (GH-2167)
+
+	// ParentID is set for an in-process decomposition subtask (see
+	// RegisterSubtask) to the parent task's ID. ReconcileDeadOwners (GH-5354)
+	// uses it to treat the parent's live-worker liveness as the subtask's
+	// own — the dispatcher worker tracks only the parent ID while executing
+	// subtasks sequentially (runner_decompose.go), so a subtask never has a
+	// live-worker entry of its own even while genuinely running. Empty for
+	// every non-subtask entry.
+	ParentID string
 }
 
 // LiveWorkerChecker reports which task IDs a live executor worker is
@@ -91,6 +100,28 @@ func (m *Monitor) Register(taskID, title, issueURL string) {
 		Phase:    "Pending",
 		Progress: 0,
 		IssueURL: issueURL,
+	}
+}
+
+// RegisterSubtask registers a new in-process decomposition subtask, recording
+// parentID so ReconcileDeadOwners (GH-5354) can treat the parent's
+// live-worker liveness as the subtask's own. Otherwise identical to
+// Register. Use this instead of Register for every subtask.ID registered
+// from executeDecomposedTask (runner_decompose.go) — Register itself is left
+// untouched since its other caller (orchestrator.go) registers top-level
+// tasks that have no parent.
+func (m *Monitor) RegisterSubtask(taskID, title, issueURL, parentID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.tasks[taskID] = &TaskState{
+		ID:       taskID,
+		Title:    title,
+		Status:   StatusPending,
+		Phase:    "Pending",
+		Progress: 0,
+		IssueURL: issueURL,
+		ParentID: parentID,
 	}
 }
 
@@ -650,6 +681,19 @@ func (m *Monitor) ReconcileDeadOwners() {
 	m.mu.RLock()
 	for id, state := range m.tasks {
 		if state.Status != StatusRunning || live[id] {
+			continue
+		}
+		// GH-5354: an in-process decomposition subtask has no live-worker
+		// entry of its own — the dispatcher worker tracks only the parent
+		// task's ID while executeDecomposedTask runs subtasks sequentially
+		// (runner_decompose.go), and subtasks have no executions row
+		// (GH-4032) for the heartbeat fallback below to find either. Without
+		// this check every running subtask reads as a dead owner the moment
+		// the grace period elapses, even mid-run with a perfectly live
+		// parent (the #5350 report). Treat the parent's presence in the
+		// live-worker set as the subtask's own liveness; a subtask whose
+		// parent is genuinely gone still falls through to the checks below.
+		if state.ParentID != "" && live[state.ParentID] {
 			continue
 		}
 		if state.StartedAt != nil && now.Sub(*state.StartedAt) < deadOwnerGracePeriod {

--- a/internal/executor/monitor_test.go
+++ b/internal/executor/monitor_test.go
@@ -649,6 +649,66 @@ func TestMonitorReconcileDeadOwners_NoHeartbeatFinalizes(t *testing.T) {
 	}
 }
 
+// TestMonitorReconcileDeadOwners_SubtaskWithLiveParentNotFinalized_GH5354 is
+// the GH-5354 acceptance test: an in-process decomposition subtask
+// (RegisterSubtask) has no execution_events row of its own (GH-4032) and is
+// never itself in the live-worker set — executeDecomposedTask's worker
+// tracks only the parent task's ID while subtasks run sequentially
+// (runner_decompose.go). Before this fix, ReconcileDeadOwners had no way to
+// tell that apart from a genuine dead owner and flipped every running
+// subtask to failed the moment deadOwnerGracePeriod elapsed, even with a
+// perfectly live parent — the literal #5350 report symptom (a 20-minute
+// subtask rendering failed for ~19.5 minutes before flipping green). A
+// subtask whose parent is live must stay StatusRunning past the grace
+// window with no execStore wired at all.
+func TestMonitorReconcileDeadOwners_SubtaskWithLiveParentNotFinalized_GH5354(t *testing.T) {
+	m := NewMonitor()
+	m.RegisterSubtask("GH-77-1", "Subtask 1", "", "GH-77")
+	m.Start("GH-77-1")
+	// The live-worker set holds the PARENT id, never the subtask id — this
+	// is the real shape executeDecomposedTask produces.
+	m.SetLiveWorkerChecker(&fakeLiveWorkerChecker{ids: []string{"GH-77"}})
+	pastStart(t, m, "GH-77-1")
+
+	ids := m.GetRunningTaskIDs()
+	found := false
+	for _, id := range ids {
+		if id == "GH-77-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Expected in-process subtask with a live parent to remain drain-blocking, got %v", ids)
+	}
+	state, _ := m.Get("GH-77-1")
+	if state.Status != StatusRunning {
+		t.Errorf("Status = %s, want %s (subtask with a live parent must not be reconciled away)", state.Status, StatusRunning)
+	}
+}
+
+// TestMonitorReconcileDeadOwners_SubtaskWithDeadParentFinalized_GH5354 is the
+// GH-5354 acceptance test's other half: once the parent itself is no longer
+// live (e.g. the executor process died mid-decomposition), the subtask must
+// still be reconciled to failed exactly like any other dead-owner candidate
+// — the parent-liveness exclusion above must not become a permanent
+// bypass.
+func TestMonitorReconcileDeadOwners_SubtaskWithDeadParentFinalized_GH5354(t *testing.T) {
+	m := NewMonitor()
+	m.RegisterSubtask("GH-78-1", "Subtask 1", "", "GH-78")
+	m.Start("GH-78-1")
+	m.SetLiveWorkerChecker(&fakeLiveWorkerChecker{}) // neither parent nor subtask is live
+	pastStart(t, m, "GH-78-1")
+
+	ids := m.GetRunningTaskIDs()
+	if len(ids) != 0 {
+		t.Fatalf("Expected subtask with a dead parent excluded from drain, got %v", ids)
+	}
+	state, _ := m.Get("GH-78-1")
+	if state.Status != StatusFailed {
+		t.Errorf("Status = %s, want %s (subtask with a genuinely dead parent must still be reconciled)", state.Status, StatusFailed)
+	}
+}
+
 // End-to-end acceptance: WaitForTasks is the method upgrade.TaskChecker calls
 // to block self-upgrade drain (GracefulUpgrader.PerformUpgrade /
 // HotUpgrader.PerformHotUpgrade). A dead-owner entry must let it resolve

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -130,7 +130,7 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 		// sub-issue ID as its own title instead of the planned subtask
 		// summary.
 		if r.monitor != nil {
-			r.monitor.Register(subtask.ID, subtask.Title, "")
+			r.monitor.RegisterSubtask(subtask.ID, subtask.Title, "", parentTask.ID)
 		}
 
 		// Temporarily disable decomposer to prevent recursive decomposition


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5354.

Closes #5354

## Changes

GitHub Issue GH-5354: fix(monitor): in-process decomposition subtasks are painted failed mid-run by the dead-owner sweep — no executions row, ID not in the live set

## Problem

Post-merge review of PR #5352 (issue #5350). The PR fixed the terminal state of subtask rows (each subtask now finalizes its own Monitor entry and the PR link is backfilled), but a subtask still renders red for the whole time it is running:

- `internal/executor/runner_decompose.go` (~133) creates the subtask Monitor entry as `StatusRunning`.
- `internal/executor/monitor.go` (~655-675) reconciles running entries: the subtask ID is never in `Dispatcher.GetRunningTaskIDs` (the worker tracks the parent ID), and subtasks have no `executions` row (GH-4032), so `executionRecentlyProgressed` returns `ErrNoRows` → false.
- After the 30 s grace the autopilot sweep (`internal/autopilot/controller.go` ~1131) flips the entry to `StatusFailed` with the "reconciled: dead-owner" reason. The `Complete()` added by #5352 only repairs it once the subtask ends.

Failure scenario: a 20-minute subtask shows as failed in the TUI for roughly 19.5 minutes, then turns green. Operators read it as a real failure (this is exactly what the #5350 report described).

## Fix

Pick one, prefer the first:
1. Exclude entries that have a parent execution (in-process subtasks) from the dead-owner reconciliation, treating the parent's liveness as theirs.
2. Or include in-process subtask IDs in the live set returned to the monitor (the runner knows which subtask it is executing).

## Tests

- Monitor test: subtask entry `StatusRunning` with a live parent, no executions row, past the grace window → must remain `StatusRunning`.
- Existing `runner_decompose_monitor_test.go` stays green.

## Acceptance

- [ ] A running in-process subtask is never flipped to failed by the reconciliation sweep while its parent is live.
- [ ] Subtask whose parent is genuinely dead still gets reconciled to failed.
- [ ] Widen `acceptanceSectionHeaderPattern` in `internal/executor/decompose.go` to also cover `## Checklist`, `## Verification`, `## Definition of Done` (note from the same review; small, same area).