### PR TITLE
GH-5391: fix(autopilot): escalateAndHold must clear SizeGuardHoldActive — a later terminal-cap hold can be revived by the size-guard redrive

### DIFF
--- a/.agent/tasks/gh-5391.md
+++ b/.agent/tasks/gh-5391.md
@@ -1,0 +1,34 @@
+# GH-5391
+
+**Created:** 2026-09-08
+
+## Problem
+
+GitHub Issue GH-5391: fix(autopilot): escalateAndHold must clear SizeGuardHoldActive — a later terminal-cap hold can be revived by the size-guard redrive
+
+## Problem
+
+PR #5387 (issue #5378) added `SizeGuardHoldActive` on `PRState` and `redriveSizeGuardHeldPR`. The field comment in `internal/autopilot/types.go` (~1341) says a fresh `escalateAndHold` supersedes the flag, but `escalateAndHold` in `internal/autopilot/controller.go` (~7597) never clears it.
+
+Scenario: size-guard hold sets the flag → the PR is revived by `redriveFailedPRForBaseRetarget` (which does not clear it) → later the PR hits the iteration cap (terminal, `escalateAndHold`) → the flag is still set → the next push to the branch revives a terminal-cap hold through `redriveSizeGuardHeldPR`.
+
+Also from the review: stale comments at ~7604 and ~7662 still say size-guard holds "stay parked"; `pilot-needs-human` removal in the redrive ignores the `pilot-failed-retry-exhausted` guard used at ~9970.
+
+## Fix
+
+1. In `escalateAndHold`, clear `SizeGuardHoldActive` and `SizeGuardHoldHeadSHA` next to the existing `RebaseHoldActive` handling, and let the size-guard call site set them after the call (or pass a reason so only that site sets the flag).
+2. Update the two stale comments.
+3. In `redriveSizeGuardHeldPR`, honour the `pilot-failed-retry-exhausted` guard before removing `pilot-needs-human`.
+
+## Tests
+
+- Size-guard hold → retarget revive → iteration-cap hold → new head SHA → PR stays `failed`.
+- Existing `TestController_ProcessAllPRs_RedrivesSizeGuardHeldPR` and state-store round trip still green.
+
+## Acceptance
+
+- [ ] A terminal-cap hold can never be revived by the size-guard redrive.
+- [ ] Comments match behaviour.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -7602,8 +7602,22 @@ func (c *Controller) escalateAndHold(ctx context.Context, prState *PRState, reas
 	// GH-4610: narrow re-adoption's re-entry scan to holds it can actually
 	// resolve (a rebase an operator fixed by pushing to the branch) rather
 	// than every StageFailed PR — other holds (CI-fix size guard, rebase-
-	// oscillation cap, CI timeout) stay parked even if their branch moves.
+	// oscillation cap, CI timeout) stay parked through a branch push alone;
+	// only a fresh escalateAndHold call (this one) or the size guard's own
+	// redrive can clear them.
 	prState.RebaseHoldActive = slices.Contains(labels, labelNeedsManualRebase)
+	// GH-5391: a fresh escalateAndHold call always supersedes any prior
+	// size-guard hold, exactly like RebaseHoldActive above — this function is
+	// the terminal rung for every unrelated hold reason (iteration cap,
+	// review cap, rebase failed, CI timeout, etc.), so leaving a stale
+	// SizeGuardHoldActive/SizeGuardHoldHeadSHA standing from an earlier hold
+	// let redriveSizeGuardHeldPR revive a later, unrelated terminal hold on
+	// the next branch push. The CI-fix size guard call site (below,
+	// controller.go ~3762) re-sets both fields immediately after this call
+	// returns, so this clear only ever removes a flag this call itself isn't
+	// setting.
+	prState.SizeGuardHoldActive = false
+	prState.SizeGuardHoldHeadSHA = ""
 
 	if prState.IssueNumber > 0 {
 		allLabels := append([]string{labelNeedsHuman}, labels...)
@@ -7659,12 +7673,14 @@ const maxReadoptAttempts = 2
 // Detection rides the existing PR poll in processAllPRs: compare the stored
 // HeadSHA against the freshly-fetched ghPR head. A changed SHA on a PR held
 // specifically via RebaseHoldActive (not any other StageFailed reason — CI-
-// fix size guard, rebase-oscillation cap, CI timeout, etc. all stay parked)
-// means someone pushed a fix, so re-enter the pipeline at StageWaitingCI for
-// fresh CI on the new head. MergeAttempts/RebaseAttempts are preserved (not
-// reset) so their own caps still apply if the PR conflicts again; the
-// external-merge scan (checkExternalMergeOrClose) remains the fallback for
-// PRs an operator merges by hand instead of pushing a fix.
+// fix size guard, rebase-oscillation cap, CI timeout, etc. all stay parked
+// through a branch push alone, though a fresh escalateAndHold call clears a
+// stale SizeGuardHoldActive flag regardless — GH-5391) means someone pushed
+// a fix, so re-enter the pipeline at StageWaitingCI for fresh CI on the new
+// head. MergeAttempts/RebaseAttempts are preserved (not reset) so their own
+// caps still apply if the PR conflicts again; the external-merge scan
+// (checkExternalMergeOrClose) remains the fallback for PRs an operator
+// merges by hand instead of pushing a fix.
 func (c *Controller) reAdoptHeldRebasePR(ctx context.Context, prState *PRState, ghPR *github.PullRequest) {
 	if ghPR == nil || prState.Stage != StageFailed || !prState.RebaseHoldActive {
 		return
@@ -7841,7 +7857,23 @@ func (c *Controller) redriveSizeGuardHeldPR(ctx context.Context, prState *PRStat
 	prState.Error = ""
 	prState.TerminalLabel = ""
 
-	c.mutateIssueLabels(ctx, prState.IssueNumber, nil, []string{labelNeedsHuman})
+	// GH-5391/GH-5099: mirror the exhaustion-outranks-close-supersedes-hold
+	// guard used at the external-close label site (controller.go ~9970) — an
+	// issue already parked at pilot-failed-retry-exhausted has a spent retry
+	// budget, a stronger signal than this hold, so a branch push that merely
+	// resolves the size-guard failure must not silently strip
+	// pilot-needs-human and un-park an issue Pilot has already given up on.
+	removeLabels := []string{labelNeedsHuman}
+	if prState.IssueNumber > 0 {
+		if issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, prState.IssueNumber); err != nil {
+			c.log.Warn("redriveSizeGuardHeldPR: failed to fetch issue, leaving pilot-needs-human unchanged", "pr", prState.PRNumber, "issue", prState.IssueNumber, "error", err)
+			removeLabels = nil
+		} else if github.HasLabel(issue, github.LabelFailedRetryExhausted) {
+			c.log.Info("redriveSizeGuardHeldPR: pilot-failed-retry ladder already exhausted, leaving pilot-needs-human standing", "pr", prState.PRNumber, "issue", prState.IssueNumber)
+			removeLabels = nil
+		}
+	}
+	c.mutateIssueLabels(ctx, prState.IssueNumber, nil, removeLabels)
 
 	c.log.Info("redriveSizeGuardHeldPR: branch updated on size-guard-held PR, re-entering pipeline",
 		"pr", prState.PRNumber, "issue", prState.IssueNumber,

--- a/internal/autopilot/gh5391_test.go
+++ b/internal/autopilot/gh5391_test.go
@@ -1,0 +1,181 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestEscalateAndHold_ClearsSizeGuardHold is the direct unit-level regression
+// for GH-5391: PR #5387 (GH-5378) added SizeGuardHoldActive/HeadSHA but
+// escalateAndHold never cleared them, even though its own field comment
+// (types.go) already promised "a fresh escalateAndHold call supersedes it".
+// A PR previously held by the CI-fix size guard that later reaches an
+// unrelated terminal hold (iteration cap, review cap, rebase failed, etc.)
+// must not carry the stale flag forward — otherwise a later branch push
+// wrongly revives the NEW, unrelated hold through redriveSizeGuardHeldPR.
+func TestEscalateAndHold_ClearsSizeGuardHold(t *testing.T) {
+	rec, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:             5356,
+		IssueNumber:          5351,
+		HeadSHA:              "sha-A",
+		Stage:                StageFailed,
+		Error:                "CI fix size guard fired",
+		SizeGuardHoldActive:  true,
+		SizeGuardHoldHeadSHA: "sha-A",
+	}
+
+	c.escalateAndHold(context.Background(), prState, "CI fix iteration limit reached (3/3)", []string{labelNeedsHuman}, "iteration cap hit")
+
+	if prState.SizeGuardHoldActive {
+		t.Error("SizeGuardHoldActive should be cleared by a fresh escalateAndHold call")
+	}
+	if prState.SizeGuardHoldHeadSHA != "" {
+		t.Errorf("SizeGuardHoldHeadSHA = %q, want empty after a fresh escalateAndHold call", prState.SizeGuardHoldHeadSHA)
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %v, want StageFailed", prState.Stage)
+	}
+	_ = rec
+}
+
+// TestGH5391_TerminalCapHoldSurvivesSizeGuardRedrive covers the exact
+// scenario from the issue: a size-guard hold gets revived by a base
+// retarget (redriveFailedPRForBaseRetarget, which has no reason to touch
+// SizeGuardHoldActive), the PR then hits the iteration cap and is
+// terminally held again via escalateAndHold, and only THEN does a new
+// commit land on the branch. Before the GH-5391 fix, the stale
+// SizeGuardHoldActive flag from the original size-guard hold would let
+// redriveSizeGuardHeldPR revive the unrelated, terminal iteration-cap hold.
+// After the fix, escalateAndHold's clear means the flag is already gone by
+// the time the new commit is observed, so the PR stays parked at
+// StageFailed.
+func TestGH5391_TerminalCapHoldSurvivesSizeGuardRedrive(t *testing.T) {
+	rec, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:             5356,
+		IssueNumber:          5351,
+		HeadSHA:              "sha-A",
+		TargetBranch:         "stale-base",
+		Stage:                StageFailed,
+		Error:                "CI fix size guard fired",
+		SizeGuardHoldActive:  true,
+		SizeGuardHoldHeadSHA: "sha-A",
+	}
+
+	// Step 1: GitHub has since retargeted the PR back to the default branch
+	// ("main", DefaultConfig's fallback) — redriveFailedPRForBaseRetarget
+	// revives it to StageWaitingCI but has no size-guard-specific knowledge,
+	// so it must not touch SizeGuardHoldActive either way.
+	retargetedPR := &github.PullRequest{Number: 5356, Head: github.PRRef{SHA: "sha-A"}, Base: github.PRRef{Ref: "main"}}
+	c.redriveFailedPRForBaseRetarget(context.Background(), prState, retargetedPR)
+
+	if prState.Stage != StageWaitingCI {
+		t.Fatalf("after retarget revive: Stage = %v, want StageWaitingCI", prState.Stage)
+	}
+	if !prState.SizeGuardHoldActive {
+		t.Fatal("after retarget revive: SizeGuardHoldActive should still be set — redriveFailedPRForBaseRetarget has no reason to clear it")
+	}
+
+	// Step 2: the PR fails again, this time hitting the iteration cap — a
+	// fresh, unrelated terminal hold via escalateAndHold.
+	c.escalateAndHold(context.Background(), prState, "CI fix iteration limit reached (3/3)", []string{labelNeedsHuman}, "iteration cap hit")
+
+	if prState.Stage != StageFailed {
+		t.Fatalf("after iteration-cap hold: Stage = %v, want StageFailed", prState.Stage)
+	}
+	if prState.SizeGuardHoldActive {
+		t.Fatal("after iteration-cap hold: SizeGuardHoldActive must be cleared by the fresh escalateAndHold call (GH-5391)")
+	}
+
+	// Step 3: a new commit lands on the branch. Before the fix, the stale
+	// SizeGuardHoldActive flag would let this call wrongly revive the
+	// terminal iteration-cap hold. After the fix, the flag is already
+	// cleared, so redriveSizeGuardHeldPR is a no-op and the PR stays failed.
+	newPush := &github.PullRequest{Number: 5356, Head: github.PRRef{SHA: "sha-B"}}
+	c.redriveSizeGuardHeldPR(context.Background(), prState, newPush)
+
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %v, want StageFailed — a terminal-cap hold must never be revived by the size-guard redrive", prState.Stage)
+	}
+	if prState.Error != "CI fix iteration limit reached (3/3)" {
+		t.Errorf("Error = %q, want the iteration-cap reason preserved (not silently cleared)", prState.Error)
+	}
+	_ = rec
+}
+
+// TestRedriveSizeGuardHeldPR_HonoursRetryExhaustedGuard covers the third fix
+// in GH-5391: redriveSizeGuardHeldPR's pilot-needs-human removal must defer
+// to an issue already parked at pilot-failed-retry-exhausted (GH-5099's
+// exhaustion-outranks-close-supersedes-hold rule, mirrored here from the
+// external-close label site at controller.go ~9970) — a spent retry budget
+// is a stronger signal than the size-guard hold this function resolves, so
+// the redrive must not silently un-park an issue Pilot has already given up
+// on, even though the PR itself is free to re-enter CI.
+func TestRedriveSizeGuardHeldPR_HonoursRetryExhaustedGuard(t *testing.T) {
+	var labelDeletes int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/5351":
+			resp := github.Issue{
+				Number: 5351,
+				State:  "open",
+				Labels: []github.Label{{Name: github.LabelFailedRetryExhausted}, {Name: labelNeedsHuman}},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/issues/5351/labels/"+labelNeedsHuman:
+			labelDeletes++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:             5356,
+		IssueNumber:          5351,
+		HeadSHA:              "old-sha",
+		Stage:                StageFailed,
+		Error:                "CI fix size guard fired",
+		SizeGuardHoldActive:  true,
+		SizeGuardHoldHeadSHA: "old-sha",
+	}
+
+	ghPR := &github.PullRequest{Number: 5356, Head: github.PRRef{SHA: "new-sha"}}
+	c.redriveSizeGuardHeldPR(context.Background(), prState, ghPR)
+
+	// The PR itself still re-enters the pipeline — only the issue label is
+	// exempted.
+	if prState.Stage != StageWaitingCI {
+		t.Errorf("Stage = %v, want StageWaitingCI (branch update still re-enters CI)", prState.Stage)
+	}
+	if prState.SizeGuardHoldActive {
+		t.Error("SizeGuardHoldActive should still be cleared once redriven")
+	}
+	if labelDeletes != 0 {
+		t.Errorf("pilot-needs-human removal calls = %d, want 0 — pilot-failed-retry-exhausted must keep it standing", labelDeletes)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5391.

Closes #5391

## Changes

GitHub Issue GH-5391: fix(autopilot): escalateAndHold must clear SizeGuardHoldActive — a later terminal-cap hold can be revived by the size-guard redrive

## Problem

PR #5387 (issue #5378) added `SizeGuardHoldActive` on `PRState` and `redriveSizeGuardHeldPR`. The field comment in `internal/autopilot/types.go` (~1341) says a fresh `escalateAndHold` supersedes the flag, but `escalateAndHold` in `internal/autopilot/controller.go` (~7597) never clears it.

Scenario: size-guard hold sets the flag → the PR is revived by `redriveFailedPRForBaseRetarget` (which does not clear it) → later the PR hits the iteration cap (terminal, `escalateAndHold`) → the flag is still set → the next push to the branch revives a terminal-cap hold through `redriveSizeGuardHeldPR`.

Also from the review: stale comments at ~7604 and ~7662 still say size-guard holds "stay parked"; `pilot-needs-human` removal in the redrive ignores the `pilot-failed-retry-exhausted` guard used at ~9970.

## Fix

1. In `escalateAndHold`, clear `SizeGuardHoldActive` and `SizeGuardHoldHeadSHA` next to the existing `RebaseHoldActive` handling, and let the size-guard call site set them after the call (or pass a reason so only that site sets the flag).
2. Update the two stale comments.
3. In `redriveSizeGuardHeldPR`, honour the `pilot-failed-retry-exhausted` guard before removing `pilot-needs-human`.

## Tests

- Size-guard hold → retarget revive → iteration-cap hold → new head SHA → PR stays `failed`.
- Existing `TestController_ProcessAllPRs_RedrivesSizeGuardHeldPR` and state-store round trip still green.

## Acceptance

- [ ] A terminal-cap hold can never be revived by the size-guard redrive.
- [ ] Comments match behaviour.