### PR TITLE
GH-5375: fix(autopilot): review-path superseded gate adds pilot-superseded but never strips pilot / pilot-in-progress from the source issue (GH-5298 invariant)

### DIFF
--- a/internal/autopilot/gh5348_scope_mismatch_test.go
+++ b/internal/autopilot/gh5348_scope_mismatch_test.go
@@ -114,6 +114,18 @@ func (s *scopeMismatchGHServer) hasAddLabel(issue int, label string) bool {
 	return false
 }
 
+func (s *scopeMismatchGHServer) hasRemoveLabel(issue int, label string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	want := fmt.Sprintf("%d:%s", issue, label)
+	for _, c := range s.removeLabelCalls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestController_VerifyFixPRDeliversSourceScope(t *testing.T) {
 	fixIssueBody := "Fixes CI failure.\n\n<!-- autopilot-meta branch:pilot/GH-100 pr:7 iteration:1 source:100 -->"
 
@@ -225,6 +237,14 @@ func TestController_VerifyFixPRDeliversSourceScope(t *testing.T) {
 				if !srv.hasAddLabel(100, github.LabelSuperseded) {
 					t.Errorf("expected %s to be added to source #100, calls=%v", github.LabelSuperseded, srv.addLabelCalls)
 				}
+				// GH-5375: pilot-superseded and pilot/pilot-in-progress must
+				// never coexist on the source issue (GH-5298 invariant).
+				if !srv.hasRemoveLabel(100, github.LabelPilot) {
+					t.Errorf("expected %s to be removed from source #100, calls=%v", github.LabelPilot, srv.removeLabelCalls)
+				}
+				if !srv.hasRemoveLabel(100, github.LabelInProgress) {
+					t.Errorf("expected %s to be removed from source #100, calls=%v", github.LabelInProgress, srv.removeLabelCalls)
+				}
 				if len(sink.events) != 0 {
 					t.Errorf("expected no alerts on a confirmed-delivery supersede, got %d", len(sink.events))
 				}
@@ -236,6 +256,15 @@ func TestController_VerifyFixPRDeliversSourceScope(t *testing.T) {
 			case tt.wantMismatchNoSupersede:
 				if srv.hasAddLabel(100, github.LabelSuperseded) {
 					t.Errorf("expected %s NOT to be added to source #100 on zero overlap, calls=%v", github.LabelSuperseded, srv.addLabelCalls)
+				}
+				// GH-5375: the zero-overlap branch must stay unchanged — no
+				// pilot/pilot-in-progress removal, since the source issue
+				// isn't being superseded.
+				if srv.hasRemoveLabel(100, github.LabelPilot) {
+					t.Errorf("did not expect %s to be removed from source #100 on zero overlap, calls=%v", github.LabelPilot, srv.removeLabelCalls)
+				}
+				if srv.hasRemoveLabel(100, github.LabelInProgress) {
+					t.Errorf("did not expect %s to be removed from source #100 on zero overlap, calls=%v", github.LabelInProgress, srv.removeLabelCalls)
 				}
 				if len(sink.events) != 1 {
 					t.Errorf("expected exactly 1 alert, got %d", len(sink.events))

--- a/internal/autopilot/gh5362_review_scope_test.go
+++ b/internal/autopilot/gh5362_review_scope_test.go
@@ -120,6 +120,18 @@ func (s *reviewScopeGHServer) hasAddLabel(issue int, label string) bool {
 	return false
 }
 
+func (s *reviewScopeGHServer) hasRemoveLabel(issue int, label string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	want := fmt.Sprintf("%d:%s", issue, label)
+	for _, c := range s.removeLabelCalls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
 // TestController_VerifyFixPRDeliversSourceScope_ReviewRevision mirrors
 // gh5348_scope_mismatch_test.go's table for a review-revision fix issue
 // (identified by "**Failure Type**: review_requested" in the body, written by
@@ -213,6 +225,16 @@ func TestController_VerifyFixPRDeliversSourceScope_ReviewRevision(t *testing.T) 
 				if srv.hasAddLabel(100, labelNeedsHuman) {
 					t.Errorf("did not expect %s on source #100, calls=%v", labelNeedsHuman, srv.addLabelCalls)
 				}
+				// GH-5375: pilot-superseded and pilot/pilot-in-progress must
+				// never coexist on the source issue (GH-5298 invariant) — the
+				// review-revision kind used to only add pilot-superseded and
+				// leave the active labels standing on an OPEN issue.
+				if !srv.hasRemoveLabel(100, github.LabelPilot) {
+					t.Errorf("expected %s to be removed from source #100, calls=%v", github.LabelPilot, srv.removeLabelCalls)
+				}
+				if !srv.hasRemoveLabel(100, github.LabelInProgress) {
+					t.Errorf("expected %s to be removed from source #100, calls=%v", github.LabelInProgress, srv.removeLabelCalls)
+				}
 			}
 			if tt.wantEscalate {
 				if !srv.hasAddLabel(100, labelNeedsHuman) {
@@ -220,6 +242,15 @@ func TestController_VerifyFixPRDeliversSourceScope_ReviewRevision(t *testing.T) 
 				}
 				if srv.hasAddLabel(100, github.LabelSuperseded) {
 					t.Errorf("did not expect %s on source #100 — it must never have been applied in the first place, calls=%v", github.LabelSuperseded, srv.addLabelCalls)
+				}
+				// GH-5375: the zero-overlap/escalate branch must stay
+				// unchanged — no pilot/pilot-in-progress removal, since the
+				// source issue isn't being superseded.
+				if srv.hasRemoveLabel(100, github.LabelPilot) {
+					t.Errorf("did not expect %s to be removed from source #100 on escalate, calls=%v", github.LabelPilot, srv.removeLabelCalls)
+				}
+				if srv.hasRemoveLabel(100, github.LabelInProgress) {
+					t.Errorf("did not expect %s to be removed from source #100 on escalate, calls=%v", github.LabelInProgress, srv.removeLabelCalls)
 				}
 				if len(sink.events) != 1 {
 					t.Errorf("expected exactly 1 alert, got %d", len(sink.events))
@@ -237,6 +268,9 @@ func TestController_VerifyFixPRDeliversSourceScope_ReviewRevision(t *testing.T) 
 			if tt.wantLabelsUntouched {
 				if len(srv.addLabelCalls) != 0 {
 					t.Errorf("expected no label writes, got %v", srv.addLabelCalls)
+				}
+				if len(srv.removeLabelCalls) != 0 {
+					t.Errorf("expected no label removals, got %v", srv.removeLabelCalls)
 				}
 				if len(sink.events) != 0 {
 					t.Errorf("expected no alerts, got %d", len(sink.events))

--- a/internal/autopilot/owner_death.go
+++ b/internal/autopilot/owner_death.go
@@ -251,18 +251,19 @@ func (c *Controller) verifyFixPRDeliversSourceScope(ctx context.Context, prState
 		// Confirmed overlap: the fix/revision PR's diff genuinely continues
 		// the origin PR's work — safe to mark the source issue superseded
 		// now that its scope is confirmed delivered.
-		if isReviewRevision {
-			if err := c.labeler.AddLabels(ctx, c.owner, c.repo, sourceNum, []string{github.LabelSuperseded}); err != nil {
-				c.log.Warn("verifyFixPRDeliversSourceScope: failed to add superseded label", "issue", sourceNum, "error", err)
-			}
-		} else {
-			// Mirrors the label set notifyExternalClose's supersededClose
-			// branch applies for the review-issue hand-off path.
-			c.mutateIssueLabels(ctx, sourceNum,
-				[]string{github.LabelSuperseded},
-				[]string{github.LabelPilot, github.LabelInProgress, labelNeedsManualRebase},
-			)
-		}
+		// GH-5375: both kinds must mirror the label set notifyExternalClose's
+		// supersededClose branch applies (controller.go ~9860-9868) — pilot
+		// and pilot-in-progress stripped in the same mutation that adds
+		// pilot-superseded. Before this fix the review-revision kind only
+		// added pilot-superseded, leaving pilot/pilot-in-progress standing on
+		// an OPEN source issue: the poller skips it (in-progress) so there's
+		// no double-dispatch, but the stale-label cleanup sweep and any
+		// operator reading labels see a live task that will never move
+		// (GH-5298 invariant: pilot-superseded and pilot must never coexist).
+		c.mutateIssueLabels(ctx, sourceNum,
+			[]string{github.LabelSuperseded},
+			[]string{github.LabelPilot, github.LabelInProgress, labelNeedsManualRebase},
+		)
 		c.log.Info("verifyFixPRDeliversSourceScope: fix/revision PR confirmed to deliver origin scope — source issue marked superseded",
 			"source", sourceNum, "fix_issue", prState.IssueNumber, "fix_pr", prState.PRNumber, "origin_pr", originPR, "review_revision", isReviewRevision)
 		c.cleanupOriginScope(prState.IssueNumber)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5375.

Closes #5375

## Changes

GitHub Issue GH-5375: fix(autopilot): review-path superseded gate adds pilot-superseded but never strips pilot / pilot-in-progress from the source issue (GH-5298 invariant)

## Problem

PR #5372 (issue #5362) moved the review-revision path to the evidence-gated `verifyFixPRDeliversSourceScope` in `internal/autopilot/owner_death.go` (~281-296). When the gate confirms delivery it only calls `AddLabels(pilot-superseded)`. The path it replaced (`notifyExternalClose`, `internal/autopilot/controller.go` ~9871-9879) also removed `pilot` and `pilot-in-progress` from the source issue — the GH-5298 invariant that a terminal label never coexists with the active labels.

Failure scenario: a review-revision PR merges with full file overlap; the source issue ends OPEN carrying `pilot`, `pilot-in-progress` and `pilot-superseded` together. The poller skips it (in-progress), so no double dispatch, but the board and the stale-label cleanup sweep in the autopilot package (the function that strips leftover pilot labels on terminal executions; find it by grepping the autopilot package for the stale-label sweep, it is not in a file named cleanup) see a live task that will never move, and an operator reading labels cannot tell it is done.

## Fix

1. In the gate's success branch (both CI-fix and review-revision kinds), after adding `pilot-superseded`, remove `pilot` and `pilot-in-progress` (use the existing label-cycle helper the controller uses elsewhere so the pilot-label guard is honoured), and close the source issue if the existing superseded flow closes it.
2. Keep the zero-overlap branch unchanged (comment + alert, no labels).
3. Tests: extend `gh5362_review_scope_test.go` (and the CI-fix twin `gh5348_scope_mismatch_test.go`) to assert the removal calls on success and their absence on zero overlap.

## Acceptance

- [ ] After a delivered revision, the source issue carries `pilot-superseded` only (no `pilot`, no `pilot-in-progress`).
- [ ] Zero-overlap path unchanged.
- [ ] Existing review/CI-fix gate tests green.