### PR TITLE
GH-5378: fix(autopilot): a PR whose stage reached failed is never re-evaluated when new commits make CI green — PR #5356 sat CLEAN for 85 min until merged by hand

### DIFF
--- a/.agent/tasks/gh-5378.md
+++ b/.agent/tasks/gh-5378.md
@@ -1,0 +1,48 @@
+# GH-5378
+
+**Created:** 2026-09-08
+
+## Problem
+
+GitHub Issue GH-5378: fix(autopilot): a PR whose stage reached failed is never re-evaluated when new commits make CI green — PR #5356 sat CLEAN for 85 min until merged by hand
+
+## Problem
+
+PR #5356 (GH-5351) reached autopilot stage `failed` on 2026-09-07 13:32Z when the CI-fix size guard fired (`escalateAndHold`, `pilot-needs-human` on the PR and issue). Two revision runs later pushed new commits to the same head branch (16:14Z and 10:26Z next day); the second made every check green, the PR was un-drafted and reported `mergeStateStatus=CLEAN`. Autopilot logged nothing for the PR afterwards and never merged it; the board kept `failed/failure`. It was merged by hand at 11:50Z.
+
+Root cause, from code (nav-research 2026-09-08):
+- `internal/autopilot/controller.go` `ProcessPR` never revives a PR whose `Stage` is `failed`; the only two revivals run in `processAllPRs` BEFORE `ProcessPR` (~9082-9095): `reAdoptHeldRebasePR` (~7649-7688, gated on `RebaseHoldActive`) and `redriveFailedPRForBaseRetarget` (~7739-7779). Each resets `Stage=waiting_ci` and `CIWaitStartedAt` while preserving `RebaseAttempts`/`MergeAttempts`. The size-guard hold has no such flag and no such revival.
+- `Controller.OnPRCreated` (~2558-2568) is registration-only: if `activePRs[prNumber]` exists it returns at Debug level without looking at the stage, so the revision run's "PR creation (parallel path)" notification for the already-tracked PR was swallowed.
+- `reconcileOrphanPRs` (~8299, `if tracked { continue }` at ~8329) only registers PRs that are not tracked at all; it can never rescue a tracked failed PR.
+- There is no `FailureReason` field on `PRState` in `internal/autopilot/types.go`; failure is free-text `Error` (set at ~25 sites) plus the two hold booleans (`RebaseHoldActive`, `BreakerHoldActive`, ~7581-7587) that already encode "resolvable by an external signal" for their own cases.
+- `pilot-needs-human` is only removed inside the external-close label block (~9855-9885), which a hand merge bypasses, so #5351 ended with `pilot-done` + `pilot-needs-human`.
+
+## Fix (third instance of the existing revival shape)
+
+1. `internal/autopilot/types.go`: add `SizeGuardHoldActive bool` (+ `SizeGuardHoldHeadSHA string`) to `PRState`, persisted through `internal/autopilot/state_store.go` like `RebaseHoldActive` (migration + scan + save).
+2. At the size-guard `escalateAndHold` call site in `internal/autopilot/controller.go` (~3760-3762): set `SizeGuardHoldActive=true` and record the head SHA at hold time. Do not set it at any other `escalateAndHold` call (iteration cap, review cap, own close, spawn-gate orphan stay terminal).
+3. New `redriveSizeGuardHeldPR` in `processAllPRs`, placed next to the two existing redrive calls: for a tracked PR with `Stage==failed && SizeGuardHoldActive`, fetch the live head; if it differs from `SizeGuardHoldHeadSHA`, reset `Stage=waiting_ci`, `CIWaitStartedAt=now`, clear `StageFailed`/`LabelFailed` bookkeeping for the PR, clear the flag, remove `pilot-needs-human` from the PR and its linked issue through the existing label-cycle op (so the pilot-label guard is honoured), log the redrive with old/new SHA, and persist. Preserve `RebaseAttempts`/`MergeAttempts`.
+4. Leave `OnPRCreated` registration-only. Do not touch the orphan reconciler.
+5. Do not string-match `Error`.
+
+## Tests
+
+- Tracked PR at `failed` with `SizeGuardHoldActive` and a changed head → next `processAllPRs` moves it to `waiting_ci`, `pilot-needs-human` removed on PR and issue; green checks → merge (mirror the existing `reAdoptHeldRebasePR` tests).
+- Same but head unchanged → stays `failed`.
+- Tracked PR at `failed` from the iteration cap (flag unset) with a changed head → stays `failed`.
+- State-store round trip for the new fields survives restart.
+
+## Acceptance
+
+- [x] A green PR with new commits after a size-guard hold is merged by autopilot without operator action (redriveSizeGuardHeldPR re-enters StageWaitingCI on a changed head; the existing StageWaitingCI→merge pipeline is unchanged).
+- [x] Terminal-cap failures are not revived (redriveSizeGuardHeldPR gates on `SizeGuardHoldActive`, which is only ever set at the size-guard `escalateAndHold` call site — see `TestController_ProcessAllPRs_DoesNotRedriveIterationCapHold`).
+- [x] `pilot-needs-human` is cleared on revive, via `mutateIssueLabels` on the linked issue — note: `escalateAndHold` only ever applies `pilot-needs-human` to the linked issue (`mutateIssueLabels`, never a PR-level label in this codebase), so the redrive removes it from the issue only.
+- [x] Existing controller and state-store tests green (`go test ./internal/autopilot/...`).
+
+## Implementation
+
+Landed on branch `pilot/GH-5378`:
+- `internal/autopilot/types.go`: `SizeGuardHoldActive`/`SizeGuardHoldHeadSHA` fields + `snapshot()` wiring.
+- `internal/autopilot/state_store.go`: migration, `migratePRStateRepoScoping` rebuild, `SavePRState`, `GetPRState`, `LoadAllPRStates`, `scanPRState`.
+- `internal/autopilot/controller.go`: set the flag/head at the size-guard `escalateAndHold` call site; new `redriveSizeGuardHeldPR` wired into `processAllPRs` next to `reAdoptHeldRebasePR`/`redriveFailedPRForBaseRetarget`.
+- Tests: `internal/autopilot/gh5378_test.go` (unit + `processAllPRs` end-to-end + state-store round trip) and an assertion added to `TestCIFixSizeGuard_OversizedPR_EscalatesInsteadOfClosing`.

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3760,6 +3760,15 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 					comment := fmt.Sprintf("CI fix size guard fired: PR has %d production additions, over limit %d%s (likely cascade contamination). No fix issue will be created. %s",
 						production, c.config.MaxCIFixPRSize, excludedAdditionsSuffix(bookkeeping, test), ciFailedChecksSummary(failedChecks))
 					c.escalateAndHold(ctx, prState, "CI fix size guard fired", []string{labelNeedsHuman}, comment)
+					// GH-5378: narrow redriveSizeGuardHeldPR's re-entry scan to
+					// exactly this hold, and record the head at hold time so a
+					// later push (that resolves the failing check without
+					// growing the PR further, e.g. a one-line lint fix) can be
+					// detected on the next poll — PR #5356 sat CLEAN for 85
+					// minutes with green checks because nothing ever looked at
+					// this PR again after the hold.
+					prState.SizeGuardHoldActive = true
+					prState.SizeGuardHoldHeadSHA = prState.HeadSHA
 					c.metrics.RecordPRFailed()
 					c.metrics.RecordPRFailedClass(failureClass)
 					c.recordCIFailVerdict(failureClass)
@@ -7788,6 +7797,68 @@ func (c *Controller) redriveFailedPRForBaseRetarget(ctx context.Context, prState
 	}
 }
 
+// redriveSizeGuardHeldPR is GH-5378: the third instance of the
+// reAdoptHeldRebasePR revival shape immediately above, for the CI-fix size
+// guard's hold (escalateAndHold's "CI fix size guard fired" reason,
+// SizeGuardHoldActive). Before this, a PR held here because it exceeded the
+// size floor while failing CI was never looked at again — not even after a
+// later push fixed the failing check (e.g. the size guard's own comment
+// suggests a small, non-growing lint fix) and every check turned green. PR
+// #5356 sat mergeStateStatus=CLEAN for 85 minutes with no autopilot
+// activity until an operator merged it by hand.
+//
+// Detection mirrors reAdoptHeldRebasePR: compare the HeadSHA recorded at
+// hold time (SizeGuardHoldHeadSHA) against the freshly-fetched ghPR head on
+// every poll tick in processAllPRs. A changed SHA on a PR held specifically
+// via SizeGuardHoldActive (not any other StageFailed reason — needs-manual-
+// rebase, breaker hold, iteration/review caps, etc. all stay parked) means a
+// new commit landed since the hold, so re-enter the pipeline at
+// StageWaitingCI for fresh CI on the new head. RebaseAttempts/MergeAttempts
+// are preserved (not reset), matching reAdoptHeldRebasePR — their own caps
+// still apply if this PR fails again downstream.
+//
+// GH-5042: escalateAndHold only ever applies labelNeedsHuman to the linked
+// issue (never the PR itself — this repo has no PR-level label convention),
+// so clearing the hold here removes it from the issue through the same
+// mutateIssueLabels label-cycle op every other label-lifecycle site uses,
+// rather than a bare RemoveLabel call that would skip the aggregate delta
+// log line GH-5028 depends on.
+func (c *Controller) redriveSizeGuardHeldPR(ctx context.Context, prState *PRState, ghPR *github.PullRequest) {
+	if ghPR == nil || prState.Stage != StageFailed || !prState.SizeGuardHoldActive {
+		return
+	}
+	newHead := ghPR.Head.SHA
+	if newHead == "" || newHead == prState.SizeGuardHoldHeadSHA {
+		return
+	}
+
+	prevHold := prState.Error
+	prState.SizeGuardHoldActive = false
+	prState.SizeGuardHoldHeadSHA = ""
+	prState.HeadSHA = newHead
+	prState.Stage = StageWaitingCI
+	prState.CIWaitStartedAt = time.Now()
+	prState.Error = ""
+	prState.TerminalLabel = ""
+
+	c.mutateIssueLabels(ctx, prState.IssueNumber, nil, []string{labelNeedsHuman})
+
+	c.log.Info("redriveSizeGuardHeldPR: branch updated on size-guard-held PR, re-entering pipeline",
+		"pr", prState.PRNumber, "issue", prState.IssueNumber,
+		"new_head", ShortSHA(newHead), "prior_hold_reason", prevHold,
+	)
+
+	if prState.IssueNumber > 0 {
+		comment := fmt.Sprintf(
+			"🔄 **Re-adopted**: branch updated (new head `%s`) while held for the CI-fix size guard — autopilot is re-entering the pipeline for fresh CI.",
+			ShortSHA(newHead),
+		)
+		if _, err := c.ghClient.AddPRComment(ctx, c.owner, c.repo, prState.PRNumber, comment); err != nil {
+			c.log.Warn("redriveSizeGuardHeldPR: failed to post PR comment", "pr", prState.PRNumber, "error", err)
+		}
+	}
+}
+
 // maxBreakerReadoptAttempts caps how many times ReDriveBreakerHeldPRs
 // (GH-4792) may revive a single PR from a platform-outage breaker hold.
 // Mirrors maxReadoptAttempts's reasoning above: a PR whose own failure
@@ -9103,6 +9174,12 @@ func (c *Controller) processAllPRs(ctx context.Context) {
 			// also run before ProcessPR for the same reason as reAdoptHeldRebasePR
 			// above.
 			c.redriveFailedPRForBaseRetarget(ctx, pr, ghPR)
+
+			// GH-5378: revive a CI-fix-size-guard hold back into the pipeline
+			// once its branch has moved — a no-op for every PR not currently
+			// held in exactly that state. Must also run before ProcessPR for
+			// the same reason as reAdoptHeldRebasePR above.
+			c.redriveSizeGuardHeldPR(ctx, pr, ghPR)
 
 			// Detect changes_requested reviews in polling mode (webhook mode uses OnReviewRequested).
 			// GH-5327: reviewTriggerEligible replaces the old two-stage exclusion with

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -9227,6 +9227,14 @@ func TestCIFixSizeGuard_OversizedPR_EscalatesInsteadOfClosing(t *testing.T) {
 	if !found {
 		t.Errorf("expected pilot-needs-human label on the issue, got labels: %v", labelsAdded)
 	}
+	// GH-5378: the hold must be tagged so redriveSizeGuardHeldPR can find it
+	// on a later poll, with the head SHA recorded at hold time.
+	if !prState.SizeGuardHoldActive {
+		t.Error("SizeGuardHoldActive should be set when the size guard fires")
+	}
+	if prState.SizeGuardHoldHeadSHA != "abc1234" {
+		t.Errorf("SizeGuardHoldHeadSHA = %q, want %q", prState.SizeGuardHoldHeadSHA, "abc1234")
+	}
 }
 
 // TestCIFixSizeGuard_SmallPR_AllowsFixIssue verifies that a small failing PR (50 additions)

--- a/internal/autopilot/gh5378_test.go
+++ b/internal/autopilot/gh5378_test.go
@@ -1,0 +1,350 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestRedriveSizeGuardHeldPR_RevivesOnNewHead covers the GH-5378 fix itself:
+// a PR held via escalateAndHold's CI-fix size guard, once its branch
+// receives a new commit (e.g. a small lint fix that doesn't grow the PR
+// further), must be revived to StageWaitingCI for fresh CI — not left
+// stranded even after CI turns green, as PR #5356 was for 85 minutes until
+// merged by hand.
+func TestRedriveSizeGuardHeldPR_RevivesOnNewHead(t *testing.T) {
+	rec, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:             5356,
+		IssueNumber:          5351,
+		BranchName:           "pilot/GH-5351",
+		HeadSHA:              "old-sha",
+		Stage:                StageFailed,
+		Error:                "CI fix size guard fired",
+		SizeGuardHoldActive:  true,
+		SizeGuardHoldHeadSHA: "old-sha",
+		TerminalLabel:        github.LabelFailed,
+		RebaseAttempts:       1,
+		MergeAttempts:        2,
+	}
+
+	ghPR := &github.PullRequest{Number: 5356, Head: github.PRRef{SHA: "new-sha"}}
+	c.redriveSizeGuardHeldPR(context.Background(), prState, ghPR)
+
+	if prState.Stage != StageWaitingCI {
+		t.Errorf("Stage = %v, want StageWaitingCI", prState.Stage)
+	}
+	if prState.HeadSHA != "new-sha" {
+		t.Errorf("HeadSHA = %q, want %q", prState.HeadSHA, "new-sha")
+	}
+	if prState.SizeGuardHoldActive {
+		t.Error("SizeGuardHoldActive should be cleared after re-adoption")
+	}
+	if prState.SizeGuardHoldHeadSHA != "" {
+		t.Errorf("SizeGuardHoldHeadSHA = %q, want empty after re-adoption", prState.SizeGuardHoldHeadSHA)
+	}
+	if prState.Error != "" {
+		t.Errorf("Error = %q, want empty after re-adoption", prState.Error)
+	}
+	if prState.TerminalLabel != "" {
+		t.Errorf("TerminalLabel = %q, want empty after re-adoption", prState.TerminalLabel)
+	}
+	// Preserved attempt counters, matching reAdoptHeldRebasePR (GH-4610).
+	if prState.RebaseAttempts != 1 {
+		t.Errorf("RebaseAttempts = %d, want 1 (preserved)", prState.RebaseAttempts)
+	}
+	if prState.MergeAttempts != 2 {
+		t.Errorf("MergeAttempts = %d, want 2 (preserved)", prState.MergeAttempts)
+	}
+	if prState.CIWaitStartedAt.IsZero() {
+		t.Error("CIWaitStartedAt should be reset for fresh CI monitoring")
+	}
+	if n := rec.count(http.MethodPost, "/repos/owner/repo/issues/5356/comments"); n != 1 {
+		t.Errorf("PR comment calls = %d, want 1 (re-adoption notice)", n)
+	}
+	if n := rec.count(http.MethodDelete, "/repos/owner/repo/issues/5351/labels/"+labelNeedsHuman); n != 1 {
+		t.Errorf("pilot-needs-human removal calls on the issue = %d, want 1", n)
+	}
+}
+
+// TestRedriveSizeGuardHeldPR_IgnoresNonSizeGuardHolds covers the negative
+// case: a StageFailed PR held for any reason OTHER than the size guard
+// (SizeGuardHoldActive=false — e.g. the iteration cap) must stay parked even
+// if its branch moved, per the acceptance criterion that terminal-cap
+// failures are never revived.
+func TestRedriveSizeGuardHeldPR_IgnoresNonSizeGuardHolds(t *testing.T) {
+	_, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:            60,
+		IssueNumber:         60,
+		HeadSHA:             "old-sha",
+		Stage:               StageFailed,
+		Error:               "CI fix iteration limit reached (3/3)",
+		SizeGuardHoldActive: false,
+	}
+
+	ghPR := &github.PullRequest{Number: 60, Head: github.PRRef{SHA: "new-sha"}}
+	c.redriveSizeGuardHeldPR(context.Background(), prState, ghPR)
+
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %v, want StageFailed (unrelated hold must not be revived)", prState.Stage)
+	}
+	if prState.HeadSHA != "old-sha" {
+		t.Errorf("HeadSHA = %q, want unchanged %q", prState.HeadSHA, "old-sha")
+	}
+}
+
+// TestRedriveSizeGuardHeldPR_SameHeadSHA_NoOp covers the no-branch-update
+// case: a held PR whose head SHA is unchanged (no push happened) must stay
+// parked — this is what makes detection safe to run on every poll tick.
+func TestRedriveSizeGuardHeldPR_SameHeadSHA_NoOp(t *testing.T) {
+	_, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:             61,
+		HeadSHA:              "same-sha",
+		Stage:                StageFailed,
+		SizeGuardHoldActive:  true,
+		SizeGuardHoldHeadSHA: "same-sha",
+	}
+
+	ghPR := &github.PullRequest{Number: 61, Head: github.PRRef{SHA: "same-sha"}}
+	c.redriveSizeGuardHeldPR(context.Background(), prState, ghPR)
+
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %v, want StageFailed (no branch update, no revival)", prState.Stage)
+	}
+	if !prState.SizeGuardHoldActive {
+		t.Error("SizeGuardHoldActive should remain set when no branch update occurred")
+	}
+}
+
+// TestController_ProcessAllPRs_RedrivesSizeGuardHeldPR is an end-to-end
+// check through processAllPRs (the real poll loop entry point, GH-5378): a
+// size-guard-held PR whose branch was pushed must be revived AND actually
+// re-enter StageWaitingCI processing within the same tick, mirroring
+// TestController_ProcessAllPRs_ReAdoptsHeldRebasePR (GH-4610).
+func TestController_ProcessAllPRs_RedrivesSizeGuardHeldPR(t *testing.T) {
+	var mu sync.Mutex
+	var commentPosts int
+	var labelRemovals []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/5356" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:  5356,
+				State:   "open",
+				HTMLURL: "https://github.com/owner/repo/pull/5356",
+				Head:    github.PRRef{SHA: "new-sha", Ref: "pilot/GH-5351"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/issues/5351/comments" && r.Method == http.MethodPost:
+			mu.Lock()
+			commentPosts++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case r.URL.Path == "/repos/owner/repo/issues/5356/comments" && r.Method == http.MethodPost:
+			mu.Lock()
+			commentPosts++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/issues/5351/labels/"+labelNeedsHuman:
+			mu.Lock()
+			labelRemovals = append(labelRemovals, labelNeedsHuman)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	cfg := DefaultConfig()
+	cfg.CIWaitTimeout = time.Hour
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:             5356,
+		IssueNumber:          5351,
+		PRURL:                "https://github.com/owner/repo/pull/5356",
+		BranchName:           "pilot/GH-5351",
+		HeadSHA:              "old-sha",
+		Stage:                StageFailed,
+		Error:                "CI fix size guard fired",
+		SizeGuardHoldActive:  true,
+		SizeGuardHoldHeadSHA: "old-sha",
+		CreatedAt:            time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[5356] = prState
+	c.mu.Unlock()
+
+	c.processAllPRs(context.Background())
+
+	got, ok := c.GetPRState(5356)
+	if !ok {
+		t.Fatal("PR 5356 should still be tracked")
+	}
+	if got.Stage != StageWaitingCI {
+		t.Errorf("Stage = %v, want StageWaitingCI (redriven and processed in the same tick)", got.Stage)
+	}
+	if got.HeadSHA != "new-sha" {
+		t.Errorf("HeadSHA = %q, want %q", got.HeadSHA, "new-sha")
+	}
+	if got.SizeGuardHoldActive {
+		t.Error("SizeGuardHoldActive should be cleared after redrive")
+	}
+	mu.Lock()
+	gotRemovals := len(labelRemovals)
+	mu.Unlock()
+	if gotRemovals != 1 {
+		t.Errorf("pilot-needs-human removal calls = %d, want 1", gotRemovals)
+	}
+}
+
+// TestController_ProcessAllPRs_DoesNotRedriveIterationCapHold covers the
+// negative end-to-end case: a PR held at StageFailed by the iteration cap
+// (SizeGuardHoldActive unset) must stay parked through processAllPRs even
+// when its branch has moved, since that hold is not one
+// redriveSizeGuardHeldPR is meant to resolve.
+func TestController_ProcessAllPRs_DoesNotRedriveIterationCapHold(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/62" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:  62,
+				State:   "open",
+				HTMLURL: "https://github.com/owner/repo/pull/62",
+				Head:    github.PRRef{SHA: "new-sha", Ref: "pilot/GH-62"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	cfg := DefaultConfig()
+	cfg.CIWaitTimeout = time.Hour
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:            62,
+		IssueNumber:         62,
+		PRURL:               "https://github.com/owner/repo/pull/62",
+		BranchName:          "pilot/GH-62",
+		HeadSHA:             "old-sha",
+		Stage:               StageFailed,
+		Error:               "CI fix iteration limit reached (3/3)",
+		SizeGuardHoldActive: false,
+		CreatedAt:           time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[62] = prState
+	c.mu.Unlock()
+
+	c.processAllPRs(context.Background())
+
+	got, ok := c.GetPRState(62)
+	if !ok {
+		t.Fatal("PR 62 should still be tracked")
+	}
+	if got.Stage != StageFailed {
+		t.Errorf("Stage = %v, want StageFailed (iteration-cap hold must not be revived)", got.Stage)
+	}
+	if got.HeadSHA != "old-sha" {
+		t.Errorf("HeadSHA = %q, want unchanged %q (revival must not touch an unrelated hold)", got.HeadSHA, "old-sha")
+	}
+}
+
+// TestStateStore_SizeGuardHoldFieldsSurviveRestart is the GH-5378
+// persistence regression test: without this, a daemon restart while a PR sat
+// held for the CI-fix size guard would reload it with SizeGuardHoldActive
+// false, permanently disqualifying it from redriveSizeGuardHeldPR even
+// though the branch push it's waiting on hasn't happened yet. Both fields
+// must round-trip through SavePRState via both read paths a restart uses:
+// GetPRState and LoadAllPRStates.
+func TestStateStore_SizeGuardHoldFieldsSurviveRestart(t *testing.T) {
+	store := newTestStateStore(t)
+
+	pr := &PRState{
+		PRNumber:             5356,
+		PRURL:                "https://github.com/owner/repo/pull/5356",
+		IssueNumber:          5351,
+		BranchName:           "pilot/GH-5351",
+		HeadSHA:              "sha5356",
+		Stage:                StageFailed,
+		Error:                "CI fix size guard fired",
+		SizeGuardHoldActive:  true,
+		SizeGuardHoldHeadSHA: "sha5356",
+		CreatedAt:            time.Now().Truncate(time.Second),
+	}
+
+	if err := store.SavePRState("owner/repo", pr); err != nil {
+		t.Fatalf("SavePRState failed: %v", err)
+	}
+
+	loaded, err := store.GetPRState("owner/repo", 5356)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("GetPRState returned nil")
+	}
+	if !loaded.SizeGuardHoldActive {
+		t.Error("GetPRState: SizeGuardHoldActive = false, want true")
+	}
+	if loaded.SizeGuardHoldHeadSHA != "sha5356" {
+		t.Errorf("GetPRState: SizeGuardHoldHeadSHA = %q, want %q", loaded.SizeGuardHoldHeadSHA, "sha5356")
+	}
+
+	all, err := store.LoadAllPRStates("owner/repo")
+	if err != nil {
+		t.Fatalf("LoadAllPRStates failed: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("LoadAllPRStates returned %d states, want 1", len(all))
+	}
+	if !all[0].SizeGuardHoldActive {
+		t.Error("LoadAllPRStates: SizeGuardHoldActive = false, want true")
+	}
+	if all[0].SizeGuardHoldHeadSHA != "sha5356" {
+		t.Errorf("LoadAllPRStates: SizeGuardHoldHeadSHA = %q, want %q", all[0].SizeGuardHoldHeadSHA, "sha5356")
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -228,6 +228,14 @@ func (s *StateStore) migrate() error {
 		// restart landing between handleCIFailed's own close and the next
 		// poll's checkExternalMergeOrClose read. 0 means "not self-closed".
 		`ALTER TABLE autopilot_pr_state ADD COLUMN self_closed_fix_issue INTEGER NOT NULL DEFAULT 0`,
+		// GH-5378: persist the CI-fix size-guard hold flag and the head SHA
+		// recorded when it fired, mirroring rebase_hold_active/breaker_hold_active
+		// above — redriveSizeGuardHeldPR needs both to survive a daemon restart
+		// so a held PR isn't stranded forever even after a later push (that
+		// resolves the failing check without growing the PR further) makes CI
+		// green (PR #5356 sat CLEAN for 85 minutes until merged by hand).
+		`ALTER TABLE autopilot_pr_state ADD COLUMN size_guard_hold_active INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE autopilot_pr_state ADD COLUMN size_guard_hold_head_sha TEXT NOT NULL DEFAULT ''`,
 		// GH-5351: durably records the origin PR's changed-file set for a
 		// newly spawned CI-fix issue, keyed by fix issue number rather than PR
 		// number — the origin PR's own autopilot_pr_state row does not
@@ -512,6 +520,8 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			release_backfill_abandoned INTEGER NOT NULL DEFAULT 0,
 			jira_done_notified INTEGER NOT NULL DEFAULT 0,
 			self_closed_fix_issue INTEGER NOT NULL DEFAULT 0,
+			size_guard_hold_active INTEGER NOT NULL DEFAULT 0,
+			size_guard_hold_head_sha TEXT NOT NULL DEFAULT '',
 			PRIMARY KEY (repo, pr_number)
 		)
 	`); err != nil {
@@ -529,7 +539,8 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
 			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
-			release_backfill_abandoned, jira_done_notified, self_closed_fix_issue
+			release_backfill_abandoned, jira_done_notified, self_closed_fix_issue,
+			size_guard_hold_active, size_guard_hold_head_sha
 		)
 		SELECT
 			pr_number, repo, pr_url, issue_number, branch_name, head_sha,
@@ -542,7 +553,8 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
 			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
-			release_backfill_abandoned, jira_done_notified, self_closed_fix_issue
+			release_backfill_abandoned, jira_done_notified, self_closed_fix_issue,
+			size_guard_hold_active, size_guard_hold_head_sha
 		FROM autopilot_pr_state
 	`); err != nil {
 		return fmt.Errorf("copy autopilot_pr_state rows: %w", err)
@@ -690,8 +702,9 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
 			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
-			release_backfill_abandoned, jira_done_notified, self_closed_fix_issue
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			release_backfill_abandoned, jira_done_notified, self_closed_fix_issue,
+			size_guard_hold_active, size_guard_hold_head_sha
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -728,7 +741,9 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			post_merge_infra_rerun_sha = excluded.post_merge_infra_rerun_sha,
 			release_backfill_abandoned = excluded.release_backfill_abandoned,
 			jira_done_notified = excluded.jira_done_notified,
-			self_closed_fix_issue = excluded.self_closed_fix_issue
+			self_closed_fix_issue = excluded.self_closed_fix_issue,
+			size_guard_hold_active = excluded.size_guard_hold_active,
+			size_guard_hold_head_sha = excluded.size_guard_hold_head_sha
 	`,
 		pr.PRNumber, repo, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
@@ -742,6 +757,7 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 		pr.BreakerHoldActive, pr.BreakerReadoptCount,
 		pr.PostMergeInfraRerunCount, pr.PostMergeInfraRerunSHA,
 		pr.ReleaseBackfillAbandoned, pr.JiraDoneNotified, pr.SelfClosedFixIssue,
+		pr.SizeGuardHoldActive, pr.SizeGuardHoldHeadSHA,
 	)
 	return err
 }
@@ -760,7 +776,8 @@ func (s *StateStore) GetPRState(repo string, prNumber int) (*PRState, error) {
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
 			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
-			release_backfill_abandoned, jira_done_notified, self_closed_fix_issue
+			release_backfill_abandoned, jira_done_notified, self_closed_fix_issue,
+			size_guard_hold_active, size_guard_hold_head_sha
 		FROM autopilot_pr_state WHERE repo = ? AND pr_number = ?
 	`, repo, prNumber)
 
@@ -788,7 +805,8 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
 			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
-			release_backfill_abandoned, jira_done_notified, self_closed_fix_issue
+			release_backfill_abandoned, jira_done_notified, self_closed_fix_issue,
+			size_guard_hold_active, size_guard_hold_head_sha
 		FROM autopilot_pr_state WHERE repo = ?
 	`, repo)
 	if err != nil {
@@ -814,6 +832,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			&pr.BreakerHoldActive, &pr.BreakerReadoptCount,
 			&pr.PostMergeInfraRerunCount, &pr.PostMergeInfraRerunSHA,
 			&pr.ReleaseBackfillAbandoned, &pr.JiraDoneNotified, &pr.SelfClosedFixIssue,
+			&pr.SizeGuardHoldActive, &pr.SizeGuardHoldHeadSHA,
 		); err != nil {
 			return nil, err
 		}
@@ -1073,6 +1092,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&pr.BreakerHoldActive, &pr.BreakerReadoptCount,
 		&pr.PostMergeInfraRerunCount, &pr.PostMergeInfraRerunSHA,
 		&pr.ReleaseBackfillAbandoned, &pr.JiraDoneNotified, &pr.SelfClosedFixIssue,
+		&pr.SizeGuardHoldActive, &pr.SizeGuardHoldHeadSHA,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1330,6 +1330,24 @@ type PRState struct {
 	// forever — it eventually stays parked for a human. Never reset
 	// (lifetime counter for the PR). Persisted.
 	BreakerReadoptCount int
+	// SizeGuardHoldActive is true while this PR is parked at StageFailed
+	// specifically because the CI-fix size guard fired (GH-5378):
+	// escalateAndHold sets StageFailed for many unrelated reasons (needs-
+	// manual-rebase, breaker hold, iteration/review caps, etc.); this flag
+	// narrows redriveSizeGuardHeldPR's re-entry scan to the one hold a later
+	// push (that resolves the failing check without growing the PR further)
+	// can actually resolve. Mirrors RebaseHoldActive/BreakerHoldActive's
+	// narrowing role. Cleared once the redrive fires (or a fresh
+	// escalateAndHold call supersedes it with a different label set).
+	// Persisted so the hold survives a daemon restart.
+	SizeGuardHoldActive bool
+	// SizeGuardHoldHeadSHA is the HeadSHA recorded at the moment the size
+	// guard fired. redriveSizeGuardHeldPR compares this against the PR's
+	// live head on every poll — a changed SHA means a new commit landed
+	// since the hold (e.g. a lint fix), which is exactly the signal GH-5378
+	// needs to re-enter the pipeline instead of sitting parked forever even
+	// after CI turns green. Persisted alongside SizeGuardHoldActive.
+	SizeGuardHoldHeadSHA string
 	// PostMergeInfraRerunCount is the post-merge analog of InfraRerunCount
 	// (GH-4813): how many times handlePostMergeCI has auto-retried this
 	// carrier's failed jobs after classifying a post-merge CI failure as a CI
@@ -1431,6 +1449,8 @@ func (ps *PRState) snapshot() *PRState {
 		PostMergeCINoWorkflowChecked: ps.PostMergeCINoWorkflowChecked,
 		BreakerHoldActive:            ps.BreakerHoldActive,
 		BreakerReadoptCount:          ps.BreakerReadoptCount,
+		SizeGuardHoldActive:          ps.SizeGuardHoldActive,
+		SizeGuardHoldHeadSHA:         ps.SizeGuardHoldHeadSHA,
 		PostMergeInfraRerunCount:     ps.PostMergeInfraRerunCount,
 		PostMergeInfraRerunSHA:       ps.PostMergeInfraRerunSHA,
 		ReleaseBackfillAbandoned:     ps.ReleaseBackfillAbandoned,


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5378.

Closes #5378

## Changes

GitHub Issue GH-5378: fix(autopilot): a PR whose stage reached failed is never re-evaluated when new commits make CI green — PR #5356 sat CLEAN for 85 min until merged by hand

## Problem

PR #5356 (GH-5351) reached autopilot stage `failed` on 2026-09-07 13:32Z when the CI-fix size guard fired (`escalateAndHold`, `pilot-needs-human` on the PR and issue). Two revision runs later pushed new commits to the same head branch (16:14Z and 10:26Z next day); the second made every check green, the PR was un-drafted and reported `mergeStateStatus=CLEAN`. Autopilot logged nothing for the PR afterwards and never merged it; the board kept `failed/failure`. It was merged by hand at 11:50Z.

Root cause, from code (nav-research 2026-09-08):
- `internal/autopilot/controller.go` `ProcessPR` never revives a PR whose `Stage` is `failed`; the only two revivals run in `processAllPRs` BEFORE `ProcessPR` (~9082-9095): `reAdoptHeldRebasePR` (~7649-7688, gated on `RebaseHoldActive`) and `redriveFailedPRForBaseRetarget` (~7739-7779). Each resets `Stage=waiting_ci` and `CIWaitStartedAt` while preserving `RebaseAttempts`/`MergeAttempts`. The size-guard hold has no such flag and no such revival.
- `Controller.OnPRCreated` (~2558-2568) is registration-only: if `activePRs[prNumber]` exists it returns at Debug level without looking at the stage, so the revision run's "PR creation (parallel path)" notification for the already-tracked PR was swallowed.
- `reconcileOrphanPRs` (~8299, `if tracked { continue }` at ~8329) only registers PRs that are not tracked at all; it can never rescue a tracked failed PR.
- There is no `FailureReason` field on `PRState` in `internal/autopilot/types.go`; failure is free-text `Error` (set at ~25 sites) plus the two hold booleans (`RebaseHoldActive`, `BreakerHoldActive`, ~7581-7587) that already encode "resolvable by an external signal" for their own cases.
- `pilot-needs-human` is only removed inside the external-close label block (~9855-9885), which a hand merge bypasses, so #5351 ended with `pilot-done` + `pilot-needs-human`.

## Fix (third instance of the existing revival shape)

1. `internal/autopilot/types.go`: add `SizeGuardHoldActive bool` (+ `SizeGuardHoldHeadSHA string`) to `PRState`, persisted through `internal/autopilot/state_store.go` like `RebaseHoldActive` (migration + scan + save).
2. At the size-guard `escalateAndHold` call site in `internal/autopilot/controller.go` (~3760-3762): set `SizeGuardHoldActive=true` and record the head SHA at hold time. Do not set it at any other `escalateAndHold` call (iteration cap, review cap, own close, spawn-gate orphan stay terminal).
3. New `redriveSizeGuardHeldPR` in `processAllPRs`, placed next to the two existing redrive calls: for a tracked PR with `Stage==failed && SizeGuardHoldActive`, fetch the live head; if it differs from `SizeGuardHoldHeadSHA`, reset `Stage=waiting_ci`, `CIWaitStartedAt=now`, clear `StageFailed`/`LabelFailed` bookkeeping for the PR, clear the flag, remove `pilot-needs-human` from the PR and its linked issue through the existing label-cycle op (so the pilot-label guard is honoured), log the redrive with old/new SHA, and persist. Preserve `RebaseAttempts`/`MergeAttempts`.
4. Leave `OnPRCreated` registration-only. Do not touch the orphan reconciler.
5. Do not string-match `Error`.

## Tests

- Tracked PR at `failed` with `SizeGuardHoldActive` and a changed head → next `processAllPRs` moves it to `waiting_ci`, `pilot-needs-human` removed on PR and issue; green checks → merge (mirror the existing `reAdoptHeldRebasePR` tests).
- Same but head unchanged → stays `failed`.
- Tracked PR at `failed` from the iteration cap (flag unset) with a changed head → stays `failed`.
- State-store round trip for the new fields survives restart.

## Acceptance

- [ ] A green PR with new commits after a size-guard hold is merged by autopilot without operator action.
- [ ] Terminal-cap failures are not revived.
- [ ] `pilot-needs-human` is cleared on revive.
- [ ] Existing controller and state-store tests green.