### PR TITLE
GH-5346: finalization ctx everywhere, backend-outcome-first gate retry, and push+hold salvage on backend timeout

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -554,6 +554,12 @@ Examples:
 			}
 			cfg.Executor.Version = version
 
+			// GH-5346: thread orchestrator.execution.finalize_timeout into the
+			// executor config so Runner.finalizeTimeout() sees it.
+			if cfg.Orchestrator != nil && cfg.Orchestrator.Execution != nil && cfg.Orchestrator.Execution.FinalizeTimeout > 0 {
+				cfg.Executor.FinalizeTimeout = cfg.Orchestrator.Execution.FinalizeTimeout
+			}
+
 			// Resolve project path: flag > config default > cwd
 			if projectPath == "" {
 				if defaultProj := cfg.GetDefaultProject(); defaultProj != nil {

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -291,6 +291,16 @@ orchestrator:
     poll_interval: 30s         # How often to check PR status
     pr_timeout: 1h             # Max time to wait for PR merge
 
+    # GH-5346: budget granted to post-backend finalization work (quality
+    # gates, self-review, intent judge, contract evidence, push/PR create)
+    # when the task's own ctx has already hit its deadline. Without this, a
+    # backend call that timed out after landing real commits could lose
+    # those commits entirely — finalization inherited the same expired ctx
+    # and every git/gate call failed instantly. Only takes effect once the
+    # task ctx is actually Done(); a task that finishes within its normal
+    # timeout is unaffected. Default: 15m.
+    finalize_timeout: 15m
+
   # Daily receipts digest (GH-5257): an end-of-day Telegram-only summary,
   # one line per terminal execution that day — issue ref, diff size,
   # duration, dollar cost — plus a day total. Independent schedule from any

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,15 +186,22 @@ type ExecutionConfig struct {
 	WaitForMerge bool          `yaml:"wait_for_merge"` // Wait for PR merge before next task
 	PollInterval time.Duration `yaml:"poll_interval"`  // How often to check PR status (default: 30s)
 	PRTimeout    time.Duration `yaml:"pr_timeout"`     // Max wait time for PR merge (default: 1h)
+	// FinalizeTimeout bounds the fresh context granted to post-backend
+	// finalization (quality gates, self-review, intent judge, contract
+	// evidence, push/PR create) once the task's own timeout ctx has already
+	// expired. Copied into executor.BackendConfig.FinalizeTimeout at
+	// startup. Default: 15m. GH-5346.
+	FinalizeTimeout time.Duration `yaml:"finalize_timeout"`
 }
 
 // DefaultExecutionConfig returns sensible defaults for execution config
 func DefaultExecutionConfig() *ExecutionConfig {
 	return &ExecutionConfig{
-		Mode:         "auto",
-		WaitForMerge: true,
-		PollInterval: 30 * time.Second,
-		PRTimeout:    1 * time.Hour,
+		Mode:            "auto",
+		WaitForMerge:    true,
+		PollInterval:    30 * time.Second,
+		PRTimeout:       1 * time.Hour,
+		FinalizeTimeout: 15 * time.Minute,
 	}
 }
 

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -506,6 +506,24 @@ type BackendConfig struct {
 	// Version is the Pilot binary version, set at startup from the build-time version var.
 	// Used for feature matrix updates and execution reports. Not a config file field.
 	Version string `yaml:"-"`
+
+	// FinalizeTimeout bounds the fresh context finalizeCtx grants once the
+	// backend has finished and the task's own timeout ctx has already
+	// expired: quality gates, self-review, intent judge, contract-evidence
+	// verification, and push/PR creation all run on it. Mirrors
+	// orchestrator.execution.finalize_timeout (config.ExecutionConfig),
+	// which is copied here at startup. Default: 15m. GH-5346.
+	FinalizeTimeout time.Duration `yaml:"finalize_timeout,omitempty"`
+}
+
+// EffectiveFinalizeTimeout returns the post-backend finalization budget,
+// applying the 15-minute default when FinalizeTimeout is zero or unset.
+// GH-5346.
+func (c *BackendConfig) EffectiveFinalizeTimeout() time.Duration {
+	if c == nil || c.FinalizeTimeout <= 0 {
+		return 15 * time.Minute
+	}
+	return c.FinalizeTimeout
 }
 
 // EffectiveStallTimeout returns the stall detection threshold, applying the

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2644,6 +2644,307 @@ func (r *Runner) escalateUnfetchableFixSHA(ctx context.Context, task *Task) (*Ex
 	}, fmt.Errorf("autopilot-fix: %s", detail)
 }
 
+// ensureQualityCheckerFactory auto-enables a minimal build (and, when
+// detectable, test) gate when no quality checker has been configured (GH-363).
+// This ensures broken code never becomes a PR even without explicit quality
+// config. Extracted from the first-pass quality-gate block in
+// executeWithOptions (GH-5346) so attemptBackendTimeoutSalvage's single
+// gate-check can reuse the exact same auto-enable behavior instead of running
+// with no gate at all just because it takes a different code path than the
+// ordinary success flow.
+func (r *Runner) ensureQualityCheckerFactory(executionPath string, log *slog.Logger) {
+	if r.qualityCheckerFactory != nil {
+		return
+	}
+	buildCmd := quality.DetectBuildCommand(executionPath)
+	testCmd := quality.DetectTestCommand(executionPath)
+	if buildCmd == "" {
+		return
+	}
+	log.Info("Auto-enabling build gate (no quality config)",
+		slog.String("command", buildCmd),
+	)
+
+	// Create minimal quality checker with auto-detected build command
+	minimalConfig := quality.MinimalBuildGate()
+	minimalConfig.Gates[0].Command = buildCmd
+
+	// GH-2398: also auto-enable a test gate when a test runner is
+	// detectable. Empty testCmd → skip the gate entirely instead of
+	// failing it on workspaces that lack a Makefile / test harness.
+	if testCmd != "" {
+		log.Info("Auto-enabling test gate", slog.String("command", testCmd))
+		minimalConfig.Gates = append(minimalConfig.Gates, &quality.Gate{
+			Name:        "test",
+			Type:        quality.GateTest,
+			Command:     testCmd,
+			Required:    true,
+			Timeout:     5 * time.Minute,
+			MaxRetries:  1,
+			RetryDelay:  3 * time.Second,
+			FailureHint: "Fix failing tests in the changed files",
+		})
+	}
+
+	r.qualityCheckerFactory = func(taskID, projectPath string) QualityChecker {
+		return &simpleQualityChecker{
+			config:      minimalConfig,
+			projectPath: projectPath,
+			taskID:      taskID,
+		}
+	}
+}
+
+// attemptBackendTimeoutSalvage runs when the backend call itself ended
+// because the task ctx hit its deadline (timedOut == true at the call site
+// in executeWithOptions), instead of an ordinary classified backend failure.
+// GH-5346: a ctx that expires mid-run does not mean Claude Code did no
+// useful work — the deadline can fire after real commits already landed in
+// the worktree. Pre-GH-5346 that work was discarded unconditionally (the
+// backend-error branch always fell through to a bare "task failed" return).
+//
+// This is deliberately NOT the same as the ordinary quality-gate retry loop
+// (the `for retryAttempt := range maxAutoRetries` loop further down in
+// executeWithOptions): that loop re-invokes Claude Code on a gate failure,
+// and the backend has already burned its budget getting here, so
+// re-invoking it is exactly what step 2 of GH-5346 forbids. Gates run
+// exactly once, on a finalization ctx, and the result is a straight
+// pass/fail branch — never a retry.
+//
+// Returns true if it fully handled the result (result is populated and the
+// caller in executeWithOptions should return immediately). Returns false if
+// there was nothing to salvage (no commits on the branch) — the caller
+// should fall through to its normal "task failed" return.
+func (r *Runner) attemptBackendTimeoutSalvage(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, executionPath string, log *slog.Logger, recorder *replay.Recorder) bool {
+	if git == nil || task.Branch == "" || task.DirectCommit || !task.CreatePR {
+		// Direct-commit tasks push straight to main with no branch/PR to
+		// salvage this way, and a task that never wanted a PR/branch has
+		// nothing here worth pushing either.
+		return false
+	}
+
+	finCtx, cancel := finalizeCtx(ctx, r.finalizeTimeout())
+	defer cancel()
+
+	baseBranch := task.BaseBranch
+	if baseBranch == "" {
+		baseBranch, _ = git.GetDefaultBranch(finCtx)
+		if baseBranch == "" {
+			baseBranch = "main"
+		}
+	}
+
+	commitCount, countErr := git.CountNewCommitsAgainstOrigin(finCtx, baseBranch)
+	if countErr != nil {
+		// GH-5342/GH-5346: one re-count before giving up — a transient git
+		// error is not proof there is nothing to salvage, and treating it
+		// as such is exactly the silent-data-loss bug both issues fix.
+		commitCount, countErr = git.CountNewCommitsAgainstOrigin(finCtx, baseBranch)
+	}
+	if countErr != nil {
+		r.holdPushedBranch(finCtx, task, git, result, log,
+			fmt.Sprintf("task ended by %v and commit count could not be verified after a retry: %v", ctx.Err(), countErr))
+		return true
+	}
+	if commitCount == 0 {
+		// Nothing to salvage — let the caller's ordinary "task failed"
+		// return run; there is no branch worth pushing or holding.
+		return false
+	}
+
+	log.Info("timeout salvage: backend ended by ctx expiry with commits present, attempting to save the work",
+		slog.String("task_id", task.ID),
+		slog.String("branch", task.Branch),
+		slog.Int("commit_count", commitCount),
+		slog.Any("ctx_err", ctx.Err()),
+	)
+
+	if !task.SkipQualityGates {
+		r.ensureQualityCheckerFactory(executionPath, log)
+		if r.qualityCheckerFactory != nil {
+			checker := r.qualityCheckerFactory(task.ID, executionPath)
+			outcome, qErr := checker.Check(finCtx)
+			switch {
+			case qErr != nil:
+				r.holdPushedBranch(finCtx, task, git, result, log,
+					fmt.Sprintf("timeout salvage: quality gate error: %v", qErr))
+				return true
+			case outcome == nil || !outcome.Passed:
+				r.holdPushedBranch(finCtx, task, git, result, log,
+					"timeout salvage: quality gates failed after task timeout")
+				return true
+			default:
+				result.QualityGates = r.buildQualityGatesResult(outcome, 0)
+				r.recordQualityGateEvents(task.LogExecutionID(), outcome)
+			}
+		}
+	}
+
+	r.pushAndCreatePRAfterTimeout(finCtx, task, git, result, recorder, log)
+	return true
+}
+
+// holdPushedBranch pushes task.Branch (if it is not already on the remote)
+// and parks the source issue under pilot-needs-human instead of silently
+// discarding committed work or leaving the branch stranded only in the
+// (about-to-be-deleted) local worktree. Modeled on escalateUnfetchableFixSHA
+// above, which uses the same push/comment/label idiom for a "no more
+// automatic progress possible" state. GH-5346.
+//
+// Uses a fresh, value-preserving 30s window for the push/comment/label calls
+// (context.WithoutCancel(ctx), not ctx directly) — by the time this runs,
+// ctx itself is very often already exhausted (that is frequently WHY this is
+// being called), and building the escalation calls on a dead ctx would fail
+// them before they start.
+func (r *Runner) holdPushedBranch(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, log *slog.Logger, reason string) {
+	holdCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
+	pushed := false
+	if git != nil && task.Branch != "" {
+		if pushErr := git.Push(holdCtx, task.Branch); pushErr != nil {
+			if git.RemoteBranchExists(holdCtx, task.Branch) {
+				pushed = true
+			} else {
+				log.Warn("timeout salvage: failed to push branch for human hold",
+					slog.String("task_id", task.ID),
+					slog.String("branch", task.Branch),
+					slog.Any("error", pushErr),
+				)
+				reason = fmt.Sprintf("%s (branch push also failed: %v)", reason, pushErr)
+			}
+		} else {
+			pushed = true
+		}
+	}
+
+	log.Warn("timeout salvage: holding branch for human triage",
+		slog.String("task_id", task.ID),
+		slog.String("branch", task.Branch),
+		slog.Bool("pushed", pushed),
+		slog.String("reason", reason),
+	)
+
+	if task.SourceAdapter == "" || task.SourceAdapter == "github" {
+		if issueNum := task.GHIssueRef(); issueNum != "" {
+			outcomeNote := "The branch could not be pushed either — check the worktree/logs before retrying."
+			if pushed {
+				outcomeNote = fmt.Sprintf("Branch `%s` was pushed with the commits Pilot completed before this happened — review and finish it manually, or clear the label to let Pilot retry.", task.Branch)
+			}
+			commentBody := fmt.Sprintf("Pilot parked this task under `pilot-needs-human`: %s\n\n%s", reason, outcomeNote)
+			if commentErr := ghIssueComment(holdCtx, task.ProjectPath, issueNum, commentBody); commentErr != nil {
+				log.Warn("timeout salvage: failed to post hold comment",
+					slog.String("task_id", task.ID), slog.Any("error", commentErr))
+			}
+			if labelErr := ghEditLabels(holdCtx, task.ProjectPath, issueNum, []string{labelPilotNeedsHuman}, []string{labelPilotRetryReady}); labelErr != nil {
+				log.Warn("timeout salvage: failed to apply pilot-needs-human label",
+					slog.String("task_id", task.ID), slog.Any("error", labelErr))
+			}
+		}
+	}
+
+	result.Success = false
+	result.Outcome = "needs_human"
+	result.Error = reason
+	r.reportProgress(task.ID, "NeedsHuman", 100, reason)
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, reason)
+}
+
+// pushAndCreatePRAfterTimeout pushes task.Branch and opens (or adopts) its
+// PR after attemptBackendTimeoutSalvage confirmed real commits and (if
+// quality gates are configured) a passing single gate run. Simplified,
+// non-epic sibling of finalizeEpicBranchPR above: no epic-child sweep, and
+// none of the ordinary direct path's extra guards (adopt-open-PR,
+// issue-superseded check, dead-man push tracker, post-push ghost-SHA
+// re-check) — this is an edge-case salvage path for a task whose backend
+// call already burned its full budget, not the place to add more
+// finalization work. Any failure here falls back to holdPushedBranch so the
+// commits are never silently lost. GH-5346.
+func (r *Runner) pushAndCreatePRAfterTimeout(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, recorder *replay.Recorder, log *slog.Logger) {
+	baseBranch := task.BaseBranch
+	if baseBranch == "" {
+		baseBranch, _ = git.GetDefaultBranch(ctx)
+		if baseBranch == "" {
+			baseBranch = "main"
+		}
+	}
+
+	if err := git.Push(ctx, task.Branch); err != nil {
+		if !git.RemoteBranchExists(ctx, task.Branch) {
+			r.holdPushedBranch(ctx, task, git, result, log,
+				fmt.Sprintf("timeout salvage: branch push failed: %v", err))
+			return
+		}
+		log.Warn("timeout salvage: push reported error but branch exists on remote, continuing",
+			slog.String("task_id", task.ID), slog.Any("error", err))
+	}
+
+	if sha, shaErr := git.GetCurrentCommitSHA(ctx); shaErr == nil && sha != "" {
+		result.CommitSHA = sha
+	}
+
+	// TASK-359 Layer 1 (Shape C) parity: don't open a duplicate PR for work
+	// that is already merged (e.g. a retried dispatch of a branch salvaged
+	// once already).
+	if mergedURL, mergedErr := git.FindMergedPRByBranch(ctx, task.Branch); mergedErr == nil && mergedURL != "" {
+		result.PRUrl = mergedURL
+		result.Success = true
+		log.Info("timeout salvage: branch already merged, adopting existing PR",
+			slog.String("task_id", task.ID), slog.String("pr_url", mergedURL))
+		r.reportProgress(task.ID, "Complete", 100, "timeout salvage: work already merged")
+		if recorder != nil {
+			recorder.SetPRUrl(mergedURL)
+		}
+		return
+	}
+
+	diffStats, _ := git.GetDiffStats(ctx, baseBranch)
+	normalizedTitle, titleErr := normalizeTitle(task.Title, task.Labels, diffStats)
+	if titleErr != nil {
+		r.holdPushedBranch(ctx, task, git, result, log,
+			fmt.Sprintf("timeout salvage: PR title normalization failed: %v", titleErr))
+		return
+	}
+	prTitle := fmt.Sprintf("%s: %s", task.ID, normalizedTitle)
+	issueNum := strings.TrimPrefix(task.ID, "GH-")
+	prBody := fmt.Sprintf("## Summary\n\nAutomated PR created by Pilot after a task timeout (GH-5346 salvage path) for %s.\n\nCloses #%s%s\n\n## Changes\n\n%s",
+		task.ID, issueNum, extraFixesKeyword(task.Description, issueNum), task.Description)
+
+	// GH-5346: adapter-aware routing, matching the ordinary direct-path
+	// PR-create leg (executeWithOptions) — a GitHub-SDK-managed repo, a
+	// non-GitHub adapter's PRCreator, and the gh-CLI fallback all need PRs
+	// opened through their own creator, not just `gh pr create`.
+	var prURL string
+	var createErr error
+	switch {
+	case task.SourceAdapter == "github" && task.SourceRepo != "" && r.prCreatorFor("github:"+task.SourceRepo) != nil:
+		prURL, createErr = r.prCreatorFor("github:" + task.SourceRepo).CreatePR(ctx, task.Branch, baseBranch, prTitle, prBody)
+	case r.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github":
+		closeKeyword := ""
+		if task.SourceIssueID != "" {
+			closeKeyword = fmt.Sprintf("\n\nCloses #%s", task.SourceIssueID)
+		}
+		mrBody := fmt.Sprintf("## Summary\n\nAutomated MR created by Pilot after a task timeout (GH-5346 salvage path) for %s.%s\n\n## Changes\n\n%s", task.ID, closeKeyword, task.Description)
+		prURL, createErr = r.prCreator.CreatePR(ctx, task.Branch, baseBranch, prTitle, mrBody)
+	default:
+		prURL, createErr = git.CreatePR(ctx, prTitle, prBody, baseBranch)
+	}
+	if createErr != nil {
+		r.holdPushedBranch(ctx, task, git, result, log,
+			fmt.Sprintf("timeout salvage: PR creation failed: %v", createErr))
+		return
+	}
+
+	result.PRUrl = prURL
+	result.Success = true
+	log.Info("timeout salvage: PR created", slog.String("task_id", task.ID), slog.String("pr_url", prURL))
+	r.reportProgress(task.ID, "Complete", 100, "timeout salvage: PR created from committed work")
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StagePRCreated, "timeout salvage: pr created: "+prURL)
+	if recorder != nil {
+		recorder.SetPRUrl(prURL)
+	}
+}
+
 // classifyZeroDeliveryEpicCompletion reclassifies an epic-parent result that
 // reports Success=true but carries no evidence any real work happened —
 // zero tokens burned by Claude (planning or children), zero files changed,
@@ -4380,6 +4681,19 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 			})
 		}
 
+		// GH-5346: a backend call that ended because the task ctx hit its
+		// deadline does not mean Claude Code did no useful work — the
+		// deadline can fire after real commits already landed in the
+		// worktree. Attempt to salvage those commits (push+PR, or
+		// push+pilot-needs-human) before falling through to the "task
+		// failed" return below, which pre-GH-5346 discarded them
+		// unconditionally. Only reachable via the timedOut branch above —
+		// ordinary classified backend failures (rate limit, API error,
+		// refusal, ...) always fall through here exactly as before.
+		if timedOut && r.attemptBackendTimeoutSalvage(ctx, task, git, result, executionPath, log, recorder) {
+			return result, nil
+		}
+
 		// GH-1599: Log task failed milestone
 		r.saveLogEntry(task.LogExecutionID(), "error", "Task failed: "+result.Error)
 
@@ -4931,44 +5245,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 
 			// Auto-enable minimal build gate if not configured (GH-363)
 			// This ensures broken code never becomes a PR, even without explicit quality config
-			if r.qualityCheckerFactory == nil {
-				buildCmd := quality.DetectBuildCommand(executionPath)
-				testCmd := quality.DetectTestCommand(executionPath)
-				if buildCmd != "" {
-					log.Info("Auto-enabling build gate (no quality config)",
-						slog.String("command", buildCmd),
-					)
-
-					// Create minimal quality checker with auto-detected build command
-					minimalConfig := quality.MinimalBuildGate()
-					minimalConfig.Gates[0].Command = buildCmd
-
-					// GH-2398: also auto-enable a test gate when a test runner is
-					// detectable. Empty testCmd → skip the gate entirely instead of
-					// failing it on workspaces that lack a Makefile / test harness.
-					if testCmd != "" {
-						log.Info("Auto-enabling test gate", slog.String("command", testCmd))
-						minimalConfig.Gates = append(minimalConfig.Gates, &quality.Gate{
-							Name:        "test",
-							Type:        quality.GateTest,
-							Command:     testCmd,
-							Required:    true,
-							Timeout:     5 * time.Minute,
-							MaxRetries:  1,
-							RetryDelay:  3 * time.Second,
-							FailureHint: "Fix failing tests in the changed files",
-						})
-					}
-
-					r.qualityCheckerFactory = func(taskID, projectPath string) QualityChecker {
-						return &simpleQualityChecker{
-							config:      minimalConfig,
-							projectPath: projectPath,
-							taskID:      taskID,
-						}
-					}
-				}
-			}
+			r.ensureQualityCheckerFactory(executionPath, log)
 
 			// Run quality gates if configured.
 			// Previously skipped in LocalMode (v25 OOM concern), re-enabled since

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2918,7 +2918,7 @@ func (r *Runner) pushAndCreatePRAfterTimeout(ctx context.Context, task *Task, gi
 	var createErr error
 	switch {
 	case task.SourceAdapter == "github" && task.SourceRepo != "" && r.prCreatorFor("github:"+task.SourceRepo) != nil:
-		prURL, createErr = r.prCreatorFor("github:" + task.SourceRepo).CreatePR(ctx, task.Branch, baseBranch, prTitle, prBody)
+		prURL, createErr = r.prCreatorFor("github:"+task.SourceRepo).CreatePR(ctx, task.Branch, baseBranch, prTitle, prBody)
 	case r.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github":
 		closeKeyword := ""
 		if task.SourceIssueID != "" {
@@ -6029,7 +6029,6 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 		} else if task.CreatePR && task.Branch != "" {
 			// Create PR if requested and we have commits
 			r.reportProgress(task.ID, "Creating PR", 96, "Pushing branch...")
-
 
 			// GH-4022: an already-merged branch short-circuits push+CreatePR —
 			// must run BEFORE the no-commits guard below and before push, since a

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -4880,6 +4880,38 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			}
 		}
 
+		// GH-5346: from here through the end of this branch — the quality-gate
+		// first pass, self-review, intent judge, contract-evidence
+		// verification, and the final push/PR-create — every stage runs on a
+		// finalization ctx, not the raw task ctx. The backend has already
+		// returned; a deadline blowing partway through this bookkeeping must
+		// not discard a completed, committed solution (see finalizeCtx's doc
+		// comment — this is the same class of bug GH-5342 fixed for the
+		// epic/decomposed-parent PR-finalize paths, now closed for the direct
+		// path too). ctx is shadowed here for the quality-gate first pass,
+		// and re-derived again (via further finalizeCtx calls; search
+		// "GH-5346: re-derive" below) immediately before each later stage —
+		// self-review/intent judge, contract evidence, and push/PR-create —
+		// rather than once for the whole rest of the function, because each
+		// of those stages is itself a real LLM/git call that can consume
+		// enough wall-clock to blow a ctx that was still live when the
+		// *previous* stage started. Re-deriving is always safe to call
+		// again: on a still-live ctx it's just an extra context.WithCancel
+		// wrap; it only actually grants a fresh window the moment ctx.Err()
+		// is DeadlineExceeded.
+		//
+		// taskCtxWasDone is captured BEFORE this first shadow so retry-gating
+		// decisions downstream (e.g. the intent-judge retry below) keep
+		// asking "had the task's own budget already run out when the backend
+		// returned" rather than "is the current finalization ctx done" —
+		// the latter is essentially always false right after finalizeCtx
+		// grants a fresh window, which would silently re-enable a Claude
+		// Code re-invocation this GH-5346 revision is explicitly meant to
+		// forbid once the backend has timed out.
+		taskCtxWasDone := ctx.Err() != nil
+		ctx, finalizeCancel := finalizeCtx(ctx, r.finalizeTimeout())
+		defer finalizeCancel()
+
 		// Track if quality gates passed for self-review decision (GH-1079)
 		qualityGatesPassed := false
 
@@ -4954,16 +4986,22 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 
 					checker := r.qualityCheckerFactory(task.ID, executionPath)
 
-					// GH-5060: the first-pass gate check (retryAttempt == 0) stays on
-					// the attempt ctx - correct, it should not outlive the attempt.
-					// But retry-pass re-checks (retryAttempt > 0) must not run on that
-					// same ctx: GH-4876 gave the reset (line ~4523) and re-invoke (line
-					// ~4593) legs fresh contexts so an exhausted attempt deadline can't
-					// doom an otherwise-recoverable retry, but the gate re-check itself
-					// was left on the old ctx. A ctx-respecting checker whose deadline
-					// already passed by the time the fresh-ctx re-invoke completes would
-					// die here with "context deadline exceeded", producing a false
-					// task_failed right after a successful retry.
+					// GH-5060/GH-5346: the first-pass gate check (retryAttempt == 0)
+					// runs on ctx, which by this point is the finalization ctx set up
+					// above — not the raw attempt ctx. That's deliberate: this check
+					// happens after the backend has already returned, so it must
+					// survive an attempt deadline that blew while the backend was
+					// still finishing real, committed work (same reasoning as
+					// finalizeCtx's doc comment). Retry-pass re-checks (retryAttempt >
+					// 0) build their own fresh, unrelated context.Background()-rooted
+					// timeout instead: GH-4876 gave the reset (line ~4523) and
+					// re-invoke (line ~4593) legs fresh contexts so an exhausted
+					// attempt deadline can't doom an otherwise-recoverable retry, but
+					// the gate re-check itself was left needing the same treatment. A
+					// ctx-respecting checker whose deadline already passed by the time
+					// the fresh-ctx re-invoke completes would otherwise die here with
+					// "context deadline exceeded", producing a false task_failed right
+					// after a successful retry.
 					var outcome *QualityOutcome
 					var qErr error
 					if retryAttempt > 0 {
@@ -5328,6 +5366,17 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			)
 		}
 
+		// GH-5346: re-derive the finalization ctx here rather than trusting
+		// the one from the quality-gate section above — quality gates (and
+		// their retries) can themselves burn real wall-clock, so a ctx that
+		// was still live when that section started may have gone Done()
+		// since. finalizeCtx is idempotent to call again: if ctx is still
+		// live, this is just an extra context.WithCancel wrap; if it just
+		// blew its deadline, this is what actually grants the fresh window
+		// self-review and the intent judge run on.
+		ctx, selfReviewCancel := finalizeCtx(ctx, r.finalizeTimeout())
+		defer selfReviewCancel()
+
 		// GH-1079: Run self-review and intent judge in parallel (saves 2-5 min per task)
 		// Both are independent read-only operations:
 		// - Self-review checks code quality (syntax, wiring, style)
@@ -5440,24 +5489,39 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 
 				if state.intentRetried {
 					result.IntentWarning = intentVerdict.Reason
-				} else if ctx.Err() != nil {
+				} else if taskCtxWasDone || ctx.Err() != nil {
 					// GH-5342 (subtask 3): quality-gate retries above run on
 					// their own fresh, unbounded-relative-to-ctx timeout
 					// (GH-4876), so they can burn real wall-clock while this
 					// task's own ctx keeps ticking independently. By the time
 					// the intent judge flags a mismatch here, ctx may already
-					// be done (deadline exceeded, or an explicit cancel) —
-					// unlike the no-commit-retry above, nothing upstream of
-					// this branch shares ctx to fail fast on it first.
-					// Spawning another Claude Code process on an already-done
-					// ctx can't produce anything usable — backendExecute
-					// forwards ctx straight into exec.CommandContext, which
-					// refuses to even start the process on a ctx that's
-					// already Done — so skip the retry and keep the
+					// have been done (deadline exceeded, or an explicit
+					// cancel) — unlike the no-commit-retry above, nothing
+					// upstream of this branch shares ctx to fail fast on it
+					// first. Spawning another Claude Code process once the
+					// task's own budget is exhausted can't produce anything
+					// usable — backendExecute forwards ctx straight into
+					// exec.CommandContext — so skip the retry and keep the
 					// intent-judge warning instead of burning a doomed
 					// re-invocation.
+					//
+					// GH-5346: two independent signals, either one is enough
+					// to skip. taskCtxWasDone (captured before finalizeCtx
+					// ran, further up this function) catches the case where
+					// the backend itself already timed out — ctx is now the
+					// finalization ctx, a fresh budget that's essentially
+					// never Done, so checking ctx.Err() alone would silently
+					// re-enable exactly the re-invocation this guard exists
+					// to forbid. The live ctx.Err() != nil check stays too,
+					// for the other case: the backend finished comfortably
+					// inside budget, finalizeCtx handed back a plain
+					// context.WithCancel wrapping the still-ticking original
+					// ctx (not a fresh window), and it's the intent-judge
+					// call itself that ran long enough to blow that original
+					// deadline mid-finalization.
 					log.Warn("Skipping intent-judge retry: task ctx already done",
 						slog.String("task_id", task.ID),
+						slog.Bool("task_ctx_was_done", taskCtxWasDone),
 						slog.Any("ctx_err", ctx.Err()),
 					)
 					result.IntentWarning = intentVerdict.Reason
@@ -5539,6 +5603,14 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				}
 			}
 		}
+
+		// GH-5346: re-derive the finalization ctx again — self-review and the
+		// intent judge (just above) are themselves real backend/subprocess
+		// calls that can run long enough for a still-live ctx to blow its
+		// deadline meanwhile. See the matching comment above the self-review
+		// refresh for why re-calling finalizeCtx here is safe either way.
+		ctx, contractEvidenceCancel := finalizeCtx(ctx, r.finalizeTimeout())
+		defer contractEvidenceCancel()
 
 		// Contract Evidence gate (TASK-460 doc-vs-wire leg, GH-5009/GH-5012):
 		// hard-blocks tasks whose diff touches a configured contract_files
@@ -5648,6 +5720,14 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			}
 		}
 
+		// GH-5342/GH-5346: finalization (commit count, push, PR create) must
+		// not inherit an already-exhausted task ctx — see finalizeCtx's doc
+		// comment for why. Re-derived one more time here (not reused from
+		// the contract-evidence refresh above) since that gate's own git/LLM
+		// calls can themselves consume the remainder of a still-live ctx.
+		ctx, pushCancel := finalizeCtx(ctx, r.finalizeTimeout())
+		defer pushCancel()
+
 		if task.DirectCommit {
 			r.reportProgress(task.ID, "Pushing", 96, "Pushing to main...")
 
@@ -5673,11 +5753,6 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			// Create PR if requested and we have commits
 			r.reportProgress(task.ID, "Creating PR", 96, "Pushing branch...")
 
-			// GH-5342: finalization (commit count, push, PR create) must not
-			// inherit an already-exhausted task ctx — see finalizeCtx's doc
-			// comment for why. Shadows ctx for the rest of this branch.
-			ctx, cancel := finalizeCtx(ctx, finalizeGitTimeout)
-			defer cancel()
 
 			// GH-4022: an already-merged branch short-circuits push+CreatePR —
 			// must run BEFORE the no-commits guard below and before push, since a

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -297,16 +297,25 @@ const finalizeGitTimeout = 5 * time.Minute
 // shutdown) is left untouched, since that's a genuine "stop now" signal, not
 // an exhausted budget on otherwise-complete work. Only a blown deadline gets
 // a fresh, bounded window to finish saving already-completed work.
+//
+// GH-5346: the fresh window is built on context.WithoutCancel(ctx) rather
+// than context.Background() — a plain Background() root silently dropped
+// every value threaded onto the task ctx (request-scoped trace/log fields,
+// per-task deadlines set by callers further up the stack) the moment a
+// deadline blew, even though the whole point of this function is to keep
+// finalization working like nothing happened. WithoutCancel preserves ctx's
+// values and detaches only its Done()/Err() (which are already spent) and
+// its cancellation propagation — exactly the two properties we need to shed.
 func finalizeCtx(ctx context.Context, budget time.Duration) (context.Context, context.CancelFunc) {
 	if ctx.Err() == context.DeadlineExceeded {
-		return context.WithTimeout(context.Background(), budget)
+		return context.WithTimeout(context.WithoutCancel(ctx), budget)
 	}
 	return context.WithCancel(ctx)
 }
 
 // logGitCtxErr logs a post-backend git/gh call failure, downgrading to
-// Debug when the call ran on a ctx that was already Done() (deadline
-// blown or explicit cancellation) at the time it was made.
+// Debug only when the call ran on a ctx whose deadline had already blown
+// (context.DeadlineExceeded) at the time it was made.
 //
 // GH-5342 (subtask 4): several classification-only git calls made right
 // after the backend returns — the no-commit-retry's pre/post commit-count
@@ -317,12 +326,17 @@ func finalizeCtx(ctx context.Context, budget time.Duration) (context.Context, co
 // gates the retry/backstop logic that follows them (see GH-5342-3's
 // resolution note on the no-commit-retry gate). That's correct behavior,
 // but every one of those fast failures is a "context deadline exceeded"
-// (or context.Canceled) that used to log at Warn — daemon-log noise for an
-// expected, designed outcome, not evidence of an actual git/gh problem.
-// Warn is reserved for failures that aren't explained by the ctx already
-// being done.
+// that used to log at Warn — daemon-log noise for an expected, designed
+// outcome, not evidence of an actual git/gh problem.
+//
+// GH-5346: an explicit context.Canceled is NOT downgraded here — unlike a
+// blown deadline, a real cancellation (stop request, process shutdown) is
+// exactly the kind of unexpected mid-flight interruption that's worth a
+// Warn: it's the signal the push+hold path uses to decide committed work
+// needs a human's attention. Debug is reserved for the designed, expected
+// deadline-exceeded case.
 func logGitCtxErr(ctx context.Context, log *slog.Logger, msg string, attrs ...any) {
-	if ctx.Err() != nil {
+	if ctx.Err() == context.DeadlineExceeded {
 		log.Debug(msg, attrs...)
 		return
 	}
@@ -1326,6 +1340,15 @@ func (r *Runner) effectiveStallTimeout() time.Duration {
 	return r.config.EffectiveStallTimeout()
 }
 
+// finalizeTimeout returns the budget finalizeCtx should grant post-backend
+// finalization calls (quality gates, self-review, intent judge, contract
+// evidence, push/PR create). Delegates to
+// BackendConfig.EffectiveFinalizeTimeout(); returns the 15m default when no
+// config is set. GH-5346.
+func (r *Runner) finalizeTimeout() time.Duration {
+	return r.config.EffectiveFinalizeTimeout()
+}
+
 func (r *Runner) selfReviewTimeout() time.Duration {
 	if r.backendType() == BackendTypeOpenCode {
 		return 10 * time.Minute
@@ -2102,7 +2125,8 @@ func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, err
 func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, childTerminalStates []string) {
 	// GH-5342: finalization (commit count, push, PR create) must not inherit
 	// an already-exhausted task ctx — see finalizeCtx's doc comment for why.
-	ctx, cancel := finalizeCtx(ctx, finalizeGitTimeout)
+	// GH-5346: budget is now configurable (orchestrator.execution.finalize_timeout).
+	ctx, cancel := finalizeCtx(ctx, r.finalizeTimeout())
 	defer cancel()
 
 	// Determine base branch before the no-commits guard.

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -448,7 +448,8 @@ func (r *Runner) finalizeDecomposedParentPR(ctx context.Context, task *Task, git
 	// inherit an already-exhausted task ctx — see finalizeCtx's doc comment
 	// for why (same class of bug as finalizeEpicBranchPR and the direct
 	// path's PR-creation block).
-	ctx, cancel := finalizeCtx(ctx, finalizeGitTimeout)
+	// GH-5346: budget is now configurable (orchestrator.execution.finalize_timeout).
+	ctx, cancel := finalizeCtx(ctx, r.finalizeTimeout())
 	defer cancel()
 
 	// TASK-359 Shape C / GH-4022: an already-merged branch short-circuits

--- a/internal/executor/runner_gh5342_test.go
+++ b/internal/executor/runner_gh5342_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -421,5 +423,229 @@ func TestNoCommitRetry_PostRetryExpiredCtx_NoDeadlineExceededLogNoise(t *testing
 
 	if logged := logBuf.String(); strings.Contains(logged, "context deadline exceeded") {
 		t.Errorf("daemon log must not surface \"context deadline exceeded\" from the finalization-phase git/gate calls, got:\n%s", logged)
+	}
+}
+
+// ctxRespectingBackend is a scriptable Backend for exercising the GH-5346
+// timeout-salvage path. Unlike mockGH4964Backend (which ignores the ctx it's
+// handed entirely and always returns a nil error), a real backend — a
+// subprocess wrapper watching the ctx it was given — returns a non-nil
+// error once that ctx is done. run is invoked once per Execute() call
+// (1-indexed) and is handed the real ctx so it can block on it exactly like
+// a live subprocess wrapper would.
+type ctxRespectingBackend struct {
+	mu    sync.Mutex
+	count int
+	run   func(ctx context.Context, call int, opts ExecuteOptions) (*BackendResult, error)
+}
+
+func (b *ctxRespectingBackend) Name() string      { return "mock-ctx-respecting" }
+func (b *ctxRespectingBackend) IsAvailable() bool { return true }
+
+func (b *ctxRespectingBackend) Execute(ctx context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	b.mu.Lock()
+	b.count++
+	call := b.count
+	b.mu.Unlock()
+	return b.run(ctx, call, opts)
+}
+
+func (b *ctxRespectingBackend) callCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.count
+}
+
+// stubQualityChecker is a scriptable QualityChecker so the timeout-salvage
+// tests below can control the single (non-retrying) gate-check outcome
+// directly, instead of depending on a real build/test command being
+// detectable in the throwaway test repo.
+type stubQualityChecker struct {
+	outcome *QualityOutcome
+}
+
+func (s *stubQualityChecker) Check(context.Context) (*QualityOutcome, error) {
+	return s.outcome, nil
+}
+
+// writeFakeGhPRCreateAndLabel extends writeFakeGhPRCreate (runner_gh4220_test.go)
+// with a `gh issue edit ...` capture: the full argument line of any `issue
+// edit` invocation is appended to capturedLabelEditsFile, one line per call,
+// so a test can assert the pilot-needs-human hold path actually reached the
+// label/comment escalation call instead of only checking ExecutionResult.
+func writeFakeGhPRCreateAndLabel(t *testing.T, fakeBin, capturedTitleFile, capturedLabelEditsFile string) {
+	t.Helper()
+	script := fmt.Sprintf(`#!/bin/sh
+case "$*" in
+  *"pr list"*) echo "[]" ;;
+  *"pr create"*)
+    prev=""
+    for arg in "$@"; do
+      if [ "$prev" = "--title" ]; then
+        printf '%%s' "$arg" > %q
+      fi
+      prev="$arg"
+    done
+    echo "https://github.com/o/r/pull/777"
+    ;;
+  *"issue edit"*) echo "$*" >> %q ;;
+  *) echo "[]" ;;
+esac
+`, capturedTitleFile, capturedLabelEditsFile)
+	if err := os.WriteFile(filepath.Join(fakeBin, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+}
+
+// setUpFakeGhPRCreateAndLabelPATH mirrors setUpFakeGhPRCreatePATH but also
+// returns the file `gh issue edit` invocations get appended to.
+func setUpFakeGhPRCreateAndLabelPATH(t *testing.T) (capturedTitleFile, capturedLabelEditsFile string) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	capturedTitleFile = filepath.Join(fakeBin, "captured-title.txt")
+	capturedLabelEditsFile = filepath.Join(fakeBin, "captured-label-edits.txt")
+	writeFakeGhPRCreateAndLabel(t, fakeBin, capturedTitleFile, capturedLabelEditsFile)
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+	return capturedTitleFile, capturedLabelEditsFile
+}
+
+// TestBackendTimeoutSalvage_CommitsPresent_GatesPass_CreatesPR is the
+// GH-5346 regression guard for the "timeout + commits + gates pass" case:
+// the backend call returns only because its ctx hit the deadline (not a
+// clean success), but it left a real commit on the branch first — exactly
+// what a watchdog killing Claude Code mid-task looks like. Before GH-5346,
+// executeWithOptions's timedOut branch always fell through to a bare "task
+// failed" return, discarding that commit and leaving the branch unpushed —
+// no PR, no held branch, silent data loss. attemptBackendTimeoutSalvage must
+// instead find the commit, run quality gates exactly once (never the
+// re-invoking gate-retry loop — the backend has already burned its full
+// budget getting here), and — since they pass — push the branch and open a
+// PR.
+func TestBackendTimeoutSalvage_CommitsPresent_GatesPass_CreatesPR(t *testing.T) {
+	capturedTitleFile := setUpFakeGhPRCreatePATH(t)
+
+	const branch = "pilot/GH-5346-timeout-salvage-pass"
+	dir, _ := setupFreshnessRepo(t)
+	runGit(t, dir, "checkout", "-b", branch)
+
+	backend := &ctxRespectingBackend{
+		run: func(ctx context.Context, _ int, _ ExecuteOptions) (*BackendResult, error) {
+			// Simulate Claude Code landing a real commit before the
+			// watchdog/task-deadline kills it: commit first, then block
+			// until ctx is actually done and return its error — exactly
+			// like a ctx-respecting subprocess wrapper would.
+			writeUncommittedFile(t, dir, "salvaged.go")
+			runGit(t, dir, "add", "salvaged.go")
+			runGit(t, dir, "commit", "-m", "real work before the deadline hit")
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	runner := newGH4964Runner(backend)
+	runner.qualityCheckerFactory = func(string, string) QualityChecker {
+		return &stubQualityChecker{outcome: &QualityOutcome{Passed: true}}
+	}
+
+	task := newGH4964Task("GH-5346", branch, dir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+
+	if backend.callCount() != 1 {
+		t.Errorf("expected backend called exactly once (timeout salvage must never re-invoke Claude Code), got %d", backend.callCount())
+	}
+	if !result.Success {
+		t.Fatalf("expected Success=true, got false (error=%q)", result.Error)
+	}
+	if result.Outcome == "no_op" {
+		t.Errorf("committed work must never be recorded as no_op after a backend timeout, got Outcome=%q error=%q", result.Outcome, result.Error)
+	}
+	if result.PRUrl == "" {
+		t.Error("expected a PR URL, got none")
+	}
+	if _, statErr := os.Stat(capturedTitleFile); statErr != nil {
+		t.Errorf("gh pr create was never invoked: %v", statErr)
+	}
+
+	remoteBranches := gitOutput(t, dir, "ls-remote", "origin", branch)
+	if strings.TrimSpace(remoteBranches) == "" {
+		t.Errorf("expected branch %q to be pushed to origin, ls-remote returned nothing", branch)
+	}
+}
+
+// TestBackendTimeoutSalvage_CommitsPresent_GatesFail_HoldsBranchNoReinvocation
+// is the GH-5346 regression guard for the "timeout + commits + gates fail"
+// case: same ctx-timeout-with-a-real-commit shape as the gates-pass test
+// above, but this time the single post-timeout gate check fails. GH-5346
+// step 2 forbids re-invoking Claude Code once the backend has already
+// consumed its full budget on this timeout — there is no more time to burn
+// on a fix-it retry — so the gate failure must route straight to
+// holdPushedBranch: push the branch (so the work is not stranded only in
+// the about-to-be-cleaned-up worktree) and park the source issue under
+// pilot-needs-human, never silently drop back to a bare "task failed" with
+// an unpushed branch.
+func TestBackendTimeoutSalvage_CommitsPresent_GatesFail_HoldsBranchNoReinvocation(t *testing.T) {
+	capturedTitleFile, capturedLabelEditsFile := setUpFakeGhPRCreateAndLabelPATH(t)
+
+	const branch = "pilot/GH-5346-timeout-salvage-fail"
+	dir, _ := setupFreshnessRepo(t)
+	runGit(t, dir, "checkout", "-b", branch)
+
+	backend := &ctxRespectingBackend{
+		run: func(ctx context.Context, _ int, _ ExecuteOptions) (*BackendResult, error) {
+			writeUncommittedFile(t, dir, "salvaged.go")
+			runGit(t, dir, "add", "salvaged.go")
+			runGit(t, dir, "commit", "-m", "real work before the deadline hit")
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	runner := newGH4964Runner(backend)
+	runner.qualityCheckerFactory = func(string, string) QualityChecker {
+		return &stubQualityChecker{outcome: &QualityOutcome{Passed: false}}
+	}
+
+	task := newGH4964Task("GH-5346", branch, dir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+
+	if backend.callCount() != 1 {
+		t.Errorf("expected backend called exactly once (a timeout-with-failing-gates salvage must never re-invoke Claude Code), got %d", backend.callCount())
+	}
+	if result.Success {
+		t.Errorf("expected Success=false when post-timeout quality gates fail, got true")
+	}
+	if result.Outcome != "needs_human" {
+		t.Errorf("expected Outcome=%q, got %q (error=%q)", "needs_human", result.Outcome, result.Error)
+	}
+	if result.PRUrl != "" {
+		t.Errorf("expected no PR URL (gates failed), got %q", result.PRUrl)
+	}
+	if _, statErr := os.Stat(capturedTitleFile); statErr == nil {
+		t.Error("gh pr create must not be invoked when post-timeout quality gates fail")
+	}
+
+	remoteBranches := gitOutput(t, dir, "ls-remote", "origin", branch)
+	if strings.TrimSpace(remoteBranches) == "" {
+		t.Errorf("expected branch %q to still be pushed to origin even though gates failed, ls-remote returned nothing", branch)
+	}
+
+	labelEdits, readErr := os.ReadFile(capturedLabelEditsFile)
+	if readErr != nil {
+		t.Fatalf("expected a `gh issue edit` call applying pilot-needs-human, got no captured calls: %v", readErr)
+	}
+	if !strings.Contains(string(labelEdits), labelPilotNeedsHuman) {
+		t.Errorf("expected the captured `gh issue edit` call to add %q, got:\n%s", labelPilotNeedsHuman, labelEdits)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #5345 (merged) — implements the remaining acceptance criteria from GH-5346:

- `finalizeCtx` (`internal/executor/runner.go`) uses `context.WithoutCancel(taskCtx)` + a configurable budget (`orchestrator.execution.finalize_timeout`, default `15m`) so ctx values survive and a mid-finalization deadline no longer kills push/PR. Threaded into the quality-gate first pass, intent-judge diff, self-review, and contract-evidence diff call sites.
- The gate-retry loop no longer re-invokes Claude Code after a backend timeout — a new single-shot salvage path (`attemptBackendTimeoutSalvage`) runs quality gates once on the finalization ctx and branches on the result instead.
- New push+hold path: on a commit-count error after a single re-count, a canceled ctx, or gates failing after a timeout with commits present, the branch is pushed, `pilot-needs-human` is applied via the existing escalate/label idiom, and one comment naming the error is posted — the worktree is never left with an unpushed branch.
- Two new regression tests cover the missing outcomes: timeout + commits + gates pass → PR created; timeout + commits + gates fail → branch pushed + hold label, no re-invocation.
- `orchestrator.execution.finalize_timeout` documented in `configs/pilot.example.yaml`.
- `logGitCtxErr` downgraded to Debug for `DeadlineExceeded` only.

Closes #5346

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full repo, green)
- [x] `go test ./internal/executor/... -run 'TestBackendTimeoutSalvage'` (new tests, both pass)
- [x] `go test ./internal/executor/... -run 'TestRunner_NoOpSignal|TestRunner_BareExitSignal|TestRunner_GhostSHA|TestRunner_DeclinedMarker|TestCountNewCommitsAgainstOrigin|TestFinalizeEpicBranchPR'` (GH-4566/GH-4964 regression suites, all pass)