### PR TITLE
GH-5360: fix(autopilot): CI-fix size guard blocks the fix for a single lint annotation on Pilot's own PR — PR held needs-human with no fix issue and no operator signal

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3725,27 +3725,46 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 			// be mistaken for cascade contamination just because it has tests.
 			production, bookkeeping, test := productionAdditions(files)
 			if production > c.config.MaxCIFixPRSize {
-				c.log.Warn("CI fix size guard fired — failing PR exceeds size floor, refusing to spawn fix issue",
-					"pr", prState.PRNumber, "production_additions", production, "test_additions", test,
-					"bookkeeping_additions", bookkeeping, "limit", c.config.MaxCIFixPRSize)
-				// GH-3260: Sync board card to "Blocked/Failed" column on execution failure (size guard).
-				if c.boardSync != nil && prState.IssueNodeID != "" && c.failStatus != "" {
-					if err := c.boardSync.UpdateProjectItemStatus(ctx, prState.IssueNodeID, c.failStatus); err != nil {
-						c.log.Warn("board sync on exec failure (size guard) failed", "pr", prState.PRNumber, "error", err)
-						c.alertBoardSyncScopeFailureOnce(err)
+				// GH-5360: a large PR failing CI on a small number of
+				// lint/vet/fmt annotations (PR #5356's incident: 387
+				// production additions, one golangci-lint `unused` finding)
+				// is exactly the case where an automated fix issue is
+				// cheapest and a human hold is most expensive — the size
+				// guard's purpose is to stop fix-loop churn on PRs whose
+				// failure itself is evidence of contamination, not to block
+				// a one-line lint fix on an otherwise-healthy large PR.
+				// sizeGuardAnnotationExemption only exempts when every
+				// gathered failed check is a real compiler/lint annotation
+				// on a lint/vet/fmt-named check and the total annotation
+				// count stays small — a failing `test` job or a multi-
+				// annotation failure still falls through to the guard below.
+				if exempt, annotationCount := sizeGuardAnnotationExemption(perCheckLogs); exempt {
+					c.log.Info("CI fix size guard exempted — small lint/vet/fmt annotation count overrides size floor",
+						"pr", prState.PRNumber, "production_additions", production, "limit", c.config.MaxCIFixPRSize,
+						"annotation_count", annotationCount, "max_annotations", ciFixSizeGuardAnnotationExemptionMax)
+				} else {
+					c.log.Warn("CI fix size guard fired — failing PR exceeds size floor, refusing to spawn fix issue",
+						"pr", prState.PRNumber, "production_additions", production, "test_additions", test,
+						"bookkeeping_additions", bookkeeping, "limit", c.config.MaxCIFixPRSize)
+					// GH-3260: Sync board card to "Blocked/Failed" column on execution failure (size guard).
+					if c.boardSync != nil && prState.IssueNodeID != "" && c.failStatus != "" {
+						if err := c.boardSync.UpdateProjectItemStatus(ctx, prState.IssueNodeID, c.failStatus); err != nil {
+							c.log.Warn("board sync on exec failure (size guard) failed", "pr", prState.PRNumber, "error", err)
+							c.alertBoardSyncScopeFailureOnce(err)
+						}
 					}
+					// GH-4459: never self-close here — a closed PR with no fix
+					// issue to continue the work is the exact dead end that lost
+					// the GH-4415 fix twice. Hold for a human instead, PR and
+					// branch intact.
+					comment := fmt.Sprintf("CI fix size guard fired: PR has %d production additions, over limit %d%s (likely cascade contamination). No fix issue will be created. %s",
+						production, c.config.MaxCIFixPRSize, excludedAdditionsSuffix(bookkeeping, test), ciFailedChecksSummary(failedChecks))
+					c.escalateAndHold(ctx, prState, "CI fix size guard fired", []string{labelNeedsHuman}, comment)
+					c.metrics.RecordPRFailed()
+					c.metrics.RecordPRFailedClass(failureClass)
+					c.recordCIFailVerdict(failureClass)
+					return nil
 				}
-				// GH-4459: never self-close here — a closed PR with no fix
-				// issue to continue the work is the exact dead end that lost
-				// the GH-4415 fix twice. Hold for a human instead, PR and
-				// branch intact.
-				comment := fmt.Sprintf("CI fix size guard fired: PR has %d production additions, over limit %d%s (likely cascade contamination). No fix issue will be created. %s",
-					production, c.config.MaxCIFixPRSize, excludedAdditionsSuffix(bookkeeping, test), ciFailedChecksSummary(failedChecks))
-				c.escalateAndHold(ctx, prState, "CI fix size guard fired", []string{labelNeedsHuman}, comment)
-				c.metrics.RecordPRFailed()
-				c.metrics.RecordPRFailedClass(failureClass)
-				c.recordCIFailVerdict(failureClass)
-				return nil
 			}
 		}
 	}

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -9531,6 +9531,180 @@ func TestCIFixSizeGuard_GenuineCascade_StillBlocksFixIssue(t *testing.T) {
 	}
 }
 
+// TestCIFixSizeGuard_SingleLintAnnotation_ExemptsGuard_SpawnsFixIssue is the
+// GH-5360 regression: PR #5356's incident shape — 850 production additions,
+// CI failing on exactly one golangci-lint annotation (`test` job green) —
+// must exempt the CI-fix size guard and spawn a continuation fix issue
+// instead of holding for a human. The guard's purpose is to stop fix-loop
+// churn on PRs whose failure itself is evidence of contamination; a single
+// lint annotation on an otherwise-healthy large PR is not that.
+func TestCIFixSizeGuard_SingleLintAnnotation_ExemptsGuard_SpawnsFixIssue(t *testing.T) {
+	const codeLog = `Run golangci-lint run ./...
+internal/autopilot/owner_death.go:158:6: func markSelfClosed is unused (unused)
+##[error]Process completed with exit code 1.`
+
+	issueCreated := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/gh5360sha1/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{ID: 5360, Name: "lint", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/5360/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(codeLog))
+		case r.URL.Path == "/repos/owner/repo/issues/5351" && r.Method == http.MethodGet:
+			resp := github.Issue{Number: 5351, Body: "<!-- autopilot-meta branch:pilot/GH-5351 pr:5356 iteration:1 -->"}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/5356/files" && r.Method == http.MethodGet:
+			files := []*github.PRFile{
+				{Filename: "internal/autopilot/owner_death.go", Status: "modified", Additions: 850},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, files))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			resp := github.Issue{Number: 5361}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/5356" && r.Method == http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.MaxCIFixPRSize = 200
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	prState := &PRState{
+		PRNumber:    5356,
+		IssueNumber: 5351,
+		HeadSHA:     "gh5360sha1",
+		Stage:       StageCIFailed,
+	}
+
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if !issueCreated {
+		t.Error("fix issue MUST be created for a single-annotation lint failure, even on a large PR (GH-5360)")
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "CI fix size guard exempted") {
+		t.Errorf("expected the guard's exemption log line, got logs:\n%s", logs)
+	}
+	if strings.Contains(logs, "CI fix size guard fired") {
+		t.Errorf("guard must not fire for a single-annotation lint failure, got logs:\n%s", logs)
+	}
+}
+
+// TestCIFixSizeGuard_LargePR_FailingTestJob_StillBlocksAndComments is the
+// GH-5360 companion case: a large PR (850 production additions) whose
+// failing check is a `test` job — never a lint/vet/fmt check, regardless of
+// whether its log happens to contain a `.go:LINE:COL:`-shaped line (e.g. a
+// compile error blocking the test binary) — must still trip the size guard
+// exactly as before, and the resulting hold must leave a PR comment naming
+// the production-addition count and the configured limit.
+func TestCIFixSizeGuard_LargePR_FailingTestJob_StillBlocksAndComments(t *testing.T) {
+	const codeLog = `Run go test ./...
+internal/autopilot/owner_death.go:200:6: undefined: someHelper
+FAIL	github.com/qf-studio/pilot/internal/autopilot [build failed]`
+
+	issueCreated := false
+	var comments []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/gh5360sha2/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{ID: 5362, Name: "test", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/5362/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(codeLog))
+		case r.URL.Path == "/repos/owner/repo/issues/5352" && r.Method == http.MethodGet:
+			resp := github.Issue{Number: 5352, Body: "<!-- autopilot-meta branch:pilot/GH-5352 pr:5357 iteration:1 -->"}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/5357/files" && r.Method == http.MethodGet:
+			files := []*github.PRFile{
+				{Filename: "internal/autopilot/owner_death.go", Status: "modified", Additions: 850},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, files))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			resp := github.Issue{Number: 5363}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues/5357/comments" && r.Method == http.MethodPost:
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			comments = append(comments, body["body"])
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.MaxCIFixPRSize = 200
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    5357,
+		IssueNumber: 5352,
+		HeadSHA:     "gh5360sha2",
+		Stage:       StageCIFailed,
+	}
+
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if issueCreated {
+		t.Error("fix issue must NOT be created — a failing test job must never exempt the size guard")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+	}
+	if len(comments) == 0 {
+		t.Fatal("expected a PR comment naming the size-guard hold, got none")
+	}
+	if !strings.Contains(comments[0], "850 production additions") || !strings.Contains(comments[0], "over limit 200") {
+		t.Errorf("comment should name the production-addition count and limit, got: %s", comments[0])
+	}
+}
+
 // TestHandleCIFailed_FixIssueCreateErrors_EscalatesInsteadOfClosing covers the
 // CI-fail rung of GH-4459: when CreateFailureIssue's underlying GitHub call
 // errors (here, a 500 from the issues-create endpoint), the PR must be held

--- a/internal/autopilot/scope_guard.go
+++ b/internal/autopilot/scope_guard.go
@@ -218,3 +218,64 @@ func SizeFloorReason(files []*github.PRFile) string {
 	}
 	return ""
 }
+
+// ciFixSizeGuardAnnotationExemptionMax caps how many real compiler/lint
+// annotation lines the GH-5360 exemption below tolerates before deferring to
+// the CI-fix size guard as usual. GH-5360's incident (PR #5356, 387
+// production additions) failed on exactly one golangci-lint `unused`
+// finding — a single-annotation lint failure is cheap to auto-fix and not
+// the cascade-contamination shape the guard exists to catch; a handful more
+// (proposed ceiling: 3) is still cheap, but an unbounded count would let a
+// genuinely broken PR slip through disguised as "just lint".
+const ciFixSizeGuardAnnotationExemptionMax = 3
+
+// lintClassCheckNameRe matches a CI check name that looks like a lint/vet/fmt
+// job (this repo's own checks are literally named "lint"/"build"/"test", and
+// golangci-lint's default config runs `go vet` as one of its analyzers under
+// that same "lint" job — see `.golangci.yml`), as opposed to a "test" or
+// "build" job whose failure could carry a `.go:LINE:COL:` shaped annotation
+// for an entirely different, non-lint reason (e.g. a compile error blocking
+// the test binary). GH-5360's exemption must never fire for those.
+var lintClassCheckNameRe = regexp.MustCompile(`(?i)lint|vet|fmt`)
+
+// isLintClassCheckName reports whether name names a lint/vet/fmt-shaped CI
+// check, per lintClassCheckNameRe.
+func isLintClassCheckName(name string) bool {
+	return lintClassCheckNameRe.MatchString(name)
+}
+
+// sizeGuardAnnotationExemption reports whether checks collectively qualify
+// for GH-5360's small-lint-annotation exemption from the CI-fix size guard:
+// every gathered failed check must (a) classify as FailureClassCode via the
+// signalRealAnnotation tier specifically — never an ambiguous/prose/
+// structural signal, and never any other check classifying differently
+// (e.g. a failing `test` job alongside the lint failure) — and (b) run on a
+// check whose name looks like lint/vet/fmt (isLintClassCheckName). The
+// total count of real annotation lines across every qualifying check must
+// also stay at or under ciFixSizeGuardAnnotationExemptionMax. Returns
+// (false, 0) — never exempt — the moment any single check fails either
+// condition, and when checks is empty (nothing to exempt on).
+//
+// annotationCount is returned alongside the bool purely for the caller's
+// diagnostic log line, so an operator can see exactly why the guard was
+// skipped without re-deriving the count by hand.
+func sizeGuardAnnotationExemption(checks []FailedCheckLog) (exempt bool, annotationCount int) {
+	if len(checks) == 0 {
+		return false, 0
+	}
+	total := 0
+	for _, chk := range checks {
+		class, signal := classifyCheckFailureFull(chk)
+		if class != FailureClassCode || signal != signalRealAnnotation {
+			return false, 0
+		}
+		if !isLintClassCheckName(chk.CheckName) {
+			return false, 0
+		}
+		total += len(realAnnotationRe.FindAllString(chk.Logs, -1))
+	}
+	if total > ciFixSizeGuardAnnotationExemptionMax {
+		return false, total
+	}
+	return true, total
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5360.

Closes #5360

## Changes

GitHub Issue GH-5360: fix(autopilot): CI-fix size guard blocks the fix for a single lint annotation on Pilot's own PR — PR held needs-human with no fix issue and no operator signal

## Problem

PR #5356 (GH-5351) failed CI on exactly one `golangci-lint` `unused` finding (`class=code signal=real_annotation`, `test` job green). Autopilot classified it correctly, then:

```
13:32:54.056Z "CI fix size guard fired — failing PR exceeds size floor, refusing to spawn fix issue" production_additions=387 test_additions=463 bookkeeping_additions=30 limit=200
13:32:55.706Z "escalateAndHold: PR held for human review, branch intact" reason="CI fix size guard fired" labels=[pilot-needs-human]
```

The guard keys only on the size of the failing PR (`internal/autopilot/controller.go`), not on the size or class of the failure. A one-line fix on an 880-line PR is exactly the case where an automated fix issue is cheapest and a human hold is most expensive. The hold also fired before `max_ci_fix_iterations` and the platform breaker were consulted, and the only trace was the `pilot-needs-human` label on the PR/issue: no comment on the PR, no alert.

## Fix

1. Exempt from the size guard CI failures whose classification is `real_annotation` with a small annotation count (proposed: ≤ 3 annotations, all in lint/vet/fmt checks). The guard's purpose is to stop fix-loop churn on large broken PRs; single-annotation lint failures are not that.
2. When the guard does fire, post the same explanatory comment on the PR that `escalateBasePresenceHold` now posts (PR #5306 pattern) with the sizes and the limit, and emit the existing `needs_human` alert so the operator sees it.
3. Keep the guard for test failures and multi-annotation failures.

## Tests

- Failing PR of 850 additions with one lint annotation → fix issue spawned (guard skipped, log states the exemption).
- Failing PR of 850 additions with a failing `test` job → guard fires as today, comment posted.

## Acceptance

- [ ] Single-annotation lint failures on large PRs get a fix issue.
- [ ] Every size-guard hold leaves a PR comment naming the sizes and the limit.
- [ ] Existing size-guard tests green.