### PR TITLE
fix(rearm): use Timeline API edited-events for stalled re-arm evidence (GH-5381)

### DIFF
--- a/.agent/tasks/gh-5381.md
+++ b/.agent/tasks/gh-5381.md
@@ -1,0 +1,63 @@
+# GH-5381
+
+**Created:** 2026-09-08
+
+## Problem
+
+GitHub Issue GH-5381: fix(rearm): drop the updated_at re-arm evidence merged in PR #5380 — the bot's own stall comment re-arms every stalled task into an infinite retry loop; probe-error backstop; label-failure handling
+
+## Context
+
+Fix-forward for PR #5380 (issue #5376), which autopilot merged at 2026-09-08 12:21Z one minute before the REQUEST-CHANGES review landed (merge commit e25714eb). The merged change contains a self-re-arming loop: `cmd/pilot/rearm_stalled.go` (~187-189) treats `issue.UpdatedAt.After(completed_at)` as re-arm evidence, but the dispatcher's own stall surfacing (`internal/executor/dispatcher.go` ~2447-2460, then `surfaceStalledIssue` ~2540-2551: comment + `pilot-blocked`) bumps `updated_at` seconds after `completed_at`, so every stalled task is re-armed on the next sweep, retried, stalls again, and repeats — the hard cap is defeated and each cycle is a paid run. This must land before the next release train picks up main. Work on a NEW branch from main.
+
+## Changes
+
+1. **Remove the `updated_at` fallback** in `cmd/pilot/rearm_stalled.go` (~187-189). The dispatcher's own stall surfacing (`internal/executor/dispatcher.go` ~2447-2460 then `surfaceStalledIssue` ~2540-2551: comment + `pilot-blocked`) bumps `updated_at` seconds after `completed_at`, so with this signal every stall re-arms itself on the next sweep and the hard cap is defeated. Any comment by anyone has the same effect.
+2. **Real body-edit evidence**: use the issue Timeline API (classic Events never emit `edited`, as the PR's own comment at ~169-173 says) and accept an `edited` timeline event newer than `completed_at` only when the actor is not the bot account (`alekspetrov` when acting as Pilot is fine to exclude by checking the actor against the configured bot login, or by excluding events whose actor equals the token identity). Keep label/reopen events as today. Log which evidence kind matched.
+3. **Backstop gaps**: the probe error path (~272-276) must also increment the no-evidence streak before `recordClaimLostDrop`, so a persistent GitHub API error cannot loop unbounded. When the escalation `AddLabels` fails (~363-366), do not reset the streak; retry the label on the next sweep and log at Warn.
+4. **Poller log**: either pass the real reason through `terminalCompletionChecker` so the SDK line is not emitted for stalled tasks, or state in the PR body that item 3 of #5376 is deferred and file the SDK-side change as a studio-sdk issue with the pilot label. Do not claim it fixed.
+5. Tests: add the realistic post-stall case — stall stamp at T0, bot comment + `pilot-blocked` at T0+2 s (fixture `UpdatedAt` = T0+2 s), no label/reopen/edited event → NOT re-armed. Add: probe error ×3 → escalation. Keep the existing body-edit and escalation tests, adjusting the body-edit fixture to a Timeline `edited` event.
+
+## Acceptance
+
+- [x] A freshly stalled task whose only activity is the bot's stall comment and label is not re-armed.
+- [x] An operator body edit (Timeline `edited` by a non-bot actor) re-arms within one sweep.
+- [x] Three consecutive probe errors escalate exactly like three no-evidence sweeps.
+- [x] `make lint && make test` green (`golangci-lint` unavailable in this sandbox — `go build ./...`, `go vet ./...`, `gofmt -l`, and `go test ./...` all clean/green instead).
+
+## Resolution
+
+- Removed the `updated_at` fallback entirely (the pre-#5380 code, already
+  reverted in f8532806, never had it — this branch starts from that
+  baseline and does not reintroduce it).
+- Added `github.Client.ListIssueTimeline` (`internal/adapters/github/client.go`)
+  and `TimelineEvent` — the classic Events API (`ListIssueEvents`) never
+  emits `edited`; the Timeline API does. `tryRearmStalled`
+  (`cmd/pilot/rearm_stalled.go`) now falls back to a Timeline `edited` event
+  newer than `completed_at`, authored by anyone other than the bot account
+  (`resolveBotLogin`, cached via `GetAuthenticatedUser`, mirrors
+  `autopilot.Controller.getBotLogin`), only after label/reopen evidence
+  (unchanged, classic Events) comes back empty.
+- `recordStalledRearmMiss` is now the single path both the probe-error
+  branch and the clean-no-evidence branch of `sweepStalledRearm` go through,
+  so a persistent GitHub API failure feeds the same
+  `stalledRearmNoEvidenceStreaks` counter and escalates after
+  `terminalDropPilotStripThreshold` (3) misses exactly like ordinary
+  no-evidence sweeps.
+- `escalateStalledRearmNoEvidence` now returns whether `AddLabels` actually
+  applied `pilot-needs-human`; the streak is only reset on success, so an
+  `AddLabels` failure retries the label (and, as an accepted tradeoff, may
+  re-post the comment) on the next sweep pass instead of silently resuming
+  ordinary backoff with `pilot-needs-human` never applied.
+- **Item 4 (poller log) deferred, not fixed**: `terminalCompletionChecker`
+  implements the vendored `studio-sdk` poller's `ExecutionChecker` interface
+  as a plain `(bool, error)` — there is no channel to pass a "real reason"
+  string through it, so the SDK's own "completed execution exists" log line
+  cannot be suppressed or reworded from the pilot side without an SDK
+  change. This session's `gh` access does not include `gh issue create`
+  (gh-guard denies it), so the studio-sdk issue could not be filed from
+  here — flagging for the next session/operator to file
+  `qf-studio/studio-sdk` issue with the `pilot` label instead.
+
+## Acceptance Criteria
+

--- a/cmd/pilot/gh5381_stalled_rearm_test.go
+++ b/cmd/pilot/gh5381_stalled_rearm_test.go
@@ -1,0 +1,563 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// resetBotLoginCacheForTest clears resolveBotLogin's package-level cache —
+// without this, whichever test in this package resolves a bot login first
+// would leak that login into every later test's resolveBotLogin call
+// (cachedBotLogin/botLoginResolved are cached for the process lifetime by
+// design, since terminalCompletionChecker has no field to hold it — see
+// resolveBotLogin's doc comment). Each test that exercises Timeline
+// edited-event evidence must start from a clean cache so it only ever talks
+// to its own mock server.
+func resetBotLoginCacheForTest(t *testing.T) {
+	t.Helper()
+	botLoginMu.Lock()
+	cachedBotLogin = ""
+	botLoginResolved = false
+	botLoginMu.Unlock()
+	t.Cleanup(func() {
+		botLoginMu.Lock()
+		cachedBotLogin = ""
+		botLoginResolved = false
+		botLoginMu.Unlock()
+	})
+}
+
+// TestTryRearmStalled_BotCommentAndLabelOnly_NotRearmed is GH-5381's core
+// regression test for the reverted PR #5380: the ONLY post-stall activity on
+// the issue is exactly what the dispatcher's own stall surfacing produces
+// (surfaceStalledIssue, internal/executor/dispatcher.go ~2540-2551) — a
+// bot comment and a pilot-blocked label add, both landing seconds after the
+// stall timestamp and bumping issue.UpdatedAt right along with them. #5380
+// treated issue.UpdatedAt moving past the stall as re-arm evidence, so this
+// exact fixture re-armed itself every single sweep pass (GH-5381's incident).
+// Neither event qualifies as real evidence: the labeled event names
+// pilot-blocked, not the trigger label or a retry-ready label, and nothing
+// in the (empty) Timeline shows an "edited" event.
+func TestTryRearmStalled_BotCommentAndLabelOnly_NotRearmed(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+	botActivityTime := stallTime.Add(2 * time.Second)
+
+	srv := newRearmTestServer(t,
+		&github.Issue{
+			Number: 5139, State: "open",
+			Labels:    []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}},
+			UpdatedAt: botActivityTime,
+		},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+			{Event: "labeled", CreatedAt: botActivityTime, Label: &github.Label{Name: github.LabelBlocked}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5139", "/project-gh5381-bot-comment-only"
+	seedStalledRow(t, store, "exec-stalled-bot-comment-only", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
+
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rearmed {
+		t.Fatal("expected rearmed=false — the only post-stall activity is the bot's own comment+pilot-blocked label, not deliberate operator evidence")
+	}
+
+	exec, err := store.GetExecution("exec-stalled-bot-comment-only")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "stalled" {
+		t.Errorf("expected the row to remain status=stalled, got %q", exec.Status)
+	}
+}
+
+// TestTryRearmStalled_TimelineEditByOperator_Rearms is GH-5381's real
+// body-edit evidence acceptance test: a Timeline "edited" event authored by
+// someone other than the bot, timestamped after the stall, counts as
+// evidence even with zero label/reopen events — the classic Events API
+// (ListIssueEvents) never emits "edited" at all, so this is only observable
+// via ListIssueTimeline.
+func TestTryRearmStalled_TimelineEditByOperator_Rearms(t *testing.T) {
+	resetBotLoginCacheForTest(t)
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+	editTime := stallTime.Add(30 * time.Minute)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/user" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(&github.User{Login: "pilot-bot"})
+		case r.URL.Path == "/repos/owner/repo/issues/5139" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(&github.Issue{
+				Number: 5139, State: "open",
+				Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelRetry1}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/5139/events" && r.Method == http.MethodGet:
+			// No labeled/reopened event after the stall — a body edit alone
+			// is not surfaced as a labeled/reopened classic event.
+			_ = json.NewEncoder(w).Encode([]*github.IssueEvent{
+				{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+				{Event: "labeled", CreatedAt: stallTime.Add(-23 * time.Hour), Label: &github.Label{Name: github.LabelRetry1}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/5139/timeline" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]*github.TimelineEvent{
+				{Event: "edited", CreatedAt: editTime, Actor: &github.User{Login: "operator-jane"}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/5139/labels/"+github.LabelBlocked && r.Method == http.MethodDelete:
+			// A successful re-arm always tries to clear pilot-blocked,
+			// regardless of which evidence type triggered it (this fixture
+			// carries pilot-retry-1, not pilot-blocked, but the removal call
+			// still fires unconditionally — see tryRearmStalled).
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5139", "/project-gh5381-timeline-edit"
+	seedStalledRow(t, store, "exec-stalled-timeline-edit", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
+
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rearmed {
+		t.Fatal("expected rearmed=true — a non-bot Timeline 'edited' event postdates the stall")
+	}
+
+	exec, err := store.GetExecution("exec-stalled-timeline-edit")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected the stalled row to be reclassified to status=failed, got %q", exec.Status)
+	}
+}
+
+// TestTryRearmStalled_TimelineEditByBot_NotRearmed proves the actor filter:
+// an "edited" event authored by the bot account itself (e.g. an
+// autopilot-meta footer rewrite) must NOT count as re-arm evidence — this is
+// exactly the class of self-inflicted signal GH-5381 fixes forward from
+// (PR #5380 used issue.UpdatedAt, which can't distinguish the bot's own
+// edits from an operator's).
+func TestTryRearmStalled_TimelineEditByBot_NotRearmed(t *testing.T) {
+	resetBotLoginCacheForTest(t)
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+	editTime := stallTime.Add(30 * time.Minute)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/user" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(&github.User{Login: "pilot-bot"})
+		case r.URL.Path == "/repos/owner/repo/issues/5139" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(&github.Issue{
+				Number: 5139, State: "open",
+				Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/5139/events" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]*github.IssueEvent{
+				{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/5139/timeline" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]*github.TimelineEvent{
+				{Event: "edited", CreatedAt: editTime, Actor: &github.User{Login: "pilot-bot"}},
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5139", "/project-gh5381-timeline-bot-edit"
+	seedStalledRow(t, store, "exec-stalled-timeline-bot-edit", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
+
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rearmed {
+		t.Fatal("expected rearmed=false — the 'edited' event was authored by the bot account itself, not an operator")
+	}
+}
+
+// forceRepickBackoffReady clears key's backoff window so the very next
+// gateStatus/allow check reports not-gated, regardless of how recently a
+// drop was recorded. Test-only: reaches into repickBackoffTracker's
+// unexported fields (same package) to simulate several sweep intervals
+// elapsing without an actual test sleep.
+func forceRepickBackoffReady(key string) {
+	repickBackoff.mu.Lock()
+	defer repickBackoff.mu.Unlock()
+	if e, ok := repickBackoff.entries[key]; ok {
+		e.nextAllowedAt = time.Time{}
+		e.gateLogged = false
+	}
+}
+
+// gh5381EscalationServer is a stateful mock GitHub server shared by
+// TestSweepStalledRearm_NoEvidenceThreeTimes_EscalatesAndStops and
+// TestSweepStalledRearm_ProbeErrorThreeTimes_EscalatesLikeNoEvidence: the
+// served issue's labels grow across calls (AddLabels mutates the same state
+// ListIssues/GetIssue read back), mirroring how a real repo would reflect
+// escalateStalledRearmNoEvidence's own pilot-needs-human application on the
+// very next sweep pass. getIssueFails, when true, makes the per-issue GET
+// error instead of succeeding — simulating a persistent GitHub API outage
+// on the probe call specifically (ListIssues itself still succeeds, exactly
+// like a real partial outage would look from the sweep's perspective).
+type gh5381EscalationServer struct {
+	mu            sync.Mutex
+	labels        []string
+	updatedAt     time.Time
+	events        []*github.IssueEvent
+	getIssueFails bool
+	listCalls     int
+	getCalls      int
+	commentCalls  int
+	addLabelCall  int
+}
+
+func newGH5381EscalationServer(t *testing.T, issueNum int, initialLabels []string, updatedAt time.Time, events []*github.IssueEvent, getIssueFails bool) (*httptest.Server, *gh5381EscalationServer) {
+	t.Helper()
+	state := &gh5381EscalationServer{labels: append([]string{}, initialLabels...), updatedAt: updatedAt, events: events, getIssueFails: getIssueFails}
+
+	issuePath := "/repos/owner/repo/issues/" + strconv.Itoa(issueNum)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		state.mu.Lock()
+		defer state.mu.Unlock()
+
+		labelObjs := make([]github.Label, len(state.labels))
+		for i, l := range state.labels {
+			labelObjs[i] = github.Label{Name: l}
+		}
+
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodGet:
+			state.listCalls++
+			if p := r.URL.Query().Get("page"); p != "1" && p != "" {
+				_ = json.NewEncoder(w).Encode([]*github.Issue{})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]*github.Issue{
+				{Number: issueNum, State: "open", Labels: labelObjs, UpdatedAt: state.updatedAt},
+			})
+		case r.URL.Path == issuePath && r.Method == http.MethodGet:
+			state.getCalls++
+			if state.getIssueFails {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"simulated outage"}`))
+				return
+			}
+			_ = json.NewEncoder(w).Encode(&github.Issue{
+				Number: issueNum, State: "open", Labels: labelObjs, UpdatedAt: state.updatedAt,
+			})
+		case r.URL.Path == issuePath+"/events" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(state.events)
+		case r.URL.Path == issuePath+"/timeline" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]*github.TimelineEvent{})
+		case r.URL.Path == issuePath+"/comments" && r.Method == http.MethodPost:
+			state.commentCalls++
+			_ = json.NewEncoder(w).Encode(&github.Comment{ID: 1})
+		case r.URL.Path == issuePath+"/labels" && r.Method == http.MethodPost:
+			state.addLabelCall++
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			state.labels = append(state.labels, body.Labels...)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, state
+}
+
+// TestSweepStalledRearm_NoEvidenceThreeTimes_EscalatesAndStops is GH-5381's
+// (carried forward from the reverted #5380/GH-5376) backstop acceptance
+// test: a stalled task_id with zero re-arm evidence across repeated sweep
+// passes must stop accumulating claim-lost drops after
+// terminalDropPilotStripThreshold (3) consecutive no-evidence findings,
+// escalate to pilot-needs-human with an explanatory comment instead, and
+// never repeat the escalation or resume probing on subsequent passes.
+func TestSweepStalledRearm_NoEvidenceThreeTimes_EscalatesAndStops(t *testing.T) {
+	resetBotLoginCacheForTest(t)
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+
+	// UpdatedAt/events both predate the stall — no evidence of any kind,
+	// ever, across every sweep pass in this test.
+	srv, state := newGH5381EscalationServer(t, 5346,
+		[]string{"pilot", github.LabelBlocked},
+		stallTime.Add(-2*time.Hour),
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+		},
+		false,
+	)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5346", "/project-gh5381-escalate"
+	seedStalledRow(t, store, "exec-gh5346-stalled", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
+
+	ctx := context.Background()
+
+	// Sweep passes 1 and 2: ordinary no-evidence drops, no escalation yet.
+	for i := 1; i <= 2; i++ {
+		checker.sweepStalledRearm(ctx, projectPath)
+		if _, _, claimLostDrops, _ := repickBackoff.gateDetail(key); claimLostDrops != i {
+			t.Errorf("after sweep pass %d: expected claim_lost_drops=%d, got %d", i, i, claimLostDrops)
+		}
+		state.mu.Lock()
+		comments, addLabels := state.commentCalls, state.addLabelCall
+		state.mu.Unlock()
+		if comments != 0 || addLabels != 0 {
+			t.Fatalf("after sweep pass %d: expected no escalation yet, got comments=%d addLabelCalls=%d", i, comments, addLabels)
+		}
+		forceRepickBackoffReady(key)
+	}
+
+	// Sweep pass 3: the third consecutive no-evidence finding must escalate
+	// instead of recording a third claim-lost drop.
+	checker.sweepStalledRearm(ctx, projectPath)
+	if _, _, claimLostDrops, _ := repickBackoff.gateDetail(key); claimLostDrops != 2 {
+		t.Errorf("expected claim_lost_drops to stay at 2 (no further recordClaimLostDrop call on the escalating pass), got %d", claimLostDrops)
+	}
+	state.mu.Lock()
+	comments, addLabels := state.commentCalls, state.addLabelCall
+	labels := append([]string{}, state.labels...)
+	state.mu.Unlock()
+	if comments != 1 {
+		t.Errorf("expected exactly 1 escalation comment posted, got %d", comments)
+	}
+	if addLabels != 1 {
+		t.Errorf("expected exactly 1 AddLabels call for pilot-needs-human, got %d", addLabels)
+	}
+	if !containsString(labels, labelPilotNeedsHumanSDK) {
+		t.Errorf("expected pilot-needs-human to have been applied, labels=%v", labels)
+	}
+
+	forceRepickBackoffReady(key)
+
+	// Sweep pass 4: the issue now carries pilot-needs-human (reflected by the
+	// stateful mock, exactly like a real repo would show on the next poll),
+	// so the sweep's candidate filter must exclude it entirely — no further
+	// GetIssue probe, no further drop, no repeat escalation.
+	getCallsBefore := state.getCalls
+	checker.sweepStalledRearm(ctx, projectPath)
+	state.mu.Lock()
+	getCallsAfter, commentsAfter, addLabelsAfter := state.getCalls, state.commentCalls, state.addLabelCall
+	state.mu.Unlock()
+	if getCallsAfter != getCallsBefore {
+		t.Errorf("expected no further GetIssue probe once pilot-needs-human is applied, got %d new calls", getCallsAfter-getCallsBefore)
+	}
+	if commentsAfter != 1 || addLabelsAfter != 1 {
+		t.Errorf("expected no repeat escalation, got comments=%d addLabelCalls=%d", commentsAfter, addLabelsAfter)
+	}
+	if _, _, claimLostDrops, _ := repickBackoff.gateDetail(key); claimLostDrops != 2 {
+		t.Errorf("expected claim_lost_drops to remain 2 after the filtered-out pass, got %d", claimLostDrops)
+	}
+
+	exec, err := store.GetExecution("exec-gh5346-stalled")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "stalled" {
+		t.Errorf("expected the row to remain status=stalled throughout (never re-armed), got %q", exec.Status)
+	}
+}
+
+// TestSweepStalledRearm_ProbeErrorThreeTimes_EscalatesLikeNoEvidence is
+// GH-5381's probe-error backstop test (item 3 of the task): a persistent
+// GitHub API failure on the per-issue probe (GetIssue erroring every call,
+// simulating an outage) must feed the SAME no-evidence streak an ordinary
+// "checked, found nothing" result does — three consecutive probe errors
+// escalate to pilot-needs-human exactly like three consecutive no-evidence
+// sweeps, rather than calling recordClaimLostDrop forever with no backstop.
+func TestSweepStalledRearm_ProbeErrorThreeTimes_EscalatesLikeNoEvidence(t *testing.T) {
+	resetBotLoginCacheForTest(t)
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+
+	srv, state := newGH5381EscalationServer(t, 5347,
+		[]string{"pilot", github.LabelBlocked},
+		stallTime.Add(-2*time.Hour),
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+		},
+		true, // every GetIssue call fails
+	)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5347", "/project-gh5381-probe-error"
+	seedStalledRow(t, store, "exec-gh5347-stalled", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
+
+	ctx := context.Background()
+
+	for i := 1; i <= 2; i++ {
+		checker.sweepStalledRearm(ctx, projectPath)
+		state.mu.Lock()
+		comments, addLabels := state.commentCalls, state.addLabelCall
+		state.mu.Unlock()
+		if comments != 0 || addLabels != 0 {
+			t.Fatalf("after sweep pass %d: expected no escalation yet, got comments=%d addLabelCalls=%d", i, comments, addLabels)
+		}
+		forceRepickBackoffReady(key)
+	}
+
+	// Sweep pass 3: the third consecutive probe error must escalate exactly
+	// like the third consecutive no-evidence result would.
+	checker.sweepStalledRearm(ctx, projectPath)
+	state.mu.Lock()
+	comments, addLabels := state.commentCalls, state.addLabelCall
+	labels := append([]string{}, state.labels...)
+	getCalls := state.getCalls
+	state.mu.Unlock()
+	if getCalls != 3 {
+		t.Errorf("expected exactly 3 GetIssue probe attempts, got %d", getCalls)
+	}
+	if comments != 1 {
+		t.Errorf("expected exactly 1 escalation comment posted after 3 consecutive probe errors, got %d", comments)
+	}
+	if addLabels != 1 {
+		t.Errorf("expected exactly 1 AddLabels call for pilot-needs-human, got %d", addLabels)
+	}
+	if !containsString(labels, labelPilotNeedsHumanSDK) {
+		t.Errorf("expected pilot-needs-human to have been applied, labels=%v", labels)
+	}
+
+	exec, err := store.GetExecution("exec-gh5347-stalled")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "stalled" {
+		t.Errorf("expected the row to remain status=stalled throughout (never re-armed), got %q", exec.Status)
+	}
+}
+
+// TestRecordStalledRearmMiss_LabelFailure_StreakNotReset is GH-5381's
+// label-failure-handling test: when the escalation's AddLabels call fails,
+// the no-evidence streak must NOT be reset — otherwise pilot-needs-human
+// never lands (the issue stays a sweep candidate) and the streak silently
+// drops back below threshold, so the very next miss just resumes ordinary
+// claim-lost-drop backoff instead of retrying the label application.
+func TestRecordStalledRearmMiss_LabelFailure_StreakNotReset(t *testing.T) {
+	var commentCalls, addLabelCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/comments") && r.Method == http.MethodPost:
+			commentCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(&github.Comment{ID: 1})
+		case strings.HasSuffix(r.URL.Path, "/labels") && r.Method == http.MethodPost:
+			addLabelCalls++
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"simulated label failure"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	checker := terminalCompletionChecker{
+		ghClient:  github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-9001", "/project-gh5381-label-failure"
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
+
+	ctx := context.Background()
+	// Drive the streak to exactly the escalation threshold.
+	for i := 1; i < terminalDropPilotStripThreshold; i++ {
+		checker.recordStalledRearmMiss(ctx, taskID, 9001, key)
+	}
+	// This miss crosses the threshold and attempts escalation; AddLabels
+	// fails.
+	checker.recordStalledRearmMiss(ctx, taskID, 9001, key)
+	if addLabelCalls != 1 {
+		t.Fatalf("expected 1 AddLabels attempt, got %d", addLabelCalls)
+	}
+	if commentCalls != 1 {
+		t.Fatalf("expected 1 escalation comment attempt, got %d", commentCalls)
+	}
+
+	// The streak must still be at/above threshold, so the very next miss
+	// retries escalation (comment + label) rather than quietly falling back
+	// to recordClaimLostDrop.
+	checker.recordStalledRearmMiss(ctx, taskID, 9001, key)
+	if addLabelCalls != 2 {
+		t.Errorf("expected the label application to be retried on the next miss (streak not reset), got %d AddLabels calls", addLabelCalls)
+	}
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if strings.EqualFold(s, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/pilot/rearm_canceled_test.go
+++ b/cmd/pilot/rearm_canceled_test.go
@@ -16,7 +16,9 @@ import (
 // event list at GET .../issues/{n}/events, and fails the test if any other
 // path is hit — used to prove HasCompletedExecution makes NO GitHub calls at
 // all for genuine completed/no_op rows (only a canceled row should ever be
-// probed).
+// probed). The timeline route always returns an empty list — callers that
+// need GH-5381 Timeline "edited"-event evidence use a custom inline server
+// instead (newRearmTestServer's shared fixture has no case for it).
 func newRearmTestServer(t *testing.T, issue *github.Issue, events []*github.IssueEvent) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -26,6 +28,8 @@ func newRearmTestServer(t *testing.T, issue *github.Issue, events []*github.Issu
 			_ = json.NewEncoder(w).Encode(issue)
 		case r.URL.Path == "/repos/owner/repo/issues/5139/events" && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode(events)
+		case r.URL.Path == "/repos/owner/repo/issues/5139/timeline" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]*github.TimelineEvent{})
 		case r.URL.Path == "/repos/owner/repo/issues/5139/labels/"+github.LabelBlocked && r.Method == http.MethodDelete:
 			// Only exercised by GH-5212 stalled-rearm tests (tryRearmCanceled
 			// never removes labels) — kept here since this fixture is shared.

--- a/cmd/pilot/rearm_stalled.go
+++ b/cmd/pilot/rearm_stalled.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
@@ -115,17 +117,49 @@ func (c terminalCompletionChecker) tryRearmStalled(taskID, projectPath, backoffK
 	if err != nil {
 		return false, fmt.Errorf("listing issue #%d events: %w", issueNum, err)
 	}
-	rearmEvent := latestRearmEvent(events, *exec.CompletedAt, append([]string{c.triggerLabel}, retryReadyRearmLabels...)...)
-	if rearmEvent == nil {
-		// Open + labeled, but nothing in the timeline shows that state was
-		// reached AFTER the stall (neither a base-label relabel/reopen NOR a
-		// pilot-retry-ready/-1/-2 label add) — not a deliberate re-arm
-		// gesture.
+
+	var kind string
+	var evidenceAt time.Time
+	if rearmEvent := latestRearmEvent(events, *exec.CompletedAt, append([]string{c.triggerLabel}, retryReadyRearmLabels...)...); rearmEvent != nil {
+		kind, evidenceAt = rearmEvent.Event, rearmEvent.CreatedAt
+	} else {
+		// GH-5381: no label/reopen evidence found via the classic Events API
+		// — fall back to the Timeline API, the only endpoint that surfaces a
+		// body/title "edited" event at all (confirmed during the GH-5376
+		// incident; the classic Events API never emits one). This is
+		// deliberately NOT issue.UpdatedAt (PR #5380's approach, reverted in
+		// f8532806): UpdatedAt moves on ANY mutation, including the
+		// dispatcher's own stall comment + pilot-blocked label
+		// (surfaceStalledIssue, internal/executor/dispatcher.go), so it
+		// re-armed every stalled task on the very next sweep. An "edited"
+		// timeline event authored by anyone other than the bot itself is a
+		// much narrower, deliberate-operator-gesture signal.
+		timeline, timelineErr := c.ghClient.ListIssueTimeline(ctx, c.repoOwner, c.repoName, issueNum)
+		if timelineErr != nil {
+			return false, fmt.Errorf("listing issue #%d timeline: %w", issueNum, timelineErr)
+		}
+		// Only spend a GetAuthenticatedUser call resolving the bot login
+		// (resolveBotLogin) when there's at least one "edited" event that
+		// could possibly qualify — the common case (no edit at all since the
+		// stall) has nothing to filter by actor, so this skips an API call
+		// on every ordinary no-evidence sweep pass.
+		if hasEditedEventAfter(timeline, *exec.CompletedAt) {
+			botLogin := resolveBotLogin(ctx, c.ghClient)
+			if at, ok := stalledTimelineRearmEvidence(timeline, *exec.CompletedAt, botLogin); ok {
+				kind, evidenceAt = "edited", at
+			}
+		}
+	}
+	if kind == "" {
+		// Open + labeled, but nothing observed shows that state was reached
+		// AFTER the stall (no base-label relabel/reopen, no
+		// pilot-retry-ready/-1/-2 label add, no non-bot body/title edit) —
+		// not a deliberate re-arm gesture.
 		return false, nil
 	}
 
-	reason := fmt.Sprintf("GH-5212: re-armed by issue #%d %s event at %s (stalled at %s)",
-		issueNum, rearmEvent.Event, rearmEvent.CreatedAt.Format(time.RFC3339), exec.CompletedAt.Format(time.RFC3339))
+	reason := fmt.Sprintf("GH-5212: re-armed by issue #%d %s evidence at %s (stalled at %s)",
+		issueNum, kind, evidenceAt.Format(time.RFC3339), exec.CompletedAt.Format(time.RFC3339))
 	if err := c.store.ReclassifyStalledForRearm(taskID, projectPath, reason); err != nil {
 		return false, fmt.Errorf("reclassifying stalled row: %w", err)
 	}
@@ -146,9 +180,103 @@ func (c terminalCompletionChecker) tryRearmStalled(taskID, projectPath, backoffK
 	}
 
 	repickBackoff.recordSuccess(backoffKey)
-	logging.WithComponent("dispatch").Info("GH-5212: stalled task re-armed via GitHub reopen/relabel",
-		slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.String("event", rearmEvent.Event))
+	stalledRearmNoEvidenceStreaks.reset(backoffKey)
+	logging.WithComponent("dispatch").Info("GH-5212: stalled task re-armed via GitHub reopen/relabel/edit",
+		slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.String("evidence", kind))
 	return true, nil
+}
+
+// hasEditedEventAfter reports whether events contains any "edited" entry
+// timestamped after since, with no actor filtering — a cheap pre-check so
+// tryRearmStalled only pays for resolveBotLogin's GetAuthenticatedUser call
+// when there's actually something that could qualify as evidence.
+func hasEditedEventAfter(events []*github.TimelineEvent, since time.Time) bool {
+	for _, ev := range events {
+		if ev != nil && ev.Event == "edited" && ev.CreatedAt.After(since) {
+			return true
+		}
+	}
+	return false
+}
+
+// stalledTimelineRearmEvidence is GH-5381's real body-edit evidence check.
+// GitHub's classic Events API never emits an "edited" event for a body/title
+// edit (the GH-5376 incident and the now-reverted PR #5380 confirmed this —
+// #5380 substituted issue.UpdatedAt instead, which broke worse: the
+// dispatcher's OWN stall comment + pilot-blocked label bump UpdatedAt
+// seconds after CompletedAt, so every stalled task re-armed itself on the
+// very next sweep — see commit f8532806's revert). The Timeline API DOES
+// surface "edited" events, each with an actor, so a genuine operator body
+// edit can be told apart from the bot's own activity by actor login alone —
+// no timestamp heuristic needed.
+//
+// botLogin is the authenticated token identity (resolveBotLogin, cached); an
+// edited event whose actor matches it (case-insensitive) is excluded — it's
+// Pilot's own doing (e.g. an autopilot-meta footer rewrite), never a
+// deliberate operator re-arm gesture. An empty botLogin (resolution failed)
+// accepts NO edited-event evidence this pass — fail closed, since accepting
+// one without an actor filter risks reintroducing exactly the self-re-arm
+// bug this function exists to avoid. Label/reopen evidence (checked first,
+// unconditionally, in tryRearmStalled) is unaffected by this fallback.
+func stalledTimelineRearmEvidence(events []*github.TimelineEvent, since time.Time, botLogin string) (at time.Time, ok bool) {
+	if botLogin == "" {
+		return time.Time{}, false
+	}
+	var latest *github.TimelineEvent
+	for _, ev := range events {
+		if ev == nil || ev.Event != "edited" || !ev.CreatedAt.After(since) {
+			continue
+		}
+		if ev.Actor != nil && strings.EqualFold(ev.Actor.Login, botLogin) {
+			continue
+		}
+		if latest == nil || ev.CreatedAt.After(latest.CreatedAt) {
+			latest = ev
+		}
+	}
+	if latest == nil {
+		return time.Time{}, false
+	}
+	return latest.CreatedAt, true
+}
+
+// botLoginMu/cachedBotLogin/botLoginResolved cache the authenticated GitHub
+// login for the Pilot token, mirroring internal/autopilot.Controller's
+// getBotLogin — package-level here because terminalCompletionChecker is a
+// value type constructed fresh per call (see sweepStalledRearm's doc
+// comment), so an instance-level cache would never survive across sweep
+// passes.
+var (
+	botLoginMu       sync.Mutex
+	cachedBotLogin   string
+	botLoginResolved bool
+)
+
+// resolveBotLogin returns the authenticated GitHub login for client's token,
+// resolved lazily on first call and cached for the process lifetime. Returns
+// "" when it can't be determined (e.g. a transient GetAuthenticatedUser
+// failure); callers must treat that as "exclude nothing can be confirmed
+// safe" — see stalledTimelineRearmEvidence's fail-closed handling.
+func resolveBotLogin(ctx context.Context, client *github.Client) string {
+	botLoginMu.Lock()
+	if botLoginResolved {
+		login := cachedBotLogin
+		botLoginMu.Unlock()
+		return login
+	}
+	botLoginMu.Unlock()
+
+	user, err := client.GetAuthenticatedUser(ctx)
+	if err != nil {
+		logging.WithComponent("dispatch").Warn("GH-5381: could not resolve bot login for edited-event actor exclusion — Timeline edited-event evidence disabled until this succeeds",
+			slog.Any("error", err))
+		return ""
+	}
+	botLoginMu.Lock()
+	cachedBotLogin = user.Login
+	botLoginResolved = true
+	botLoginMu.Unlock()
+	return user.Login
 }
 
 // sweepStalledRearm scans repoOwner/repoName for open issues currently
@@ -199,6 +327,14 @@ func (c terminalCompletionChecker) sweepStalledRearm(ctx context.Context, projec
 			// this sweep needs to spend a probe on.
 			continue
 		}
+		if github.HasLabel(issue, labelPilotNeedsHumanSDK) {
+			// GH-5381: already escalated by escalateStalledRearmNoEvidence
+			// below — an operator must clear pilot-needs-human (and satisfy
+			// tryRearmStalled's evidence check) before this sweep resumes
+			// probing. Without this, the sweep would keep re-probing (and
+			// re-posting the escalation comment) on every pass forever.
+			continue
+		}
 
 		taskID := fmt.Sprintf("GH-%d", issue.Number)
 		backoffKey := repickBackoffKey(projectPath, taskID)
@@ -223,15 +359,131 @@ func (c terminalCompletionChecker) sweepStalledRearm(ctx context.Context, projec
 
 		rearmed, err := c.tryRearmStalled(taskID, projectPath, backoffKey)
 		if err != nil {
+			// GH-5381: a probe error (e.g. a persistent GitHub API outage)
+			// must count toward the no-evidence streak exactly like an
+			// ordinary "no evidence found" result — before this, only the
+			// !rearmed branch below fed the streak, so a GitHub API error
+			// repeating every sweep pass could recordClaimLostDrop forever
+			// without ever reaching the escalation backstop.
 			logging.WithComponent("dispatch").Warn("GH-5212 stalled re-arm probe failed",
 				slog.String("task_id", taskID), slog.Any("error", err))
-			repickBackoff.recordClaimLostDrop(backoffKey)
+			c.recordStalledRearmMiss(ctx, taskID, issue.Number, backoffKey)
 			continue
 		}
-		if !rearmed {
-			repickBackoff.recordClaimLostDrop(backoffKey)
+		if rearmed {
+			continue
 		}
+		c.recordStalledRearmMiss(ctx, taskID, issue.Number, backoffKey)
 	}
+}
+
+// stalledRearmNoEvidenceTracker counts, per repickBackoffKey, how many
+// consecutive sweepStalledRearm passes found no re-arm evidence for that key
+// (GH-5381, carried forward from the reverted #5380) — a probe error and an
+// ordinary "no evidence" result both count via recordStalledRearmMiss.
+// Reset on any successful re-arm (tryRearmStalled returning true) or once
+// escalateStalledRearmNoEvidence successfully applies pilot-needs-human —
+// that label is what actually stops the sweep from revisiting the issue (see
+// the candidate-filter check above); resetting the streak here just keeps
+// this counter from drifting stale if the label is ever cleared without a
+// genuine re-arm.
+//
+// A package-level var (mirroring repickBackoff) since terminalCompletionChecker
+// is constructed fresh per call by runStalledRearmSweepLoop's closure — the
+// streak has to outlive any single sweepStalledRearm call to count "in a
+// row" across sweep passes.
+type stalledRearmNoEvidenceTracker struct {
+	mu      sync.Mutex
+	streaks map[string]int
+}
+
+func newStalledRearmNoEvidenceTracker() *stalledRearmNoEvidenceTracker {
+	return &stalledRearmNoEvidenceTracker{streaks: make(map[string]int)}
+}
+
+// increment bumps key's streak and returns the new count.
+func (t *stalledRearmNoEvidenceTracker) increment(key string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.streaks[key]++
+	return t.streaks[key]
+}
+
+// reset clears key's streak, e.g. after a successful re-arm or an escalation.
+func (t *stalledRearmNoEvidenceTracker) reset(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.streaks, key)
+}
+
+var stalledRearmNoEvidenceStreaks = newStalledRearmNoEvidenceTracker()
+
+// recordStalledRearmMiss is sweepStalledRearm's shared "no evidence this
+// pass" handler — reached both when tryRearmStalled returns a hard error
+// (a GitHub API failure) and when it returns rearmed=false cleanly. Below
+// terminalDropPilotStripThreshold (GH-5297's constant, reused here)
+// consecutive misses, it behaves exactly like the pre-GH-5381 code:
+// recordClaimLostDrop arms the ordinary repick-backoff cooldown. At or past
+// the threshold, it escalates to an operator instead of growing the backoff
+// window forever (GH-5346: 76 claim-lost drops over 33h with no signal,
+// since claim_lost_drops is deliberately excluded from the dispatcher's
+// hard-cap counter).
+func (c terminalCompletionChecker) recordStalledRearmMiss(ctx context.Context, taskID string, issueNum int, backoffKey string) {
+	streak := stalledRearmNoEvidenceStreaks.increment(backoffKey)
+	if streak < terminalDropPilotStripThreshold {
+		repickBackoff.recordClaimLostDrop(backoffKey)
+		return
+	}
+	if c.escalateStalledRearmNoEvidence(ctx, taskID, issueNum, streak) {
+		stalledRearmNoEvidenceStreaks.reset(backoffKey)
+		return
+	}
+	// GH-5381: AddLabels failed — pilot-needs-human never landed, so the
+	// sweep's candidate filter won't exclude this issue and would otherwise
+	// silently resume ordinary claim-lost-drop backoff next pass. Leave the
+	// streak at/above threshold so the very next sweep retries the
+	// escalation (comment + label) instead of quietly falling back.
+}
+
+// escalateStalledRearmNoEvidence posts the explanatory comment and applies
+// pilot-needs-human once sweepStalledRearm has found no re-arm evidence
+// (probe error or clean no-evidence result alike) terminalDropPilotStripThreshold
+// times in a row for the same task_id — the operator-signal backstop the
+// GH-5346 incident (76 claim-lost drops, 33h, no signal) never had. Mirrors
+// GH-5300's stripPilotLabelAndCommentSDK shape but applies pilot-needs-human
+// instead of stripping the trigger label: the sweep's own candidate filter
+// (in sweepStalledRearm above) already excludes pilot-needs-human issues, so
+// applying it here is what makes this a one-shot escalation rather than a
+// per-sweep-pass repeat, without touching pilot-blocked/pilot-retry-ready
+// (which the documented re-arm recipe still expects to manipulate).
+//
+// Returns whether pilot-needs-human was successfully applied — callers must
+// only reset the no-evidence streak on success (see recordStalledRearmMiss):
+// on an AddLabels failure the escalation comment may already have posted,
+// so a retried pass can end up posting a second explanatory comment, an
+// accepted, visible cost against the alternative of a silently stuck
+// escalation that the sweep never retries.
+func (c terminalCompletionChecker) escalateStalledRearmNoEvidence(ctx context.Context, taskID string, issueNum int, streak int) bool {
+	comment := fmt.Sprintf(
+		"⚠️ **Pilot could not confirm this stalled task was re-armed**\n\n"+
+			"This issue was checked %d times with no evidence of a deliberate re-arm gesture since it stalled. "+
+			"Re-arm evidence is any of: re-adding the `%s` label, adding one of `%s`, reopening the issue, "+
+			"or editing the issue body/title as a human (not Pilot itself) — all timestamped after the stall.\n\n"+
+			"Applying `%s` so this stops being silently re-checked. Remove it and repeat one of the above to re-arm.",
+		streak, c.triggerLabel, strings.Join(retryReadyRearmLabels, "`, `"), labelPilotNeedsHumanSDK,
+	)
+	if _, err := c.ghClient.AddComment(ctx, c.repoOwner, c.repoName, issueNum, comment); err != nil {
+		logging.WithComponent("dispatch").Warn("GH-5381: failed to post stalled-no-evidence escalation comment",
+			slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.Any("error", err))
+	}
+	if err := c.ghClient.AddLabels(ctx, c.repoOwner, c.repoName, issueNum, []string{labelPilotNeedsHumanSDK}); err != nil {
+		logging.WithComponent("dispatch").Warn("GH-5381: failed to apply pilot-needs-human after repeated no-evidence sweeps — will retry on the next sweep pass",
+			slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.Any("error", err))
+		return false
+	}
+	logging.WithComponent("dispatch").Warn("GH-5381: stalled re-arm sweep escalated to pilot-needs-human after repeated no-evidence checks",
+		slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.Int("streak", streak))
+	return true
 }
 
 // runStalledRearmSweepLoop drives sweepStalledRearm on the same cadence as

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -306,6 +306,22 @@ type IssueEvent struct {
 	Label *Label `json:"label,omitempty"`
 }
 
+// TimelineEvent represents one entry of a GitHub issue's Timeline API (the
+// `/issues/{number}/timeline` endpoint) — a superset of IssueEvent's classic
+// Events API that additionally surfaces comments, cross-references, and,
+// critically, an "edited" event for body/title edits. GH-5381: the classic
+// Events API (ListIssueEvents/IssueEvent above) never emits "edited" at all
+// (confirmed live during the GH-5376 incident), so a genuine operator
+// body-edit re-arm gesture is only observable via this endpoint. Actor is
+// who performed the action, letting callers tell a bot's own edit (e.g. an
+// autopilot-meta footer write) apart from a deliberate operator edit.
+type TimelineEvent struct {
+	Event     string    `json:"event"`
+	CreatedAt time.Time `json:"created_at"`
+	Actor     *User     `json:"actor,omitempty"`
+	Label     *Label    `json:"label,omitempty"`
+}
+
 // doRequest performs an HTTP request to the GitHub API with automatic retry on
 // transient errors (429, 5xx, network failures). The request body is buffered
 // once before the retry loop so it can be replayed on each attempt.
@@ -421,6 +437,21 @@ func (c *Client) ListIssueComments(ctx context.Context, owner, repo string, numb
 func (c *Client) ListIssueEvents(ctx context.Context, owner, repo string, number int) ([]*IssueEvent, error) {
 	path := fmt.Sprintf("/repos/%s/%s/issues/%d/events?per_page=100", owner, repo, number)
 	var events []*IssueEvent
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &events); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+// ListIssueTimeline returns an issue's Timeline API entries, oldest first —
+// see TimelineEvent's doc comment for why this exists alongside
+// ListIssueEvents rather than replacing it (only this endpoint emits
+// "edited"). Single page at the max per_page (100), same rationale as
+// ListIssueEvents: this is a re-arm probe call gated behind repickBackoff,
+// not a hot poll loop.
+func (c *Client) ListIssueTimeline(ctx context.Context, owner, repo string, number int) ([]*TimelineEvent, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/timeline?per_page=100", owner, repo, number)
+	var events []*TimelineEvent
 	if err := c.doRequest(ctx, http.MethodGet, path, nil, &events); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Fix-forward for PR #5380 (GH-5376), which was already reverted (f8532806)
after autopilot merged it one minute before a REQUEST-CHANGES review
landed. The reverted change treated `issue.updated_at` after
`completed_at` as re-arm evidence — but the dispatcher's own stall
surfacing (comment + `pilot-blocked` label) bumps `updated_at` seconds
after `completed_at`, so every stalled task re-armed itself on the next
sweep, retried, stalled again, and repeated forever (defeating the hard
retry cap, each cycle a paid run).

This PR does **not** reintroduce the `updated_at` fallback. Instead:

- Adds `github.Client.ListIssueTimeline` + `TimelineEvent`. The classic
  Events API never emits `edited` — only the Timeline API does.
- `tryRearmStalled` falls back to a Timeline `edited` event newer than
  `completed_at`, authored by anyone other than the resolved bot account
  (cached via `GetAuthenticatedUser`, mirroring
  `autopilot.Controller.getBotLogin`), and only when label/reopen
  evidence is absent. Fails **closed** (no evidence) if the bot login
  can't be resolved, so a transient API error can never reintroduce the
  self-re-arm bug.
- `recordStalledRearmMiss` unifies the probe-error and no-evidence paths
  in `sweepStalledRearm`, so a persistent GitHub API failure escalates
  through the same `stalledRearmNoEvidenceStreaks` counter as ordinary
  no-evidence sweeps instead of looping unbounded.
- `escalateStalledRearmNoEvidence` only resets the streak when
  `AddLabels` actually succeeds, so a label-apply failure retries
  `pilot-needs-human` on the next sweep pass instead of silently
  resuming backoff without ever escalating.

## Deferred (not fixed)

Item 4 of GH-5376/GH-5381 — suppressing the SDK poller's "completed
execution exists" log line for stalled tasks — is **not** fixed here.
`terminalCompletionChecker` implements the vendored `studio-sdk`
`ExecutionChecker` interface as a plain `(bool, error)` return with no
channel for a reason string, so this can't be addressed from the pilot
side without a `studio-sdk` change. This session's `gh-guard` does not
permit `gh issue create`, so the studio-sdk issue could not be filed
from here — flagging for the next session/operator to file a
`qf-studio/studio-sdk` issue with the `pilot` label.

## Test plan

- [x] `TestTryRearmStalled_BotCommentAndLabelOnly_NotRearmed` — freshly
      stalled task whose only activity is the bot's stall comment +
      `pilot-blocked` label is NOT re-armed.
- [x] `TestTryRearmStalled_TimelineEditByOperator_Rearms` — operator body
      edit (Timeline `edited` by non-bot actor) re-arms within one sweep.
- [x] `TestTryRearmStalled_TimelineEditByBot_NotRearmed` — bot-authored
      edit does not re-arm.
- [x] `TestSweepStalledRearm_ProbeErrorThreeTimes_EscalatesLikeNoEvidence`
      — three consecutive probe errors escalate exactly like three
      no-evidence sweeps.
- [x] `TestRecordStalledRearmMiss_LabelFailure_StreakNotReset` —
      `AddLabels` failure retries the label on the next miss.
- [x] `TestSweepStalledRearm_NoEvidenceThreeTimes_EscalatesAndStops` —
      pre-existing escalation behavior preserved.
- [x] All pre-existing `rearm_stalled_test.go` tests pass unmodified.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...`
      (full repo) all clean/green. `golangci-lint` unavailable in this
      sandbox (no network to fetch transitive deps).