### PR TITLE
GH-5358: chore(deps): bump studio-sdk to v0.38.1 — poller no longer marks an issue done from another issue's merged PR on a reused branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/qf-studio/grom v0.2.0
-	github.com/qf-studio/studio-sdk v0.38.0
+	github.com/qf-studio/studio-sdk v0.38.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qf-studio/grom v0.2.0 h1:EefLLr794KGk8ihdpKBgJnmSyUc//b/n8zZ77VbeuXY=
 github.com/qf-studio/grom v0.2.0/go.mod h1:YVihqE0treA2091TLNhGWvGi5+vMYv/ZBlAlX7Mr/JI=
-github.com/qf-studio/studio-sdk v0.38.0 h1:zR/5Y9pOs9TYjzKmvmNXQEgneNBHFVoTy4YPQmCFRWg=
-github.com/qf-studio/studio-sdk v0.38.0/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
+github.com/qf-studio/studio-sdk v0.38.1 h1:qegWl7ZR3xouP4/3u/dInnFhr9r5bQ3+73rfuQW6GNk=
+github.com/qf-studio/studio-sdk v0.38.1/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5358.

Closes #5358

## Changes

GitHub Issue GH-5358: chore(deps): bump studio-sdk to v0.38.1 — poller no longer marks an issue done from another issue's merged PR on a reused branch

## Context

studio-sdk v0.38.1 (tagged 2026-09-07 14:01Z) ships the `hasMergedWork` fix from studio-sdk#138 and #140: the branch-lookup fallback in the GitHub poller now requires the found PR to reference the issue (title prefix `GH-<n>:` or a closing keyword reference) before stamping `pilot-done`. Without it the box still runs the matcher that marked pilot-console #275 done from #277's merged CI-fix PR on the reused `pilot/GH-275` branch and made #275 permanently unpickable.

Pilot consumes the SDK poller via `cmd/pilot/handlers.go`.

## Implementation

1. In `go.mod`, bump `github.com/qf-studio/studio-sdk` from v0.38.0 to v0.38.1; run `go mod tidy`; commit `go.mod` and `go.sum`.
2. Build and run the short test suite; no code changes expected (the SDK change is internal to the poller; `FindMergedPRByBranch` signature change is inside the SDK, pilot's own `internal/adapters/github` function of the same name is a different type).
3. If any pilot test references the SDK poller's branch-lookup behaviour, update it to the new contract.

## Acceptance

- [ ] `go.mod` pins studio-sdk v0.38.1 and `go build ./...` is green.
- [ ] `go test -short ./cmd/pilot/... ./internal/adapters/...` green.
- [ ] No other dependency changes in `go.mod`.