### PR TITLE
GH-5376: fix(rearm): stalled re-arm sweep loops forever on a body-edit re-arm — only label/reopen events count as evidence and recordClaimLostDrop has no drop-count backstop (GH-5346: 76 drops, 33 h)

### DIFF
--- a/.agent/tasks/gh-5376.md
+++ b/.agent/tasks/gh-5376.md
@@ -1,0 +1,46 @@
+# GH-5376
+
+**Created:** 2026-09-08
+
+## Problem
+
+GitHub Issue GH-5376: fix(rearm): stalled re-arm sweep loops forever on a body-edit re-arm — only label/reopen events count as evidence and recordClaimLostDrop has no drop-count backstop (GH-5346: 76 drops, 33 h)
+
+## Problem
+
+Issue #5346 (`pilot-retry-1`) stalled at 2026-09-07 09:21Z (generation 1, "consecutive identical failures") and was re-armed by the operator with a body edit ("new branch from main"). It was never re-picked. 33 hours later the `repick_backoff` row read `claim_lost_drops=76`, `next_allowed_at` always 16 min ahead, and the log repeated every ~5.5 min:
+
+```
+component=dispatch task_id=GH-5346 msg="skip reason: repick-backoff cooldown, NOT a completed execution — ..."
+component=github-sdk-poller number=5346 msg="Skipping re-dispatch — completed execution exists"
+```
+
+Mechanics (`cmd/pilot/rearm_stalled.go` ~182-235, `cmd/pilot/repick_backoff.go` ~198-260):
+1. `sweepStalledRearm` picks up the issue (`pilot-retry-*` / `pilot-blocked`), calls `tryRearmStalled`, which requires a `labeled`/`reopened` GitHub event newer than the stalled row's `completed_at`. A body edit is not an event, so `latestRearmEvent` returns nil and `tryRearmStalled` returns false.
+2. Line ~232 then unconditionally calls `recordClaimLostDrop`, which re-arms the backoff window (`30s·2^min(drops-1,5)` → capped 16 min) and increments `claim_lost_drops`, which by design never counts toward the hard cap. Nothing bounds the loop.
+3. The SDK poller evaluates the same key and logs "completed execution exists", which is false (`HasTerminalCompletion` never counts `stalled`).
+
+The #5297 backstop (`terminalDropPilotStripThreshold=3`) lives only on the `shouldUnwindGithubInProgressLabel` path; the sweep never reaches it.
+
+Recovery used: label cycle `pilot-retry-1` → `pilot-retry-ready` (label event newer than the stall). Same class as the 08-26 "manual pilot-blocked strip bypasses the #5215 re-arm probe" memory.
+
+## Fix
+
+1. Evidence: in `tryRearmStalled`, also accept an issue `edited` event (body edit) or `issue.updated_at` newer than the stalled row's `completed_at` as re-arm evidence, in addition to label/reopen events. Log which evidence kind matched.
+2. Backstop: when the sweep fails to find evidence N times in a row for the same key (N=3, reuse the #5297 constant), stop calling `recordClaimLostDrop`; instead post the explanatory comment used by the base-presence hold (what evidence is required, how to re-arm) and apply `pilot-needs-human`, so the loop ends with an operator signal.
+3. Poller log: when the dispatch layer has already logged the repick-backoff reason, suppress or reword the SDK poller's "completed execution exists" line for that task (it is a known-misleading message; the fix belongs on the pilot side if the SDK message cannot be changed, e.g. by passing the real reason through `terminalCompletionChecker`).
+
+## Tests
+
+- Stalled row at T0, body edit at T1 > T0, no label event → sweep re-arms.
+- Stalled row, no evidence at all → after 3 sweeps: needs-human label + comment, no further `recordClaimLostDrop` calls.
+- Existing `TryRearm*` / `SweepStalledRearm*` tests green.
+
+## Acceptance
+
+- [ ] A body-edit re-arm is picked up within one sweep interval.
+- [ ] A stalled task with no evidence cannot accumulate more than 3 claim-lost drops from the sweep before escalating.
+- [ ] Log no longer claims a completed execution exists for a stalled task.
+
+## Acceptance Criteria
+

--- a/cmd/pilot/gh5376_stalled_rearm_test.go
+++ b/cmd/pilot/gh5376_stalled_rearm_test.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestTryRearmStalled_BodyEditAfterStall_Rearms is GH-5376's evidence-type
+// acceptance test: the GH-5346 incident re-armed pilot-retry-1 with a body
+// edit alone ("new branch from main") — no label event, no reopen. Before
+// this fix, latestRearmEvent only recognized labeled/reopened timeline
+// events, so tryRearmStalled kept reporting rearmed=false forever even
+// though the operator had performed exactly the deliberate gesture the
+// re-arm probe exists to detect.
+func TestTryRearmStalled_BodyEditAfterStall_Rearms(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+	editTime := stallTime.Add(30 * time.Minute)
+
+	srv := newRearmTestServer(t,
+		&github.Issue{
+			Number: 5139, State: "open",
+			Labels:    []github.Label{{Name: "pilot"}, {Name: github.LabelRetry1}},
+			UpdatedAt: editTime,
+		},
+		[]*github.IssueEvent{
+			// No labeled/reopened event after the stall — a body edit alone
+			// is not surfaced as a labeled/reopened timeline event.
+			{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+			{Event: "labeled", CreatedAt: stallTime.Add(-23 * time.Hour), Label: &github.Label{Name: github.LabelRetry1}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5139", "/project-gh5376-body-edit"
+	seedStalledRow(t, store, "exec-stalled-body-edit", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
+
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rearmed {
+		t.Fatal("expected rearmed=true — issue.UpdatedAt moved past the stall timestamp via a body edit")
+	}
+
+	exec, err := store.GetExecution("exec-stalled-body-edit")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected the stalled row to be reclassified to status=failed, got %q", exec.Status)
+	}
+}
+
+// TestTryRearmStalled_NoUpdateAtAll_NotRearmed proves the UpdatedAt fallback
+// doesn't over-trigger: an issue whose UpdatedAt predates the stall (nothing
+// touched it since) must not be treated as re-armed.
+func TestTryRearmStalled_NoUpdateAtAll_NotRearmed(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+
+	srv := newRearmTestServer(t,
+		&github.Issue{
+			Number: 5139, State: "open",
+			Labels:    []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}},
+			UpdatedAt: stallTime.Add(-2 * time.Hour),
+		},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5139", "/project-gh5376-no-update"
+	seedStalledRow(t, store, "exec-stalled-no-update", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
+
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rearmed {
+		t.Fatal("expected rearmed=false — issue.UpdatedAt predates the stall, no deliberate edit happened after it")
+	}
+}
+
+// forceRepickBackoffReady clears key's backoff window so the very next
+// gateStatus/allow check reports not-gated, regardless of how recently a
+// drop was recorded. Test-only: reaches into repickBackoffTracker's
+// unexported fields (same package) to simulate several sweep intervals
+// elapsing without an actual test sleep.
+func forceRepickBackoffReady(key string) {
+	repickBackoff.mu.Lock()
+	defer repickBackoff.mu.Unlock()
+	if e, ok := repickBackoff.entries[key]; ok {
+		e.nextAllowedAt = time.Time{}
+		e.gateLogged = false
+	}
+}
+
+// gh5376EscalationServer is a stateful mock GitHub server for
+// TestSweepStalledRearm_NoEvidenceThreeTimes_EscalatesAndStops: the served
+// issue's labels grow across calls (AddLabels mutates the same state
+// ListIssues/GetIssue read back), mirroring how a real repo would reflect
+// escalateStalledRearmNoEvidence's own pilot-needs-human application on the
+// very next sweep pass.
+type gh5376EscalationServer struct {
+	mu           sync.Mutex
+	labels       []string
+	listCalls    int
+	getCalls     int
+	commentCalls int
+	addLabelCall int
+}
+
+func newGH5376EscalationServer(t *testing.T, issueNum int, initialLabels []string, updatedAt time.Time, events []*github.IssueEvent) (*httptest.Server, *gh5376EscalationServer) {
+	t.Helper()
+	state := &gh5376EscalationServer{labels: append([]string{}, initialLabels...)}
+
+	issuePath := "/repos/owner/repo/issues/" + strconv.Itoa(issueNum)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		state.mu.Lock()
+		defer state.mu.Unlock()
+
+		labelObjs := make([]github.Label, len(state.labels))
+		for i, l := range state.labels {
+			labelObjs[i] = github.Label{Name: l}
+		}
+
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodGet:
+			state.listCalls++
+			if p := r.URL.Query().Get("page"); p != "1" && p != "" {
+				_ = json.NewEncoder(w).Encode([]*github.Issue{})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]*github.Issue{
+				{Number: issueNum, State: "open", Labels: labelObjs, UpdatedAt: updatedAt},
+			})
+		case r.URL.Path == issuePath && r.Method == http.MethodGet:
+			state.getCalls++
+			_ = json.NewEncoder(w).Encode(&github.Issue{
+				Number: issueNum, State: "open", Labels: labelObjs, UpdatedAt: updatedAt,
+			})
+		case r.URL.Path == issuePath+"/events" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(events)
+		case r.URL.Path == issuePath+"/comments" && r.Method == http.MethodPost:
+			state.commentCalls++
+			_ = json.NewEncoder(w).Encode(&github.Comment{ID: 1})
+		case r.URL.Path == issuePath+"/labels" && r.Method == http.MethodPost:
+			state.addLabelCall++
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			state.labels = append(state.labels, body.Labels...)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, state
+}
+
+// TestSweepStalledRearm_NoEvidenceThreeTimes_EscalatesAndStops is GH-5376's
+// backstop acceptance test: a stalled task_id with zero re-arm evidence
+// across repeated sweep passes must stop accumulating claim-lost drops after
+// terminalDropPilotStripThreshold (3) consecutive no-evidence findings,
+// escalate to pilot-needs-human with an explanatory comment instead, and
+// never repeat the escalation or resume probing on subsequent passes
+// (reproducing GH-5346's 76-drops-over-33h loop bounded to exactly 3).
+func TestSweepStalledRearm_NoEvidenceThreeTimes_EscalatesAndStops(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+
+	// UpdatedAt/events both predate the stall — no evidence of any kind,
+	// ever, across every sweep pass in this test.
+	srv, state := newGH5376EscalationServer(t, 5346,
+		[]string{"pilot", github.LabelBlocked},
+		stallTime.Add(-2*time.Hour),
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+		},
+	)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5346", "/project-gh5376-escalate"
+	seedStalledRow(t, store, "exec-gh5346-stalled", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
+
+	ctx := context.Background()
+
+	// Sweep passes 1 and 2: ordinary no-evidence drops, no escalation yet.
+	for i := 1; i <= 2; i++ {
+		checker.sweepStalledRearm(ctx, projectPath)
+		if _, _, claimLostDrops, _ := repickBackoff.gateDetail(key); claimLostDrops != i {
+			t.Errorf("after sweep pass %d: expected claim_lost_drops=%d, got %d", i, i, claimLostDrops)
+		}
+		state.mu.Lock()
+		comments, addLabels := state.commentCalls, state.addLabelCall
+		state.mu.Unlock()
+		if comments != 0 || addLabels != 0 {
+			t.Fatalf("after sweep pass %d: expected no escalation yet, got comments=%d addLabelCalls=%d", i, comments, addLabels)
+		}
+		forceRepickBackoffReady(key)
+	}
+
+	// Sweep pass 3: the third consecutive no-evidence finding must escalate
+	// instead of recording a third claim-lost drop.
+	checker.sweepStalledRearm(ctx, projectPath)
+	if _, _, claimLostDrops, _ := repickBackoff.gateDetail(key); claimLostDrops != 2 {
+		t.Errorf("expected claim_lost_drops to stay at 2 (no further recordClaimLostDrop call on the escalating pass), got %d", claimLostDrops)
+	}
+	state.mu.Lock()
+	comments, addLabels := state.commentCalls, state.addLabelCall
+	labels := append([]string{}, state.labels...)
+	state.mu.Unlock()
+	if comments != 1 {
+		t.Errorf("expected exactly 1 escalation comment posted, got %d", comments)
+	}
+	if addLabels != 1 {
+		t.Errorf("expected exactly 1 AddLabels call for pilot-needs-human, got %d", addLabels)
+	}
+	if !containsString(labels, labelPilotNeedsHumanSDK) {
+		t.Errorf("expected pilot-needs-human to have been applied, labels=%v", labels)
+	}
+
+	forceRepickBackoffReady(key)
+
+	// Sweep pass 4: the issue now carries pilot-needs-human (reflected by the
+	// stateful mock, exactly like a real repo would show on the next poll),
+	// so the sweep's candidate filter must exclude it entirely — no further
+	// GetIssue probe, no further drop, no repeat escalation.
+	getCallsBefore := state.getCalls
+	checker.sweepStalledRearm(ctx, projectPath)
+	state.mu.Lock()
+	getCallsAfter, commentsAfter, addLabelsAfter := state.getCalls, state.commentCalls, state.addLabelCall
+	state.mu.Unlock()
+	if getCallsAfter != getCallsBefore {
+		t.Errorf("expected no further GetIssue probe once pilot-needs-human is applied, got %d new calls", getCallsAfter-getCallsBefore)
+	}
+	if commentsAfter != 1 || addLabelsAfter != 1 {
+		t.Errorf("expected no repeat escalation, got comments=%d addLabelCalls=%d", commentsAfter, addLabelsAfter)
+	}
+	if _, _, claimLostDrops, _ := repickBackoff.gateDetail(key); claimLostDrops != 2 {
+		t.Errorf("expected claim_lost_drops to remain 2 after the filtered-out pass, got %d", claimLostDrops)
+	}
+
+	exec, err := store.GetExecution("exec-gh5346-stalled")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "stalled" {
+		t.Errorf("expected the row to remain status=stalled throughout (never re-armed), got %q", exec.Status)
+	}
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if strings.EqualFold(s, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -4358,6 +4358,22 @@ func (c terminalCompletionChecker) HasCompletedExecution(taskID, projectPath str
 				slog.Int("claim_lost_drops", claimLostDrops),
 			)
 		}
+		// GH-5376: name the actual underlying ledger status when it's a
+		// stalled row — the GH-5346 incident's confusing log pair
+		// ("repick-backoff cooldown, NOT a completed execution" immediately
+		// followed by the SDK's "completed execution exists") gave an
+		// operator no way to tell WHY the task was gated without a manual DB
+		// query. Best-effort/fail-open: a lookup error or no stalled row
+		// just omits the field, matching every other fail-open probe in this
+		// file.
+		if c.store != nil {
+			if exec, found, err := c.store.LatestStalledExecution(taskID, projectPath); err == nil && found {
+				attrs = append(attrs, slog.String("underlying_status", "stalled"))
+				if exec.CompletedAt != nil {
+					attrs = append(attrs, slog.Time("stalled_at", *exec.CompletedAt))
+				}
+			}
+		}
 		logging.WithComponent("dispatch").Info(
 			"skip reason: repick-backoff cooldown, NOT a completed execution — the SDK poller's next log line (\"completed execution exists\") is misleading for this task",
 			attrs...)

--- a/cmd/pilot/rearm_stalled.go
+++ b/cmd/pilot/rearm_stalled.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
@@ -115,17 +117,17 @@ func (c terminalCompletionChecker) tryRearmStalled(taskID, projectPath, backoffK
 	if err != nil {
 		return false, fmt.Errorf("listing issue #%d events: %w", issueNum, err)
 	}
-	rearmEvent := latestRearmEvent(events, *exec.CompletedAt, append([]string{c.triggerLabel}, retryReadyRearmLabels...)...)
-	if rearmEvent == nil {
-		// Open + labeled, but nothing in the timeline shows that state was
-		// reached AFTER the stall (neither a base-label relabel/reopen NOR a
-		// pilot-retry-ready/-1/-2 label add) — not a deliberate re-arm
-		// gesture.
+	kind, evidenceAt, ok := stalledRearmEvidence(issue, events, *exec.CompletedAt, append([]string{c.triggerLabel}, retryReadyRearmLabels...)...)
+	if !ok {
+		// Open + labeled, but nothing observed shows that state was reached
+		// AFTER the stall (no base-label relabel/reopen, no
+		// pilot-retry-ready/-1/-2 label add, no body/metadata edit) — not a
+		// deliberate re-arm gesture.
 		return false, nil
 	}
 
-	reason := fmt.Sprintf("GH-5212: re-armed by issue #%d %s event at %s (stalled at %s)",
-		issueNum, rearmEvent.Event, rearmEvent.CreatedAt.Format(time.RFC3339), exec.CompletedAt.Format(time.RFC3339))
+	reason := fmt.Sprintf("GH-5212: re-armed by issue #%d %s evidence at %s (stalled at %s)",
+		issueNum, kind, evidenceAt.Format(time.RFC3339), exec.CompletedAt.Format(time.RFC3339))
 	if err := c.store.ReclassifyStalledForRearm(taskID, projectPath, reason); err != nil {
 		return false, fmt.Errorf("reclassifying stalled row: %w", err)
 	}
@@ -146,9 +148,46 @@ func (c terminalCompletionChecker) tryRearmStalled(taskID, projectPath, backoffK
 	}
 
 	repickBackoff.recordSuccess(backoffKey)
-	logging.WithComponent("dispatch").Info("GH-5212: stalled task re-armed via GitHub reopen/relabel",
-		slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.String("event", rearmEvent.Event))
+	stalledRearmNoEvidenceStreaks.reset(backoffKey)
+	logging.WithComponent("dispatch").Info("GH-5212: stalled task re-armed via GitHub reopen/relabel/edit",
+		slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.String("evidence", kind))
 	return true, nil
+}
+
+// stalledRearmEvidence is GH-5376's broadened evidence check for
+// tryRearmStalled: on top of latestRearmEvent's labeled/reopened events, a
+// body edit also counts as a deliberate operator re-arm gesture — the
+// GH-5346 incident re-armed pilot-retry-1 by editing the issue body ("new
+// branch from main") alone, which latestRearmEvent can never see (neither a
+// label nor a reopen), so tryRearmStalled kept reporting rearmed=false
+// forever and the sweep never stopped calling recordClaimLostDrop.
+//
+// Two signals are checked, in order:
+//  1. An "edited" timeline event (as returned by ListIssueEvents) newer than
+//     since — present if/when GitHub's classic Events API ever surfaces body
+//     edits for a given repo.
+//  2. issue.UpdatedAt newer than since — the reliable fallback, since GH's
+//     classic /issues/{n}/events endpoint (unlike the newer Timeline API)
+//     does not emit an "edited" event for a body-only edit in practice, but
+//     GetIssue's own UpdatedAt field always moves forward on any edit
+//     (body, title, or otherwise). issue is the same GetIssue response
+//     tryRearmStalled already fetched for the open/labeled check, so this
+//     costs no extra API call.
+//
+// Returns the evidence kind (for logging) and its timestamp alongside ok.
+func stalledRearmEvidence(issue *github.Issue, events []*github.IssueEvent, since time.Time, labels ...string) (kind string, at time.Time, ok bool) {
+	if ev := latestRearmEvent(events, since, labels...); ev != nil {
+		return ev.Event, ev.CreatedAt, true
+	}
+	for _, ev := range events {
+		if ev != nil && ev.Event == "edited" && ev.CreatedAt.After(since) {
+			return "edited", ev.CreatedAt, true
+		}
+	}
+	if issue != nil && issue.UpdatedAt.After(since) {
+		return "body/metadata edit (updated_at)", issue.UpdatedAt, true
+	}
+	return "", time.Time{}, false
 }
 
 // sweepStalledRearm scans repoOwner/repoName for open issues currently
@@ -199,6 +238,14 @@ func (c terminalCompletionChecker) sweepStalledRearm(ctx context.Context, projec
 			// this sweep needs to spend a probe on.
 			continue
 		}
+		if github.HasLabel(issue, labelPilotNeedsHumanSDK) {
+			// GH-5376: already escalated by escalateStalledRearmNoEvidence
+			// below — an operator must clear pilot-needs-human (and satisfy
+			// tryRearmStalled's evidence check) before this sweep resumes
+			// probing. Without this, the sweep would keep re-probing (and
+			// re-posting the escalation comment) on every pass forever.
+			continue
+		}
 
 		taskID := fmt.Sprintf("GH-%d", issue.Number)
 		backoffKey := repickBackoffKey(projectPath, taskID)
@@ -228,10 +275,98 @@ func (c terminalCompletionChecker) sweepStalledRearm(ctx context.Context, projec
 			repickBackoff.recordClaimLostDrop(backoffKey)
 			continue
 		}
-		if !rearmed {
-			repickBackoff.recordClaimLostDrop(backoffKey)
+		if rearmed {
+			continue
 		}
+
+		// GH-5376: recordClaimLostDrop alone has no backstop — nothing ever
+		// stopped this branch from firing again next sweep pass, forever
+		// (GH-5346: 76 drops over 33h with claim_lost_drops explicitly
+		// excluded from dispatcherRepickHardCap's gating counter by design).
+		// Once the SAME key has found no evidence
+		// terminalDropPilotStripThreshold (GH-5297's constant, reused here)
+		// times in a row, stop growing the backoff via recordClaimLostDrop
+		// and escalate to an operator instead.
+		streak := stalledRearmNoEvidenceStreaks.increment(backoffKey)
+		if streak >= terminalDropPilotStripThreshold {
+			c.escalateStalledRearmNoEvidence(ctx, taskID, issue.Number, streak)
+			stalledRearmNoEvidenceStreaks.reset(backoffKey)
+			continue
+		}
+		repickBackoff.recordClaimLostDrop(backoffKey)
 	}
+}
+
+// stalledRearmNoEvidenceStreaks counts, per repickBackoffKey, how many
+// consecutive sweepStalledRearm passes found no re-arm evidence for that key
+// (GH-5376). Reset on any successful re-arm (tryRearmStalled returning true)
+// or once escalateStalledRearmNoEvidence fires — the pilot-needs-human label
+// applied there is what actually stops the sweep from revisiting the issue
+// (see the candidate-filter check above), so resetting the streak here just
+// keeps this counter from drifting stale if the label is ever cleared
+// without a genuine re-arm.
+//
+// A package-level var (mirroring repickBackoff) since terminalCompletionChecker
+// is constructed fresh per call by runStalledRearmSweepLoop's closure — the
+// streak has to outlive any single sweepStalledRearm call to count "in a
+// row" across sweep passes.
+type stalledRearmNoEvidenceTracker struct {
+	mu      sync.Mutex
+	streaks map[string]int
+}
+
+func newStalledRearmNoEvidenceTracker() *stalledRearmNoEvidenceTracker {
+	return &stalledRearmNoEvidenceTracker{streaks: make(map[string]int)}
+}
+
+// increment bumps key's streak and returns the new count.
+func (t *stalledRearmNoEvidenceTracker) increment(key string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.streaks[key]++
+	return t.streaks[key]
+}
+
+// reset clears key's streak, e.g. after a successful re-arm or an escalation.
+func (t *stalledRearmNoEvidenceTracker) reset(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.streaks, key)
+}
+
+var stalledRearmNoEvidenceStreaks = newStalledRearmNoEvidenceTracker()
+
+// escalateStalledRearmNoEvidence posts the explanatory comment and applies
+// pilot-needs-human once sweepStalledRearm has failed to find re-arm
+// evidence terminalDropPilotStripThreshold times in a row for the same
+// task_id (GH-5376) — the operator-signal backstop the GH-5346 incident
+// (76 claim-lost drops, 33h, no signal) never had. Mirrors GH-5300's
+// stripPilotLabelAndCommentSDK shape but applies pilot-needs-human instead
+// of stripping the trigger label: the sweep's own candidate filter (in
+// sweepStalledRearm above) already excludes pilot-needs-human issues, so
+// applying it here is what makes this a one-shot escalation rather than a
+// per-sweep-pass repeat, without touching pilot-blocked/pilot-retry-ready
+// (which the documented re-arm recipe still expects to manipulate).
+func (c terminalCompletionChecker) escalateStalledRearmNoEvidence(ctx context.Context, taskID string, issueNum int, streak int) {
+	comment := fmt.Sprintf(
+		"⚠️ **Pilot could not confirm this stalled task was re-armed**\n\n"+
+			"This issue was checked %d times with no evidence of a deliberate re-arm gesture since it stalled. "+
+			"Re-arm evidence is any of: re-adding the `%s` label, adding one of `%s`, reopening the issue, "+
+			"or editing the issue body/title — all timestamped after the stall.\n\n"+
+			"Applying `%s` so this stops being silently re-checked. Remove it and repeat one of the above to re-arm.",
+		streak, c.triggerLabel, strings.Join(retryReadyRearmLabels, "`, `"), labelPilotNeedsHumanSDK,
+	)
+	if _, err := c.ghClient.AddComment(ctx, c.repoOwner, c.repoName, issueNum, comment); err != nil {
+		logging.WithComponent("dispatch").Warn("GH-5376: failed to post stalled-no-evidence escalation comment",
+			slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.Any("error", err))
+	}
+	if err := c.ghClient.AddLabels(ctx, c.repoOwner, c.repoName, issueNum, []string{labelPilotNeedsHumanSDK}); err != nil {
+		logging.WithComponent("dispatch").Warn("GH-5376: failed to apply pilot-needs-human after repeated no-evidence sweeps",
+			slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.Any("error", err))
+		return
+	}
+	logging.WithComponent("dispatch").Warn("GH-5376: stalled re-arm sweep escalated to pilot-needs-human after repeated no-evidence checks",
+		slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.Int("streak", streak))
 }
 
 // runStalledRearmSweepLoop drives sweepStalledRearm on the same cadence as


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5376.

Closes #5376

## Changes

GitHub Issue GH-5376: fix(rearm): stalled re-arm sweep loops forever on a body-edit re-arm — only label/reopen events count as evidence and recordClaimLostDrop has no drop-count backstop (GH-5346: 76 drops, 33 h)

## Problem

Issue #5346 (`pilot-retry-1`) stalled at 2026-09-07 09:21Z (generation 1, "consecutive identical failures") and was re-armed by the operator with a body edit ("new branch from main"). It was never re-picked. 33 hours later the `repick_backoff` row read `claim_lost_drops=76`, `next_allowed_at` always 16 min ahead, and the log repeated every ~5.5 min:

```
component=dispatch task_id=GH-5346 msg="skip reason: repick-backoff cooldown, NOT a completed execution — ..."
component=github-sdk-poller number=5346 msg="Skipping re-dispatch — completed execution exists"
```

Mechanics (`cmd/pilot/rearm_stalled.go` ~182-235, `cmd/pilot/repick_backoff.go` ~198-260):
1. `sweepStalledRearm` picks up the issue (`pilot-retry-*` / `pilot-blocked`), calls `tryRearmStalled`, which requires a `labeled`/`reopened` GitHub event newer than the stalled row's `completed_at`. A body edit is not an event, so `latestRearmEvent` returns nil and `tryRearmStalled` returns false.
2. Line ~232 then unconditionally calls `recordClaimLostDrop`, which re-arms the backoff window (`30s·2^min(drops-1,5)` → capped 16 min) and increments `claim_lost_drops`, which by design never counts toward the hard cap. Nothing bounds the loop.
3. The SDK poller evaluates the same key and logs "completed execution exists", which is false (`HasTerminalCompletion` never counts `stalled`).

The #5297 backstop (`terminalDropPilotStripThreshold=3`) lives only on the `shouldUnwindGithubInProgressLabel` path; the sweep never reaches it.

Recovery used: label cycle `pilot-retry-1` → `pilot-retry-ready` (label event newer than the stall). Same class as the 08-26 "manual pilot-blocked strip bypasses the #5215 re-arm probe" memory.

## Fix

1. Evidence: in `tryRearmStalled`, also accept an issue `edited` event (body edit) or `issue.updated_at` newer than the stalled row's `completed_at` as re-arm evidence, in addition to label/reopen events. Log which evidence kind matched.
2. Backstop: when the sweep fails to find evidence N times in a row for the same key (N=3, reuse the #5297 constant), stop calling `recordClaimLostDrop`; instead post the explanatory comment used by the base-presence hold (what evidence is required, how to re-arm) and apply `pilot-needs-human`, so the loop ends with an operator signal.
3. Poller log: when the dispatch layer has already logged the repick-backoff reason, suppress or reword the SDK poller's "completed execution exists" line for that task (it is a known-misleading message; the fix belongs on the pilot side if the SDK message cannot be changed, e.g. by passing the real reason through `terminalCompletionChecker`).

## Tests

- Stalled row at T0, body edit at T1 > T0, no label event → sweep re-arms.
- Stalled row, no evidence at all → after 3 sweeps: needs-human label + comment, no further `recordClaimLostDrop` calls.
- Existing `TryRearm*` / `SweepStalledRearm*` tests green.

## Acceptance

- [ ] A body-edit re-arm is picked up within one sweep interval.
- [ ] A stalled task with no evidence cannot accumulate more than 3 claim-lost drops from the sweep before escalating.
- [ ] Log no longer claims a completed execution exists for a stalled task.