### PR TITLE
GH-5359: fix(executor): PR guard reports no_changes when merge-base against origin/main cannot be resolved — a run that already opened its PR is recorded no_op and re-picked

### DIFF
--- a/.agent/tasks/gh-5359.md
+++ b/.agent/tasks/gh-5359.md
@@ -1,0 +1,39 @@
+# GH-5359
+
+**Created:** 2026-09-07
+
+## Problem
+
+GitHub Issue GH-5359: fix(executor): PR guard reports no_changes when merge-base against origin/main cannot be resolved — a run that already opened its PR is recorded no_op and re-picked
+
+## Problem
+
+GH-5351 run 1 (2026-09-07 12:07Z→13:29Z) committed (`CommitSHA recovered via git` sha=0359ad6, new_commits=1), pushed and opened PR #5356 (autopilot adopted it at 13:24:08Z), yet the executor's terminal check ended the run as `no_op`:
+
+```
+13:29:45.010Z "Intent judge skipped: failed to get diff" error="could not resolve merge-base for \"main\" against origin/main..."
+13:29:45.047Z "Task ended without success" status=no_op error="no_changes: branch has no commits relative to base (PR guard)"
+```
+
+The PR guard in `internal/executor/runner.go` treats a failed merge-base resolution as "no commits relative to base". The dispatcher then re-picked the issue (generation 1 at 13:30:26Z) as if nothing had been delivered. Nothing was lost this time only because autopilot had already adopted the PR; the ledger row is still wrong (`no_op`) and the retry would have re-run Claude on a task that was already delivered had autopilot not held the PR first.
+
+Related pitfall: `.agent/knowledge/memories/pitfalls/pitfall_noop_terminal_state_invisible_to_dispatch_guards.md`.
+
+## Fix
+
+1. Distinguish "diff computed and empty" from "diff could not be computed". When `git merge-base` fails, do not classify as `no_changes`; fall back to (a) `git rev-list --count origin/<base>..HEAD` on the worktree after a `git fetch origin <base>`, and if that also fails, (b) check whether a PR for the branch exists on GitHub (the PR-existence check the reconciler already performs when adopting). Only if all three agree there is nothing does the guard return `no_changes`.
+2. Log the fallback path taken at Info with the branch, base and PR number.
+3. Investigate why merge-base failed in this worktree (likely `origin/main` not fetched into the fresh worktree, or a stale `main` ref in the worktree) and fix the root cause in the worktree preparation if that is it.
+
+## Tests
+
+- Worktree fixture where `origin/main` is absent (no fetch) but the branch has one commit and a PR exists → run ends `completed`, not `no_op`.
+- Fixture with a genuinely empty branch → still `no_op`.
+
+## Acceptance
+
+- [ ] A run whose branch has commits (or an open PR) can never be recorded `no_op` because of a merge-base error.
+- [ ] Existing PR-guard tests green.
+
+## Acceptance Criteria
+

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2416,6 +2416,98 @@ func (r *Runner) adoptOpenBranchPR(ctx context.Context, git *GitOperations, task
 	return true
 }
 
+// resolveEmptyBranchWithFallback is the GH-5359 fix for the direct
+// (non-epic) empty-branch PR guard (~runner.go:5580 at the time of writing).
+// A bare git.CountNewCommitsAgainstOrigin call can misreport a confirmed
+// "zero" — or error outright — when git merge-base against
+// origin/<baseBranch> can't be resolved in this worktree. GH-5351 run 1
+// committed, pushed, and opened PR #5356, yet the guard still recorded
+// no_op: "could not resolve merge-base for \"main\" against origin/main"
+// fired, and the rev-list-based count the guard trusted alone read as if
+// the branch were empty even though the PR already existed.
+//
+// firstErr is whatever error (if any) the caller's own
+// CountNewCommitsAgainstOrigin call produced — nil if it succeeded and read
+// a confirmed zero. This function is only worth calling in that "zero or
+// error" case; a confirmed nonzero count needs no fallback.
+//
+// Cross-checks, in order, before agreeing the branch is empty:
+//  1. Does git merge-base even resolve against origin/<baseBranch> (or the
+//     local fallback ref)? If the first count call already succeeded with a
+//     confirmed zero AND merge-base also resolves cleanly, there is nothing
+//     to add — the branch is genuinely empty and no further git/GitHub calls
+//     are made.
+//  2. Otherwise, retry git rev-list --count origin/<base>..HEAD after a
+//     fresh git fetch origin <base> (mirrors CountNewCommitsAgainstOrigin
+//     exactly) — isolates a one-off transient failure from a structurally
+//     unresolvable base ref.
+//  3. Whether an open PR already exists for task.Branch on GitHub. A PR can
+//     only exist if a real commit was already pushed, so its existence is
+//     conclusive evidence the branch isn't empty regardless of what the
+//     local git state currently resolves to.
+//
+// Returns hasCommits=true if either git signal found commits or step 3 found
+// an open PR (prURL is set only in the latter case, so the caller can adopt
+// it directly — mirroring adoptOpenBranchPR above — instead of re-pushing or
+// racing gh CLI into a duplicate PR). Returns confirmed=false when merge-base
+// failed, the rev-list retry also errored, and no PR was found: genuinely
+// unknown, never reported as "confirmed empty" (mirrors the GH-5342 posture
+// that a count failure is not evidence of zero commits). method is for
+// caller logging only.
+func (r *Runner) resolveEmptyBranchWithFallback(ctx context.Context, git *GitOperations, task *Task, baseBranch string, firstErr error) (hasCommits bool, confirmed bool, method string, prURL string) {
+	_, mergeBaseErr := git.resolveMergeBaseSHA(ctx, baseBranch)
+	if firstErr == nil && mergeBaseErr == nil {
+		return false, true, "merge-base-resolved-zero", ""
+	}
+
+	r.log.Info("PR guard: commit-count check inconclusive, cross-checking rev-list retry and PR existence before concluding branch state",
+		slog.String("task_id", task.ID),
+		slog.String("branch", task.Branch),
+		slog.String("base_branch", baseBranch),
+		slog.Any("count_error", firstErr),
+		slog.Any("merge_base_error", mergeBaseErr),
+	)
+
+	retryCount, retryErr := git.CountNewCommitsAgainstOrigin(ctx, baseBranch)
+	if retryErr == nil && retryCount > 0 {
+		r.log.Info("PR guard: rev-list retry found commits, branch is not empty",
+			slog.String("task_id", task.ID),
+			slog.String("branch", task.Branch),
+			slog.Int("commit_count", retryCount),
+		)
+		return true, true, "rev-list-retry", ""
+	}
+
+	if task.Branch != "" {
+		if url, prErr := git.FindOpenPRByBranch(ctx, task.Branch); prErr == nil && url != "" {
+			r.log.Info("PR guard: an open PR already exists for the branch, treating as having commits",
+				slog.String("task_id", task.ID),
+				slog.String("branch", task.Branch),
+				slog.String("base_branch", baseBranch),
+				slog.String("pr_url", url),
+			)
+			return true, true, "pr-exists", url
+		}
+	}
+
+	if retryErr != nil {
+		r.log.Warn("PR guard: merge-base, rev-list retry, and PR-existence check all inconclusive",
+			slog.String("task_id", task.ID),
+			slog.String("branch", task.Branch),
+			slog.String("base_branch", baseBranch),
+			slog.Any("rev_list_error", retryErr),
+		)
+		return false, false, "inconclusive", ""
+	}
+
+	r.log.Info("PR guard: rev-list retry and PR-existence check both confirm no commits",
+		slog.String("task_id", task.ID),
+		slog.String("branch", task.Branch),
+		slog.String("base_branch", baseBranch),
+	)
+	return false, true, "confirmed-empty-after-fallback", ""
+}
+
 // checkIssueSupersededBeforePR is the GH-4656 PR-creation preflight: it
 // refetches the task's live GitHub issue state immediately before opening a
 // PR and, if the issue is already closed, refuses to create the PR. Runs
@@ -5578,24 +5670,58 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			// confirmed zero count; a real count failure is a hard failure that
 			// feeds the normal retry/escalation path instead.
 			guardCount, guardErr := git.CountNewCommitsAgainstOrigin(ctx, baseBranch)
-			if guardErr != nil {
-				result.Success = false
-				result.Error = fmt.Sprintf("failed to verify commit count before PR creation: %v", guardErr)
-				log.Warn("Commit-count guard failed to verify commits",
-					slog.String("task_id", task.ID),
-					slog.String("base_branch", baseBranch),
-					slog.Any("error", guardErr),
-				)
-				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
-				return result, nil
-			}
-			if guardCount == 0 {
-				evaluateEmptyBranchPRGuard(false, nil, result)
-				if backendResult != nil {
-					backendResult.ErrorType = string(ErrorTypeNoChanges)
+			if guardErr != nil || guardCount == 0 {
+				// GH-5359: a merge-base failure (e.g. origin/<base> unresolvable
+				// in this worktree) can make the plain count above read a false
+				// "zero", or error outright, even though the branch already has
+				// commits — and, in GH-5351's case, an already-opened PR. Before
+				// trusting either outcome, cross-check a rev-list retry and a
+				// GitHub PR-existence lookup — see resolveEmptyBranchWithFallback's
+				// doc comment for the full three-tier rationale.
+				hasCommits, confirmed, method, prURL := r.resolveEmptyBranchWithFallback(ctx, git, task, baseBranch, guardErr)
+				switch {
+				case hasCommits && prURL != "":
+					// A PR already exists for this branch — adopt it instead of
+					// re-pushing or racing gh CLI into a duplicate (mirrors
+					// adoptOpenBranchPR above).
+					result.PRUrl = prURL
+					log.Info("PR guard: adopted existing PR found via GH-5359 fallback check",
+						slog.String("task_id", task.ID),
+						slog.String("branch", task.Branch),
+						slog.String("base_branch", baseBranch),
+						slog.String("method", method),
+						slog.String("pr_url", prURL),
+					)
+					r.reportProgress(task.ID, "Completed", 100, fmt.Sprintf("adopted existing PR (GH-5359 fallback): %s", prURL))
+					r.saveLogEntry(task.LogExecutionID(), "info", "adopted existing open PR via GH-5359 fallback: "+prURL)
+					r.recordExecutionEvent(task.LogExecutionID(), memory.StagePRCreated, "adopted existing open pr via GH-5359 fallback: "+prURL)
+					if recorder != nil {
+						recorder.SetPRUrl(prURL)
+					}
+					return result, nil
+				case hasCommits:
+					// The rev-list retry confirmed real commits after all — fall
+					// through to the normal push+CreatePR flow below exactly as
+					// if the original guard had read a nonzero count.
+				case !confirmed:
+					result.Success = false
+					result.Error = fmt.Sprintf("failed to verify commit count before PR creation: could not confirm branch state via merge-base, rev-list, or PR lookup (method=%s)", method)
+					log.Warn("Commit-count guard inconclusive after GH-5359 fallback",
+						slog.String("task_id", task.ID),
+						slog.String("base_branch", baseBranch),
+						slog.String("method", method),
+						slog.Any("error", guardErr),
+					)
+					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+					return result, nil
+				default:
+					evaluateEmptyBranchPRGuard(false, nil, result)
+					if backendResult != nil {
+						backendResult.ErrorType = string(ErrorTypeNoChanges)
+					}
+					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+					return result, nil
 				}
-				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
-				return result, nil
 			}
 
 			// GH-4286: strip any memory doc the session committed without

--- a/internal/executor/runner_gh5359_test.go
+++ b/internal/executor/runner_gh5359_test.go
@@ -1,0 +1,182 @@
+package executor
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// setupPRGuardRepoNoLocalBase mirrors setupPRGuardRepo (runner_test.go) but
+// additionally deletes the local "main" ref after checking out branch and
+// configures no origin remote, so that both origin/<base> and the local
+// <base> ref are unresolvable from the branch's worktree — reproducing the
+// GH-5359 incident shape verbatim: git merge-base for "main" against
+// origin/main (and local main) fails even though the branch itself has real
+// commits and/or an already-opened PR.
+func setupPRGuardRepoNoLocalBase(t *testing.T, branch string, addCommit bool) string {
+	t.Helper()
+	dir := setupPRGuardRepo(t, branch, addCommit)
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	// Branch is already checked out by setupPRGuardRepo; deleting "main"
+	// (a different branch than the one currently checked out) is safe.
+	run("branch", "-D", "main")
+	return dir
+}
+
+// TestRunner_PRGuard_MergeBaseFailure_OpenPRExists_EndsCompleted is GH-5359's
+// primary regression test: a worktree where merge-base against origin/<base>
+// (and local <base>) cannot be resolved, but the branch has a real commit and
+// an open PR already exists on GitHub. Before this fix, CountNewCommitsAgainstOrigin
+// would return an error (or, in other environments, a false zero), the direct
+// PR guard would immediately record `no_changes` (PR guard) — recording a
+// run that already shipped a PR as a no_op that the dispatcher then re-picks.
+// See GH-5351 run 1 / PR #5356 for the exact production incident this
+// reproduces.
+func TestRunner_PRGuard_MergeBaseFailure_OpenPRExists_EndsCompleted(t *testing.T) {
+	const branch = "pilot/GH-5359-a"
+	dir := setupPRGuardRepoNoLocalBase(t, branch, true) // one commit on branch, no local "main" ref
+
+	setUpFakeGhPATH(t,
+		[]byte(`[]`), // --state merged: nothing merged
+		[]byte(`[{"url":"https://github.com/o/r/pull/5356"}]`), // --state open: PR already exists
+	)
+
+	backend := &mockFixedBackend{
+		result: &BackendResult{Success: true, Output: "implementation complete"},
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	task := &Task{
+		ID:          "GH-5359-a",
+		Title:       "fix(executor): merge-base failure with existing PR",
+		Description: "Verify a merge-base failure doesn't clobber a real PR into no_op",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    true,
+	}
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Expected success (existing PR adopted), got failure: %q", result.Error)
+	}
+	if got := TerminalStatus(result); got != "completed" {
+		t.Errorf("TerminalStatus = %q, want %q", got, "completed")
+	}
+	if strings.HasPrefix(result.Error, "no_changes:") {
+		t.Errorf("Guard incorrectly reported no_changes despite existing commit+PR: %q", result.Error)
+	}
+	if result.PRUrl != "https://github.com/o/r/pull/5356" {
+		t.Errorf("result.PRUrl = %q, want the existing open PR", result.PRUrl)
+	}
+}
+
+// TestRunner_PRGuard_GenuinelyEmptyBranch_StillNoOp is GH-5359's regression
+// test for the baseline no_op case: origin/<base> is absent (no remote
+// configured at all, same as setupPRGuardRepo's default), but the local
+// "main" ref is present and resolvable, and the branch truly has zero
+// commits. Confirms the new GH-5359 fallback logic (which now intercepts
+// every guardCount==0 result, not just guard errors) doesn't regress the
+// ordinary no_op path — merge-base resolves cleanly via the local "main"
+// fallback, so resolveEmptyBranchWithFallback's very first check
+// short-circuits back to "confirmed empty" without ever shelling out to gh.
+func TestRunner_PRGuard_GenuinelyEmptyBranch_StillNoOp(t *testing.T) {
+	const branch = "pilot/GH-5359-b"
+	dir := setupPRGuardRepo(t, branch, false) // no additional commits; local "main" left intact
+
+	backend := &mockFixedBackend{
+		result: &BackendResult{Success: true, Output: "analysis complete"},
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	task := &Task{
+		ID:          "GH-5359-b",
+		Title:       "fix(executor): genuinely empty branch still no_op",
+		Description: "Verify the GH-5359 fallback doesn't regress the ordinary confirmed-empty case",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    true,
+	}
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Success {
+		t.Error("Expected failure (genuinely empty branch), got success")
+	}
+	if !strings.HasPrefix(result.Error, "no_changes:") {
+		t.Errorf("Expected no_changes error, got: %q", result.Error)
+	}
+	if got := TerminalStatus(result); got != "no_op" {
+		t.Errorf("TerminalStatus = %q, want %q", got, "no_op")
+	}
+}
+
+// TestRunner_PRGuard_MergeBaseFailure_NoPRFound_FailsClosedNotNoOp is GH-5359's
+// fail-closed regression test: when merge-base against origin/<base> AND the
+// local <base> ref are BOTH unresolvable (so there is no git ref at all to
+// count commits against) and no PR exists for the branch either, the guard
+// cannot actually confirm the branch is empty — there is no base to diff
+// against. Mirroring the GH-5342 precedent ("a count failure is not evidence
+// of zero commits"), this must surface as a hard failure so the task is
+// retried/escalated, NOT silently recorded as no_op (which would risk the
+// exact false negative this fix exists to prevent) and NOT recorded as
+// completed either (there's no confirmed deliverable).
+func TestRunner_PRGuard_MergeBaseFailure_NoPRFound_FailsClosedNotNoOp(t *testing.T) {
+	const branch = "pilot/GH-5359-c"
+	dir := setupPRGuardRepoNoLocalBase(t, branch, false) // no commits, no local "main" ref either
+
+	setUpFakeGhPATH(t,
+		[]byte(`[]`), // --state merged: none
+		[]byte(`[]`), // --state open: none
+	)
+
+	backend := &mockFixedBackend{
+		result: &BackendResult{Success: true, Output: "analysis complete"},
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	task := &Task{
+		ID:          "GH-5359-c",
+		Title:       "fix(executor): merge-base failure with no PR anywhere",
+		Description: "Verify a totally unresolvable base with no PR fails closed instead of guessing",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    true,
+	}
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Success {
+		t.Error("Expected failure (branch state could not be confirmed), got success")
+	}
+	if strings.HasPrefix(result.Error, "no_changes:") {
+		t.Errorf("Guard must not guess no_changes when it cannot confirm branch state, got: %q", result.Error)
+	}
+	if got := TerminalStatus(result); got == "completed" || got == "no_op" {
+		t.Errorf("TerminalStatus = %q, must be neither completed nor no_op when inconclusive", got)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5359.

Closes #5359

## Changes

GitHub Issue GH-5359: fix(executor): PR guard reports no_changes when merge-base against origin/main cannot be resolved — a run that already opened its PR is recorded no_op and re-picked

## Problem

GH-5351 run 1 (2026-09-07 12:07Z→13:29Z) committed (`CommitSHA recovered via git` sha=0359ad6, new_commits=1), pushed and opened PR #5356 (autopilot adopted it at 13:24:08Z), yet the executor's terminal check ended the run as `no_op`:

```
13:29:45.010Z "Intent judge skipped: failed to get diff" error="could not resolve merge-base for \"main\" against origin/main..."
13:29:45.047Z "Task ended without success" status=no_op error="no_changes: branch has no commits relative to base (PR guard)"
```

The PR guard in `internal/executor/runner.go` treats a failed merge-base resolution as "no commits relative to base". The dispatcher then re-picked the issue (generation 1 at 13:30:26Z) as if nothing had been delivered. Nothing was lost this time only because autopilot had already adopted the PR; the ledger row is still wrong (`no_op`) and the retry would have re-run Claude on a task that was already delivered had autopilot not held the PR first.

Related pitfall: `.agent/knowledge/memories/pitfalls/pitfall_noop_terminal_state_invisible_to_dispatch_guards.md`.

## Fix

1. Distinguish "diff computed and empty" from "diff could not be computed". When `git merge-base` fails, do not classify as `no_changes`; fall back to (a) `git rev-list --count origin/<base>..HEAD` on the worktree after a `git fetch origin <base>`, and if that also fails, (b) check whether a PR for the branch exists on GitHub (the PR-existence check the reconciler already performs when adopting). Only if all three agree there is nothing does the guard return `no_changes`.
2. Log the fallback path taken at Info with the branch, base and PR number.
3. Investigate why merge-base failed in this worktree (likely `origin/main` not fetched into the fresh worktree, or a stale `main` ref in the worktree) and fix the root cause in the worktree preparation if that is it.

## Tests

- Worktree fixture where `origin/main` is absent (no fetch) but the branch has one commit and a PR exists → run ends `completed`, not `no_op`.
- Fixture with a genuinely empty branch → still `no_op`.

## Acceptance

- [ ] A run whose branch has commits (or an open PR) can never be recorded `no_op` because of a merge-base error.
- [ ] Existing PR-guard tests green.