### PR TITLE
GH-5362: fix(autopilot): handleReviewRequested still labels the source issue superseded eagerly and deletes the branch on its own close — same #275 false-success shape as the CI-fix path fixed in #5348/#5351

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -4116,17 +4116,25 @@ func (c *Controller) logCIFailureClassification(prState *PRState, checks []Faile
 // GH-4826 fixed for CI failures, reintroduced on this sibling path. Routing
 // through this seam instead means the designation happens the moment
 // CreateReviewIssue actually returns a live issue, strictly before the PR is
-// ever closed, matching spawnFailureIssue's ordering exactly. GH-5247: on
-// success this is a healthy hand-off (a revision issue now continues the
-// work), so TerminalLabel is set to github.LabelSuperseded rather than
-// github.LabelFailed — see spawnFailureIssue's doc comment for the full
-// rationale, which applies identically here.
+// ever closed, matching spawnFailureIssue's ordering exactly.
+//
+// GH-5362: this used to also set prState.TerminalLabel = github.LabelSuperseded
+// the instant CreateReviewIssue succeeded, which notifyExternalClose would
+// have read on the very next poll to mark the source issue pilot-superseded
+// — before the revision issue's own PR existed, let alone before its diff
+// was known (the same pilot-console #275 false-success shape GH-5348/GH-5351
+// fixed on the CI-fix path). That eager label write is gone: the PR this
+// revision issue was spawned to replace is now closed via markSelfClosed
+// (see handleReviewRequested below), which makes checkExternalMergeOrClose
+// skip notifyExternalClose for this close entirely, so pilot-superseded is
+// never written here. Instead, verifyFixPRDeliversSourceScope
+// (owner_death.go) applies it later, once the revision issue's PR actually
+// merges and its diff confirms it genuinely continues the origin PR's scope
+// — no separate origin-scope recording is needed here because the origin
+// PR (closed, not deleted) stays fetchable via ListPullRequestFiles for as
+// long as verifyFixPRDeliversSourceScope needs it.
 func (c *Controller) spawnReviewIssue(ctx context.Context, prState *PRState, reviews []*github.PullRequestReview, comments []*github.PRReviewComment, iteration int) (int, error) {
-	issueNum, err := c.feedbackLoop.CreateReviewIssue(ctx, prState, reviews, comments, iteration)
-	if err == nil && issueNum > 0 {
-		prState.TerminalLabel = github.LabelSuperseded
-	}
-	return issueNum, err
+	return c.feedbackLoop.CreateReviewIssue(ctx, prState, reviews, comments, iteration)
 }
 
 // reviewFilterEmptyEscalateThreshold bounds how many consecutive
@@ -4278,10 +4286,16 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 		}
 	}
 
-	// Create revision issue with review feedback. GH-4841: routed through
-	// spawnReviewIssue rather than calling feedbackLoop.CreateReviewIssue
-	// directly, so prState.TerminalLabel is designated the moment the issue
-	// exists — strictly before the ClosePullRequest call below.
+	// Create revision issue with review feedback. GH-4841 originally routed
+	// this through spawnReviewIssue so prState.TerminalLabel was designated
+	// the moment the issue existed, strictly before the ClosePullRequest call
+	// below. GH-5362: that eager labeling reproduced the #275 false-success
+	// shape (the source issue could be marked pilot-superseded before the
+	// revision issue's own PR existed, let alone merged) — spawnReviewIssue no
+	// longer sets TerminalLabel at all. verifyFixPRDeliversSourceScope
+	// (owner_death.go) now applies pilot-superseded to the source once the
+	// revision PR actually merges with confirmed file overlap. The wrapper
+	// itself stays, as the seam CreateReviewIssue is invoked through.
 	issueNum, err := c.spawnReviewIssue(ctx, prState, triggeringReviews, triggeringComments, iteration+1)
 	// GH-4856/GH-4459: the PR must never be closed unless the revision issue
 	// actually cleared preflight admission — CreateReviewIssue's dedup guard
@@ -4345,26 +4359,39 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 
 	c.log.Info("created revision issue for review feedback", "pr", prState.PRNumber, "issue", issueNum)
 
-	// Close the PR and delete the branch
+	// GH-5362: stamp the self-close marker BEFORE closing the PR, mirroring
+	// the pilot-console #275 fix GH-5348/GH-5351 applied to the CI-fix path.
+	// Without this, the very next poll's checkExternalMergeOrClose reads this
+	// close as an external (human) rejection: it runs notifyExternalClose
+	// (which — since spawnReviewIssue no longer eagerly labels the source —
+	// would re-arm it pilot-retry-ready alongside the revision issue that
+	// already continues the work, a double-arm) and finalizeExternalClose
+	// (which deletes prState.BranchName). Deleting the branch here is exactly
+	// the #275 shape: if the revision issue's own run ever needs to continue
+	// from this PR's commits, those commits are gone and the "fix" silently
+	// rebuilds from main. Stamping first means checkExternalMergeOrClose's
+	// consumeSelfClosedMarker short-circuits into
+	// removePRTracking(pr, false) instead — tracking stops, but the branch
+	// and its commits survive.
+	c.markSelfClosed(prState.PRNumber)
+
+	// Close the PR. The branch is deliberately left alone (see above) — it
+	// is no longer deleted here, and checkExternalMergeOrClose's self-close
+	// path never deletes it either.
 	if err := c.ghClient.ClosePullRequest(ctx, c.owner, c.repo, prState.PRNumber); err != nil {
 		c.log.Warn("failed to close PR after review", "pr", prState.PRNumber, "error", err)
 	}
 
-	if prState.BranchName != "" {
-		if _, err := c.safeDeleteBranch(ctx, prState.BranchName, prState.PRNumber); err != nil {
-			c.log.Debug("branch cleanup after review", "branch", prState.BranchName, "error", err)
-		}
-	}
-
-	// GH-3806/GH-4841: name the reason so notifyExternalClose can post the
-	// audit-trail comments. prState.TerminalLabel itself was already set by
-	// spawnReviewIssue above the moment CreateReviewIssue succeeded — it is
-	// not set here, so this rung cannot forget it (mirrors the matching
-	// comment on handleCIFailed's main CI-fail branch). GH-5247: a revision
-	// issue was spawned successfully, so this is a healthy hand-off rather
-	// than a pipeline failure — c.metrics.RecordPRFailed() is deliberately
-	// NOT called here (see spawnFailureIssue's doc comment for the full
-	// rationale).
+	// GH-5362: prState.TerminalLabel is intentionally left unset here (unlike
+	// the pre-fix version of this rung). notifyExternalClose — the only code
+	// that ever read TerminalLabel to label the source issue — is now skipped
+	// entirely for this close by the self-close marker stamped above.
+	// verifyFixPRDeliversSourceScope (owner_death.go) applies pilot-superseded
+	// to the source issue later instead, once the revision issue's PR
+	// actually merges and its diff confirms it delivers this PR's scope.
+	// GH-5247: this is a healthy hand-off, not a pipeline failure —
+	// c.metrics.RecordPRFailed() is deliberately NOT called here (see
+	// spawnFailureIssue's doc comment for the full rationale).
 	prState.Stage = StageFailed
 	prState.Error = fmt.Sprintf("changes requested by reviewer; revision issue #%d created to continue this work", issueNum)
 	return nil

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6572,8 +6572,13 @@ func TestController_HandleReviewRequested_CreatesIssue(t *testing.T) {
 	if !prClosed {
 		t.Error("expected PR to be closed")
 	}
-	if !branchDeleted {
-		t.Error("expected branch to be deleted")
+	// GH-5362: the branch must survive this close — deleting it here is the
+	// #275 false-success shape (if the revision issue's own run ever needs to
+	// continue from this PR's commits, a deleted branch silently rebuilds
+	// from main instead). handleReviewRequested now stamps a self-close
+	// marker via markSelfClosed and leaves the branch alone.
+	if branchDeleted {
+		t.Error("branch must NOT be deleted on a successful review-issue create (GH-5362) — it must survive so the revision issue can continue from these commits")
 	}
 	if !notified {
 		t.Error("expected notification to be sent")
@@ -6585,6 +6590,16 @@ func TestController_HandleReviewRequested_CreatesIssue(t *testing.T) {
 	}
 	if pr.Stage != StageFailed {
 		t.Errorf("stage = %s, want %s", pr.Stage, StageFailed)
+	}
+	// GH-5362: TerminalLabel is no longer set eagerly at spawn time —
+	// verifyFixPRDeliversSourceScope (owner_death.go) now applies
+	// pilot-superseded to the source issue only once the revision PR merges
+	// with confirmed file overlap.
+	if pr.TerminalLabel != "" {
+		t.Errorf("TerminalLabel = %q, want empty (GH-5362: no longer set eagerly at spawn time)", pr.TerminalLabel)
+	}
+	if !c.consumeSelfClosedMarker(42) {
+		t.Error("expected a self-close marker to be stamped before the PR close (GH-5362) so the next external-close poll doesn't misread this as a human rejection")
 	}
 }
 

--- a/internal/autopilot/gh4841_test.go
+++ b/internal/autopilot/gh4841_test.go
@@ -263,12 +263,21 @@ func TestGH4841_ReviewRequestedCrashWindow_RetryNotArmedAfterRestart(t *testing.
 	if !prClosed {
 		t.Fatal("expected the source PR to be closed once the revision issue was spawned")
 	}
-	// GH-5247: healthy hand-off — see the matching comment in the CI-failure
-	// crash-window test above.
-	if seedPR.TerminalLabel != github.LabelSuperseded {
-		t.Fatalf("prState.TerminalLabel = %q, want %q before the simulated crash", seedPR.TerminalLabel, github.LabelSuperseded)
+	// GH-5362: unlike the CI-failure path above (spawnFailureIssue still sets
+	// TerminalLabel eagerly), spawnReviewIssue no longer designates
+	// pilot-superseded at spawn time — verifyFixPRDeliversSourceScope now
+	// applies it only once the revision PR merges with confirmed file
+	// overlap. TerminalLabel is expected to stay empty here, crash or no
+	// crash — it is no longer the mechanism this "in-memory designation
+	// didn't survive a crash" scenario is exercising for the review path.
+	if seedPR.TerminalLabel != "" {
+		t.Fatalf("prState.TerminalLabel = %q, want empty (GH-5362: no longer set eagerly at spawn time)", seedPR.TerminalLabel)
 	}
-	// Simulated crash: no persistPRState call.
+	// Simulated crash: no persistPRState call, and — since the self-close
+	// marker stamped by handleReviewRequested (GH-5362) lives only in
+	// controllerA's in-memory selfClosedPRs map — no way for controllerB
+	// (below) to see it either. Both are lost the same way a real process
+	// restart would lose them.
 
 	controllerB := NewController(cfg, ghClient, nil, "owner", "repo")
 	controllerB.SetStateStore(store)

--- a/internal/autopilot/gh4856_test.go
+++ b/internal/autopilot/gh4856_test.go
@@ -152,11 +152,23 @@ func TestHandleReviewRequested_CreateIssueErrors_EscalatesInsteadOfClosing(t *te
 	if !prClosed.Load() {
 		t.Error("expected PR to be closed once the review issue was successfully created on retry")
 	}
-	if !branchDeleted.Load() {
-		t.Error("expected branch to be deleted once the review issue was successfully created on retry")
+	// GH-5362: the branch must survive this close — deleting it here is the
+	// #275 false-success shape (if the revision issue's own run ever needs to
+	// continue from this PR's commits, a deleted branch silently rebuilds
+	// from main instead). handleReviewRequested now stamps a self-close
+	// marker and leaves the branch alone.
+	if branchDeleted.Load() {
+		t.Error("branch must NOT be deleted on a successful review-issue create (GH-5362) — it must survive so the revision issue can continue from these commits")
 	}
-	if prState.TerminalLabel != github.LabelSuperseded {
-		t.Errorf("TerminalLabel = %q, want %q after a successful review-issue create (GH-5247: healthy hand-off, not a failure)", prState.TerminalLabel, github.LabelSuperseded)
+	// GH-5362: TerminalLabel is no longer set eagerly at spawn time —
+	// verifyFixPRDeliversSourceScope (owner_death.go) now applies
+	// pilot-superseded to the source issue only once the revision PR merges
+	// with confirmed file overlap.
+	if prState.TerminalLabel != "" {
+		t.Errorf("TerminalLabel = %q, want empty (GH-5362: no longer set eagerly at spawn time)", prState.TerminalLabel)
+	}
+	if !c.consumeSelfClosedMarker(91) {
+		t.Error("expected a self-close marker to be stamped before the PR close (GH-5362) so the next external-close poll doesn't misread this as a human rejection")
 	}
 }
 
@@ -165,8 +177,8 @@ func TestHandleReviewRequested_CreateIssueErrors_EscalatesInsteadOfClosing(t *te
 // has since closed without shipping (a human closed it during a crash/
 // downtime window) must not be handed back out unverified — dedup must
 // re-check owner health (mirroring CreateFailureIssue's GH-4842 path) and
-// mint a replacement instead, so spawnReviewIssue never points TerminalLabel
-// at a corpse.
+// mint a replacement instead, so callers of spawnReviewIssue never get handed
+// back a corpse as the fix issue supposedly continuing this PR's work.
 func TestCreateReviewIssue_DedupHit_DeadOwner_MintsReplacement(t *testing.T) {
 	createCalls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/autopilot/gh5362_review_scope_test.go
+++ b/internal/autopilot/gh5362_review_scope_test.go
@@ -1,0 +1,339 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-5362: handleReviewRequested (the review-revision close path) had the
+// same "#275 false-success shape" bug GH-5348/GH-5351 fixed for the CI-fix
+// path. spawnReviewIssue used to mark the source issue pilot-superseded the
+// instant the revision issue was spawned — before that issue's own PR
+// existed, let alone merged — and handleReviewRequested closed the PR and
+// deleted the branch without ever stamping a self-close marker, so the very
+// next poll's checkExternalMergeOrClose read its own close as an external
+// (human) rejection.
+//
+// This file covers:
+//  1. handleReviewRequested's own close is never read as external, and the
+//     branch survives it (own-close + branch-preservation half of the fix,
+//     controller.go).
+//  2. verifyFixPRDeliversSourceScope's review-revision gate: pilot-superseded
+//     is applied to the source issue only once the revision PR merges with
+//     confirmed file overlap — never at spawn time (owner_death.go half of
+//     the fix, mirroring gh5348_scope_mismatch_test.go for the review path).
+
+type reviewScopeGHServer struct {
+	mu sync.Mutex
+
+	issues  map[int]*github.Issue    // GET /issues/{n}
+	prFiles map[int][]*github.PRFile // GET /pulls/{n}/files
+
+	addLabelCalls    []string // "issue:label"
+	removeLabelCalls []string // "issue:label"
+	comments         []string // "issue:body"
+}
+
+func newReviewScopeGHServer() *reviewScopeGHServer {
+	return &reviewScopeGHServer{
+		issues:  map[int]*github.Issue{},
+		prFiles: map[int][]*github.PRFile{},
+	}
+}
+
+func (s *reviewScopeGHServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/files"):
+			var num int
+			_, _ = fmt.Sscanf(r.URL.Path, "/repos/owner/repo/pulls/%d/files", &num)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(s.prFiles[num])
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/issues/") && !strings.HasSuffix(r.URL.Path, "/labels"):
+			var num int
+			if _, err := fmt.Sscanf(r.URL.Path, "/repos/owner/repo/issues/%d", &num); err == nil {
+				if issue, ok := s.issues[num]; ok {
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(issue)
+					return
+				}
+			}
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			var num int
+			_, _ = fmt.Sscanf(r.URL.Path, "/repos/owner/repo/issues/%d/labels", &num)
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for _, l := range body.Labels {
+				s.addLabelCalls = append(s.addLabelCalls, fmt.Sprintf("%d:%s", num, l))
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/labels/"):
+			parts := strings.Split(r.URL.Path, "/")
+			label := parts[len(parts)-1]
+			var num int
+			_, _ = fmt.Sscanf(r.URL.Path, "/repos/owner/repo/issues/%d/labels/", &num)
+			s.removeLabelCalls = append(s.removeLabelCalls, fmt.Sprintf("%d:%s", num, label))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			var num int
+			_, _ = fmt.Sscanf(r.URL.Path, "/repos/owner/repo/issues/%d/comments", &num)
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			s.comments = append(s.comments, fmt.Sprintf("%d:%s", num, body.Body))
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.Comment{ID: 1, Body: body.Body})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}
+}
+
+func (s *reviewScopeGHServer) hasAddLabel(issue int, label string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	want := fmt.Sprintf("%d:%s", issue, label)
+	for _, c := range s.addLabelCalls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestController_VerifyFixPRDeliversSourceScope_ReviewRevision mirrors
+// gh5348_scope_mismatch_test.go's table for a review-revision fix issue
+// (identified by "**Failure Type**: review_requested" in the body, written by
+// CreateReviewIssue) instead of a CI-fix issue. Unlike the CI path — where
+// pilot-superseded is already applied at spawn time and this function only
+// corrects a mismatch — spawnReviewIssue (GH-5362) never applies the label at
+// spawn time, so this function is the only place that ever does.
+func TestController_VerifyFixPRDeliversSourceScope_ReviewRevision(t *testing.T) {
+	reviewFixIssueBody := "Revision needed.\n\n<!-- autopilot-meta branch:pilot/GH-100 pr:7 iteration:1 source:100 -->\n\n## Context\n- **Failure Type**: review_requested\n"
+
+	tests := []struct {
+		name                string
+		sourceIssue         *github.Issue
+		fixPRFiles          []*github.PRFile
+		originPRFiles       []*github.PRFile
+		wantSuperseded      bool
+		wantEscalate        bool
+		wantLabelsUntouched bool
+	}{
+		{
+			name: "shared file — source marked superseded for the first time",
+			sourceIssue: &github.Issue{
+				Number: 100, State: github.StateOpen,
+			},
+			fixPRFiles:     []*github.PRFile{{Filename: "internal/foo/bar.go"}},
+			originPRFiles:  []*github.PRFile{{Filename: "internal/foo/bar.go"}, {Filename: "internal/foo/baz.go"}},
+			wantSuperseded: true,
+		},
+		{
+			name: "zero file overlap — source escalated to needs-human, never superseded",
+			sourceIssue: &github.Issue{
+				Number: 100, State: github.StateOpen,
+			},
+			fixPRFiles:    []*github.PRFile{{Filename: "internal/unrelated/thing.go"}},
+			originPRFiles: []*github.PRFile{{Filename: "internal/foo/bar.go"}},
+			wantEscalate:  true,
+		},
+		{
+			name: "zero overlap but source already closed — no reaction",
+			sourceIssue: &github.Issue{
+				Number: 100, State: github.StateClosed,
+			},
+			fixPRFiles:          []*github.PRFile{{Filename: "internal/unrelated/thing.go"}},
+			originPRFiles:       []*github.PRFile{{Filename: "internal/foo/bar.go"}},
+			wantLabelsUntouched: true,
+		},
+		{
+			name: "source already superseded (idempotent re-run) — no reaction",
+			sourceIssue: &github.Issue{
+				Number: 100, State: github.StateOpen,
+				Labels: []github.Label{{Name: github.LabelSuperseded}},
+			},
+			fixPRFiles:          []*github.PRFile{{Filename: "internal/unrelated/thing.go"}},
+			originPRFiles:       []*github.PRFile{{Filename: "internal/foo/bar.go"}},
+			wantLabelsUntouched: true,
+		},
+		{
+			name: "origin PR has no recorded files — skip rather than false-positive escalate",
+			sourceIssue: &github.Issue{
+				Number: 100, State: github.StateOpen,
+			},
+			fixPRFiles:          []*github.PRFile{{Filename: "internal/unrelated/thing.go"}},
+			originPRFiles:       nil,
+			wantLabelsUntouched: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newReviewScopeGHServer()
+			srv.issues[200] = &github.Issue{Number: 200, State: github.StateClosed, Body: reviewFixIssueBody, Labels: []github.Label{{Name: github.LabelDone}}}
+			srv.issues[100] = tt.sourceIssue
+			srv.prFiles[55] = tt.fixPRFiles   // fix (revision) PR number
+			srv.prFiles[7] = tt.originPRFiles // origin PR number, from "pr:7" in reviewFixIssueBody
+			ts := httptest.NewServer(srv.handler())
+			defer ts.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, ts.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+			sink := &fakeAlertSink{}
+			c.SetAlertsEngine(sink)
+
+			prState := &PRState{PRNumber: 55, IssueNumber: 200}
+			c.verifyFixPRDeliversSourceScope(context.Background(), prState)
+
+			if tt.wantSuperseded {
+				if !srv.hasAddLabel(100, github.LabelSuperseded) {
+					t.Errorf("expected %s to be added to source #100, calls=%v", github.LabelSuperseded, srv.addLabelCalls)
+				}
+				if srv.hasAddLabel(100, labelNeedsHuman) {
+					t.Errorf("did not expect %s on source #100, calls=%v", labelNeedsHuman, srv.addLabelCalls)
+				}
+			}
+			if tt.wantEscalate {
+				if !srv.hasAddLabel(100, labelNeedsHuman) {
+					t.Errorf("expected %s to be added to source #100, calls=%v", labelNeedsHuman, srv.addLabelCalls)
+				}
+				if srv.hasAddLabel(100, github.LabelSuperseded) {
+					t.Errorf("did not expect %s on source #100 — it must never have been applied in the first place, calls=%v", github.LabelSuperseded, srv.addLabelCalls)
+				}
+				if len(sink.events) != 1 {
+					t.Errorf("expected exactly 1 alert, got %d", len(sink.events))
+				}
+				foundComment := false
+				for _, c := range srv.comments {
+					if strings.HasPrefix(c, "100:") && strings.Contains(c, "Delivery mismatch") {
+						foundComment = true
+					}
+				}
+				if !foundComment {
+					t.Errorf("expected a delivery-mismatch comment on source #100, got %v", srv.comments)
+				}
+			}
+			if tt.wantLabelsUntouched {
+				if len(srv.addLabelCalls) != 0 {
+					t.Errorf("expected no label writes, got %v", srv.addLabelCalls)
+				}
+				if len(sink.events) != 0 {
+					t.Errorf("expected no alerts, got %d", len(sink.events))
+				}
+			}
+		})
+	}
+}
+
+// TestHandleReviewRequested_OwnCloseNotReadAsExternal covers the
+// controller.go half of GH-5362 end-to-end: handleReviewRequested's own PR
+// close (after successfully spawning a revision issue) must stamp a
+// self-close marker BEFORE closing the PR, and must leave the branch alone.
+// Without this, the very next poll's checkExternalMergeOrClose reads the
+// close as an external (human) rejection — re-arming the source issue
+// pilot-retry-ready (a double-arm, since the revision issue already
+// continues the work) and deleting the branch the revision issue's own run
+// might still need to continue from (the exact #275 shape).
+func TestHandleReviewRequested_OwnCloseNotReadAsExternal(t *testing.T) {
+	var branchDeleted bool
+	var issueLabelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/91/reviews":
+			resp := []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "alice"}, Body: "Fix this", State: "CHANGES_REQUESTED"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/91/comments":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 701}))
+		case r.URL.Path == "/repos/owner/repo/pulls/91" && r.Method == http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, github.PullRequest{Number: 91, State: "closed"}))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/git/refs/heads/") && r.Method == http.MethodDelete:
+			branchDeleted = true
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/repos/owner/repo/issues/40/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			issueLabelsAdded = append(issueLabelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    91,
+		IssueNumber: 40,
+		BranchName:  "pilot/GH-40",
+		Stage:       StageReviewRequested,
+	}
+	c.mu.Lock()
+	c.activePRs[91] = prState
+	c.mu.Unlock()
+
+	if err := c.handleReviewRequested(context.Background(), prState, nil); err != nil {
+		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
+	}
+
+	if prState.Stage != StageFailed {
+		t.Fatalf("Stage = %s, want %s", prState.Stage, StageFailed)
+	}
+	if prState.TerminalLabel != "" {
+		t.Fatalf("TerminalLabel = %q, want empty (GH-5362: no longer set eagerly at spawn time)", prState.TerminalLabel)
+	}
+
+	// The next poll tick's external-close check must NOT treat this as an
+	// external (human) close: the self-close marker stamped above must be
+	// consumed (one-shot), routing into removePRTracking(pr, false) instead
+	// of notifyExternalClose's re-arm + finalizeExternalClose's branch
+	// deletion. checkExternalMergeOrClose still reports true either way (the
+	// PR is resolved and processing should stop) — what distinguishes the
+	// self-close path is the side effects it must NOT trigger, checked below.
+	ghPR := &github.PullRequest{Number: 91, State: "closed", Merged: false}
+	if resolved := c.checkExternalMergeOrClose(context.Background(), prState, ghPR); !resolved {
+		t.Error("expected checkExternalMergeOrClose to report the PR as resolved")
+	}
+	if branchDeleted {
+		t.Error("branch must NOT be deleted — it must survive the own close so the revision issue can continue from these commits (GH-5362)")
+	}
+	for _, l := range issueLabelsAdded {
+		if l == github.LabelRetryReady {
+			t.Errorf("source issue must NOT be re-armed pilot-retry-ready on the own close — the revision issue (#701) already continues this work, labels added: %v", issueLabelsAdded)
+		}
+	}
+}

--- a/internal/autopilot/owner_death.go
+++ b/internal/autopilot/owner_death.go
@@ -135,8 +135,33 @@ func parseFixIssuePR(body string) (int, bool) {
 	return n, true
 }
 
-// verifyFixPRDeliversSourceScope guards GH-5348 subtask 3. spawnFailureIssue
-// (controller.go) marks a source issue pilot-superseded the moment its fix
+// fixIssueFailureTypeRe extracts the "**Failure Type**: <type>" line both
+// FeedbackLoop.generateBody (CreateFailureIssue) and CreateReviewIssue write
+// into the "## Context" section, near the top of the body, before any
+// attacker-controllable content (CI logs, review comments) — so the first
+// match is always the genuine one. CreateReviewIssue always writes
+// FailureReviewRequested; CreateFailureIssue writes one of the ci_*/
+// merge_conflict/deployment FailureType values.
+var fixIssueFailureTypeRe = regexp.MustCompile(`(?m)^-\s+\*\*Failure Type\*\*:\s+(\S+)\s*$`)
+
+// isReviewRevisionFixIssue reports whether a spawned fix issue's body
+// identifies it as a review-revision issue (CreateReviewIssue), as opposed
+// to a CI-fix continuation (CreateFailureIssue). GH-5362:
+// verifyFixPRDeliversSourceScope uses this to decide which of its two label
+// disciplines applies to a given source issue — spawnFailureIssue still
+// applies pilot-superseded eagerly at spawn time (unchanged, out of scope
+// for GH-5362), so the CI-fix path there still means "already labeled,
+// react only to a mismatch"; spawnReviewIssue no longer does, so the review
+// path means "never labeled yet, gate whether it ever is."
+func isReviewRevisionFixIssue(body string) bool {
+	m := fixIssueFailureTypeRe.FindStringSubmatch(body)
+	return len(m) >= 2 && m[1] == string(FailureReviewRequested)
+}
+
+// verifyFixPRDeliversSourceScope guards GH-5348 subtask 3 for the CI-fix
+// path, and — as of GH-5362 — gates whether pilot-superseded is ever applied
+// at all for the review-revision path. spawnFailureIssue (controller.go)
+// still marks a CI-fix source issue pilot-superseded the moment its fix
 // ISSUE is created — before that issue's own PR exists, let alone before its
 // diff is known. GH-5348 subtasks 1/2 fixed the one confirmed way that PR's
 // eventual diff could end up dropping the origin's real changes (a deleted
@@ -146,16 +171,32 @@ func parseFixIssuePR(body string) (int, bool) {
 // path. It runs once the fix PR actually merges, the one point its diff is
 // fully known, and compares its changed files against the origin PR it was
 // spawned to replace (source:N / pr:N, recorded in the fix issue body by
-// FeedbackLoop.generateBody/CreateReviewIssue). Zero file overlap means the
-// origin's real work was most likely never delivered: strip
-// pilot-superseded and escalate to pilot-needs-human instead of leaving the
-// source issue silently parked under a label that claims another PR already
-// delivered its scope.
+// FeedbackLoop.generateBody/CreateReviewIssue).
+//
+// GH-5362: spawnReviewIssue no longer applies pilot-superseded eagerly at
+// spawn time (the same pilot-console #275 false-success shape GH-5348/
+// GH-5351 fixed on the CI-fix path) — a review-revision's source issue
+// reaches here carrying no terminal label at all, and isReviewRevisionFixIssue
+// tells the two paths apart (CreateFailureIssue vs CreateReviewIssue leave a
+// different Failure Type marker in the fix issue body) so this function can
+// give each its own discipline without disturbing the other:
+//
+//   - CI-fix (isReviewRevisionFixIssue == false): unchanged GH-5348
+//     subtask-3 behavior — the label is already applied, so a source that
+//     isn't (still) carrying pilot-superseded has already been resolved some
+//     other way (re-armed, previously escalated) and is left alone; only a
+//     confirmed-superseded source with zero file overlap gets corrected
+//     (label stripped, escalated to pilot-needs-human).
+//   - Review-revision (isReviewRevisionFixIssue == true): GH-5362 gate — no
+//     label was ever applied, so this is the one place that decides whether
+//     one ever is. Confirmed overlap applies pilot-superseded for the first
+//     time; zero overlap escalates to pilot-needs-human without anything to
+//     strip.
 //
 // A no-op (fails open, logs a warning) whenever the merged PR isn't a
-// Pilot-spawned CI-fix continuation, or any GitHub read fails — this is a
-// detection backstop, not a gate that should ever block or delay a merge
-// that already landed.
+// Pilot-spawned CI-fix/revision continuation, or any GitHub read fails —
+// this is a detection backstop, not a gate that should ever block or delay
+// a merge that already landed.
 func (c *Controller) verifyFixPRDeliversSourceScope(ctx context.Context, prState *PRState) {
 	if prState.IssueNumber <= 0 {
 		return
@@ -168,7 +209,7 @@ func (c *Controller) verifyFixPRDeliversSourceScope(ctx context.Context, prState
 	}
 	sourceNum, ok := parseFixIssueSource(fixIssue.Body)
 	if !ok {
-		// Not a Pilot-spawned CI-fix issue — nothing to verify.
+		// Not a Pilot-spawned CI-fix/revision issue — nothing to verify.
 		return
 	}
 	originPR, ok := parseFixIssuePR(fixIssue.Body)
@@ -177,6 +218,7 @@ func (c *Controller) verifyFixPRDeliversSourceScope(ctx context.Context, prState
 			"issue", prState.IssueNumber, "source", sourceNum)
 		return
 	}
+	isReviewRevision := isReviewRevisionFixIssue(fixIssue.Body)
 
 	fixFiles, err := c.ghClient.ListPullRequestFiles(ctx, c.owner, c.repo, prState.PRNumber)
 	if err != nil {
@@ -190,10 +232,15 @@ func (c *Controller) verifyFixPRDeliversSourceScope(ctx context.Context, prState
 			"origin_pr", originPR, "error", err)
 		return
 	}
+	overlap := filesOverlap(fixFiles, originFiles)
 	// GH-4284-style caution: an origin PR with no recorded files (deleted
 	// commit history unreadable, or a genuinely empty diff) can't prove
-	// non-overlap either way — skip rather than escalate on a false positive.
-	if len(originFiles) == 0 || filesOverlap(fixFiles, originFiles) {
+	// overlap or non-overlap either way — skip rather than act on a false
+	// signal, whichever direction that action would take.
+	noEvidence := len(originFiles) == 0
+	if noEvidence {
+		c.log.Warn("verifyFixPRDeliversSourceScope: origin PR has no recorded files, skipping (fail-open)",
+			"source", sourceNum, "origin_pr", originPR)
 		return
 	}
 
@@ -203,31 +250,73 @@ func (c *Controller) verifyFixPRDeliversSourceScope(ctx context.Context, prState
 			"source", sourceNum, "error", err)
 		return
 	}
-	if source.State == github.StateClosed || !github.HasLabel(source, github.LabelSuperseded) {
-		// Already resolved some other way (closed, re-armed, previously
-		// escalated) — nothing left to correct.
+
+	if !isReviewRevision {
+		// Unchanged GH-5348 subtask-3 behavior for the CI-fix path.
+		if source.State == github.StateClosed || !github.HasLabel(source, github.LabelSuperseded) {
+			// Already resolved some other way (closed, re-armed, previously
+			// escalated) — nothing left to correct.
+			return
+		}
+		if overlap {
+			return
+		}
+		reasonMsg := fmt.Sprintf(
+			"its designated fix PR #%d merged but shares no changed files with the original PR #%d it was spawned to continue",
+			prState.PRNumber, originPR,
+		)
+		if err := c.labeler.AddLabels(ctx, c.owner, c.repo, sourceNum, []string{labelNeedsHuman}); err != nil {
+			c.log.Warn("verifyFixPRDeliversSourceScope: failed to add needs-human label", "issue", sourceNum, "error", err)
+		}
+		if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, sourceNum, github.LabelSuperseded); err != nil {
+			c.log.Debug("verifyFixPRDeliversSourceScope: failed to remove pilot-superseded label (may not exist)", "issue", sourceNum, "error", err)
+		}
+		comment := fmt.Sprintf(
+			"\U0001F6A8 **Delivery mismatch detected (GH-5348)**: %s — the original changes may have been silently dropped. Marked `%s` for manual review instead of staying parked under `%s`.",
+			reasonMsg, labelNeedsHuman, github.LabelSuperseded,
+		)
+		if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, sourceNum, comment); err != nil {
+			c.log.Warn("verifyFixPRDeliversSourceScope: failed to post comment", "issue", sourceNum, "error", err)
+		}
+		c.fireOwnerDeathAlert(sourceNum, reasonMsg, "escalated")
+		c.log.Warn("verifyFixPRDeliversSourceScope: fix PR shares no files with origin PR — escalated source issue",
+			"source", sourceNum, "fix_issue", prState.IssueNumber, "fix_pr", prState.PRNumber, "origin_pr", originPR)
+		return
+	}
+
+	// GH-5362 gate for the review-revision path: no label was ever applied
+	// at spawn time, so decide here, once, whether one ever is.
+	if source.State == github.StateClosed || github.HasLabel(source, github.LabelSuperseded) {
+		// Already resolved (closed) or already gated by an earlier run of
+		// this function (e.g. a daemon restart mid-gate) — idempotent,
+		// nothing more to do.
+		return
+	}
+	if overlap {
+		if err := c.labeler.AddLabels(ctx, c.owner, c.repo, sourceNum, []string{github.LabelSuperseded}); err != nil {
+			c.log.Warn("verifyFixPRDeliversSourceScope: failed to add superseded label", "issue", sourceNum, "error", err)
+		}
+		c.log.Info("verifyFixPRDeliversSourceScope: revision PR confirmed to deliver origin scope — source issue marked superseded",
+			"source", sourceNum, "fix_issue", prState.IssueNumber, "fix_pr", prState.PRNumber, "origin_pr", originPR)
 		return
 	}
 
 	reasonMsg := fmt.Sprintf(
-		"its designated fix PR #%d merged but shares no changed files with the original PR #%d it was spawned to continue",
+		"its designated revision PR #%d merged but shares no changed files with the original PR #%d it was spawned to continue",
 		prState.PRNumber, originPR,
 	)
 	if err := c.labeler.AddLabels(ctx, c.owner, c.repo, sourceNum, []string{labelNeedsHuman}); err != nil {
 		c.log.Warn("verifyFixPRDeliversSourceScope: failed to add needs-human label", "issue", sourceNum, "error", err)
 	}
-	if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, sourceNum, github.LabelSuperseded); err != nil {
-		c.log.Debug("verifyFixPRDeliversSourceScope: failed to remove pilot-superseded label (may not exist)", "issue", sourceNum, "error", err)
-	}
 	comment := fmt.Sprintf(
-		"\U0001F6A8 **Delivery mismatch detected (GH-5348)**: %s — the original changes may have been silently dropped. Marked `%s` for manual review instead of staying parked under `%s`.",
+		"\U0001F6A8 **Delivery mismatch detected (GH-5362)**: %s — the original changes may have been silently dropped. Leaving this issue open under `%s` instead of marking it `%s`.",
 		reasonMsg, labelNeedsHuman, github.LabelSuperseded,
 	)
 	if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, sourceNum, comment); err != nil {
 		c.log.Warn("verifyFixPRDeliversSourceScope: failed to post comment", "issue", sourceNum, "error", err)
 	}
 	c.fireOwnerDeathAlert(sourceNum, reasonMsg, "escalated")
-	c.log.Warn("verifyFixPRDeliversSourceScope: fix PR shares no files with origin PR — escalated source issue",
+	c.log.Warn("verifyFixPRDeliversSourceScope: revision PR shares no files with origin PR — escalated source issue",
 		"source", sourceNum, "fix_issue", prState.IssueNumber, "fix_pr", prState.PRNumber, "origin_pr", originPR)
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5362.

Closes #5362

## Changes

GitHub Issue GH-5362: fix(autopilot): handleReviewRequested still labels the source issue superseded eagerly and deletes the branch on its own close — same #275 false-success shape as the CI-fix path fixed in #5348/#5351

## Problem

#5348 and #5351 (PR #5349, PR #5356) fixed the CI-fix continuation: own-close marker persisted before the close, `superseded` applied to the source issue only after the fix PR merges with file overlap, no branch delete on own close. The review-revision path was left as-is:

- `internal/autopilot/controller.go` ~4103 `spawnReviewIssue` still sets `TerminalLabel = Superseded` eagerly when the revision issue is spawned.
- `internal/autopilot/controller.go` ~4325 `handleReviewRequested` closes the PR after spawning and deletes the branch at ~4330, and does not call `markSelfClosed`.

Failure scenario: a review-requested PR is closed by autopilot, the revision issue's run fails or its PR never merges, and the source issue already carries `superseded` while none of its code is on main; the deleted branch also removes the commits the continuation would have started from (the exact pilot-console #275 shape, now on the review path instead of the CI path).

## Fix

1. In `handleReviewRequested`, call `markSelfClosed` and persist state before the close, and keep the branch (`removePRTracking(pr, false)` semantics) so the revision continues from the same commits.
2. In `spawnReviewIssue`, stop setting `TerminalLabel = Superseded`; record the origin scope as `spawnFailureIssue` does (`RecordOriginScope`) so `verifyFixPRDeliversSourceScope` gates the label on merge + overlap for review revisions too.
3. Tests: mirror `gh5348_scope_mismatch_test.go` for the review path (own close not read as external; label only after merge with overlap; branch survives the close).

## Acceptance

- [ ] Review-revision own close is never reported as an external close.
- [ ] Source issue gets `superseded` only after the revision PR merges with file overlap.
- [ ] Branch survives the own close; existing review-cycle tests green.