### PR TITLE
GH-5377: fix(autopilot): persist PR state between markSelfClosed and ClosePullRequest in handleReviewRequested (same restart window #5361 closed on the CI-fix path)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -4379,6 +4379,16 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 	// and its commits survive.
 	c.markSelfClosed(prState, issueNum)
 
+	// GH-5377: persist the marker immediately rather than relying solely on
+	// ProcessPR's tail persistPRState call, mirroring the same fix
+	// handleCIFailed already applies (GH-5361, ~L3869). A daemon death
+	// between the markSelfClosed above and that tail persist would
+	// otherwise lose the in-memory-only marker entirely — the next
+	// restart's checkExternalMergeOrClose would then read the close GitHub
+	// already performed as external and run the destructive
+	// relabel/branch-delete path this marker exists to prevent.
+	c.persistPRState(prState)
+
 	// Close the PR. The branch is deliberately left alone (see above) — it
 	// is no longer deleted here, and checkExternalMergeOrClose's self-close
 	// path never deletes it either.

--- a/internal/autopilot/gh4841_test.go
+++ b/internal/autopilot/gh4841_test.go
@@ -43,10 +43,14 @@ import (
 // notifyExternalClose (so the HasSpawnedFixForPR fallback it used to
 // exercise no longer fires for this rung — it remains load-bearing only for
 // paths that still lose the marker, e.g. a crash before this earlier persist
-// point). The review-feedback rung (handleReviewRequested/spawnReviewIssue)
-// is untouched by GH-5351/GH-5361 and still designates TerminalLabel
-// eagerly with no equivalent immediate persist, so its crash-window test
-// below is unchanged.
+// point).
+//
+// GH-5377: handleReviewRequested now gets the same immediate-persist
+// treatment — it previously relied solely on ProcessPR's tail persistPRState
+// call, leaving the same crash window open that GH-5361 closed for the
+// CI-failure rung. TestGH4841_ReviewRequestedCrashWindow_RetryNotArmedAfterRestart
+// below now asserts the marker survives the simulated crash, mirroring the
+// CI-failure test above it.
 
 // TestGH4841_CIFailureCrashWindow_RetryNotArmedAfterRestart covers the
 // pre-merge CI-failure rung (handleCIFailed / spawnFailureIssue).
@@ -214,6 +218,13 @@ internal/autopilot/controller.go:1:1: some lint error (errcheck)
 // TestGH4841_ReviewRequestedCrashWindow_RetryNotArmedAfterRestart is the
 // review-feedback analog: handleReviewRequested must share the same
 // crash-survival property as the CI-failure rung above.
+//
+// GH-5377: handleReviewRequested now calls persistPRState immediately after
+// markSelfClosed (before the close itself), mirroring GH-5361's fix to the
+// CI-failure rung — closing the same crash window here. The assertions below
+// now expect the self-close marker to survive the simulated crash, exercising
+// the closed window rather than the notifyExternalClose fallback that used to
+// compensate for it.
 func TestGH4841_ReviewRequestedCrashWindow_RetryNotArmedAfterRestart(t *testing.T) {
 	const (
 		prNumber    = 9101
@@ -302,11 +313,18 @@ func TestGH4841_ReviewRequestedCrashWindow_RetryNotArmedAfterRestart(t *testing.
 	if seedPR.TerminalLabel != "" {
 		t.Fatalf("prState.TerminalLabel = %q, want empty (GH-5362: no longer set eagerly at spawn time)", seedPR.TerminalLabel)
 	}
-	// Simulated crash: no persistPRState call, and — since the self-close
-	// marker stamped by handleReviewRequested (GH-5362) lives only in
-	// controllerA's in-memory selfClosedPRs map — no way for controllerB
-	// (below) to see it either. Both are lost the same way a real process
-	// restart would lose them.
+	// GH-5377: the self-close marker is now durably persisted inside
+	// handleReviewRequested immediately after markSelfClosed, before the
+	// close. Assert that here, same as the CI-failure rung above.
+	if seedPR.SelfClosedFixIssue != fixIssueNum {
+		t.Fatalf("prState.SelfClosedFixIssue = %d, want %d before the simulated crash", seedPR.SelfClosedFixIssue, fixIssueNum)
+	}
+	// Deliberately do NOT call controllerA.persistPRState(seedPR) here — this
+	// is the crash. GH-5377: handleReviewRequested itself now calls
+	// persistPRState immediately after markSelfClosed (before the close), so
+	// this window no longer loses the marker — the assertions below now
+	// expect the marker to survive, exercising the closed window rather than
+	// the fallback that used to compensate for it.
 
 	controllerB := NewController(cfg, ghClient, nil, "owner", "repo")
 	controllerB.SetStateStore(store)
@@ -320,14 +338,20 @@ func TestGH4841_ReviewRequestedCrashWindow_RetryNotArmedAfterRestart(t *testing.
 	if !ok {
 		t.Fatalf("PR %d not present in controller B's activePRs after RestoreState", prNumber)
 	}
-	if restoredPR.TerminalLabel != "" {
-		t.Fatalf("restored TerminalLabel = %q, want empty — the in-memory designation must NOT have survived the simulated crash", restoredPR.TerminalLabel)
+	if restoredPR.SelfClosedFixIssue != fixIssueNum {
+		t.Fatalf("restored SelfClosedFixIssue = %d, want %d — GH-5377's immediate persist in handleReviewRequested should have survived the simulated crash", restoredPR.SelfClosedFixIssue, fixIssueNum)
 	}
 
+	// GH-5377: since the self-close marker survived, this close is correctly
+	// consumed as autopilot's own doing — checkExternalMergeOrClose
+	// short-circuits before ever reaching notifyExternalClose, so neither the
+	// old pilot-retry-ready misfire nor the GH-4841 HasSpawnedFixForPR
+	// fallback's pilot-failed label are applied; no label mutation happens on
+	// the source issue at all.
 	ghPR := &github.PullRequest{Number: prNumber, State: "closed", Merged: false}
 	externallyResolved := controllerB.checkExternalMergeOrClose(context.Background(), restoredPR, ghPR)
 	if !externallyResolved {
-		t.Fatal("expected checkExternalMergeOrClose to report the PR as externally resolved (closed)")
+		t.Fatal("expected checkExternalMergeOrClose to report the PR as resolved (self-close consumed)")
 	}
 
 	foundFailed := false
@@ -340,10 +364,10 @@ func TestGH4841_ReviewRequestedCrashWindow_RetryNotArmedAfterRestart(t *testing.
 			foundRetryReady = true
 		}
 	}
-	if !foundFailed {
-		t.Errorf("expected source issue to be labeled %q via the durable spawned-fix fallback, got labels added: %v", github.LabelFailed, issueLabelsAdded)
+	if foundFailed {
+		t.Errorf("source issue must NOT be labeled %q — the self-close marker survived (GH-5377), so this never reaches the notifyExternalClose fallback — labels added: %v", github.LabelFailed, issueLabelsAdded)
 	}
 	if foundRetryReady {
-		t.Errorf("source issue must NOT be labeled %q after a restart lost TerminalLabel while a revision issue is durably designated — labels added: %v", github.LabelRetryReady, issueLabelsAdded)
+		t.Errorf("source issue must NOT be labeled %q — the self-close marker survived (GH-5377) — labels added: %v", github.LabelRetryReady, issueLabelsAdded)
 	}
 }

--- a/internal/autopilot/gh5377_review_persist_test.go
+++ b/internal/autopilot/gh5377_review_persist_test.go
@@ -1,0 +1,111 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestHandleReviewRequested_SelfCloseMarker_PersistedBeforeTailPersist is the
+// GH-5377 regression: PR #5356 (issues #5351/#5361/#5374) persisted the
+// self-close marker immediately after markSelfClosed on the CI-fix path
+// (handleCIFailed, ~L3869) so a daemon death in that window can't lose it.
+// The review-revision path added by GH-5362 and adapted in #5356
+// (handleReviewRequested) called markSelfClosed and then ClosePullRequest
+// with no persist in between, relying entirely on ProcessPR's tail
+// persistPRState call. A daemon death between those two calls lost the
+// marker: on restart, checkExternalMergeOrClose would read the own close as
+// external and run the destructive relabel/branch-delete path the marker
+// exists to prevent (the exact pilot-console #275 incident shape).
+//
+// This test calls handleReviewRequested directly and deliberately never
+// invokes any tail persistPRState — simulating the daemon dying the instant
+// handleReviewRequested returns — then reads the marker back from a real,
+// file-backed state store to prove handleReviewRequested itself persists it
+// rather than depending on the caller. Mirrors
+// TestHandleCIFailed_SelfCloseMarker_PersistedBeforeTailPersist
+// (gh5361_selfclose_persist_test.go) for the review path.
+func TestHandleReviewRequested_SelfCloseMarker_PersistedBeforeTailPersist(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/91/reviews":
+			resp := []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "alice"}, Body: "Fix this", State: "CHANGES_REQUESTED"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/91/comments":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 701}))
+		case r.URL.Path == "/repos/owner/repo/pulls/91" && r.Method == http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, github.PullRequest{Number: 91, State: "closed"}))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	tmpDir, err := os.MkdirTemp("", "gh5377-review-persist-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	memStore, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = memStore.Close() }()
+
+	stateStore, err := NewStateStore(memStore.DB())
+	if err != nil {
+		t.Fatalf("NewStateStore: %v", err)
+	}
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+
+	prState := &PRState{
+		PRNumber:    91,
+		IssueNumber: 40,
+		BranchName:  "pilot/GH-40",
+		Stage:       StageReviewRequested,
+	}
+	c.mu.Lock()
+	c.activePRs[91] = prState
+	c.mu.Unlock()
+
+	// Deliberately no tail persistPRState call here — simulates the daemon
+	// dying the moment handleReviewRequested returns.
+	if err := c.handleReviewRequested(context.Background(), prState, nil); err != nil {
+		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
+	}
+
+	if prState.SelfClosedFixIssue != 701 {
+		t.Fatalf("prState.SelfClosedFixIssue = %d, want 701", prState.SelfClosedFixIssue)
+	}
+
+	row, err := stateStore.GetPRState("owner/repo", 91)
+	if err != nil {
+		t.Fatalf("GetPRState: %v", err)
+	}
+	if row == nil {
+		t.Fatal("state store has no row for PR 91 after handleReviewRequested — self-close marker was never persisted, only held in memory")
+	}
+	if row.SelfClosedFixIssue != 701 {
+		t.Fatalf("persisted row SelfClosedFixIssue = %d, want 701 — marker did not survive a simulated daemon death before the tail persist", row.SelfClosedFixIssue)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5377.

Closes #5377

## Changes

GitHub Issue GH-5377: fix(autopilot): persist PR state between markSelfClosed and ClosePullRequest in handleReviewRequested (same restart window #5361 closed on the CI-fix path)

## Problem

After PR #5356 (issues #5351/#5361/#5374) the CI-fix path in `internal/autopilot/controller.go` persists PR state right after `markSelfClosed` and before the own close (~3869), so a daemon death in that window cannot lose the own-close marker. The review-revision path added by #5362 and adapted in #5356 (`handleReviewRequested`, ~4380-4385) calls `markSelfClosed(prState, issueNum)` and then `ClosePullRequest` with no persist in between; it relies on the `ProcessPR` tail persist. A restart between those two calls loses the marker and the fallback reads the own close as external (`pilot-failed` + branch delete).

## Fix

1. Add the same `c.persistPRState(prState)` call (or the helper used at ~3869) immediately after `markSelfClosed` in `handleReviewRequested`, before `ClosePullRequest`.
2. Mirror the existing `TestHandleCIFailed_SelfCloseMarker_PersistedBeforeTailPersist` for the review path.

## Acceptance

- [ ] Review-path own close has the marker on disk before the close call returns; new test passes.
- [ ] Existing `gh5362_review_scope_test.go` and `gh5348_scope_mismatch_test.go` green.