### PR TITLE
GH-5390: fix(handlers): autopilot-meta footer regex matches anywhere in the body — a pilot issue that quotes the footer in backticks is dispatched onto that branch

### DIFF
--- a/.agent/tasks/gh-5390.md
+++ b/.agent/tasks/gh-5390.md
@@ -1,0 +1,33 @@
+# GH-5390
+
+**Created:** 2026-09-08
+
+## Problem
+
+GitHub Issue GH-5390: fix(handlers): autopilot-meta footer regex matches anywhere in the body — a pilot issue that quotes the footer in backticks is dispatched onto that branch
+
+## Problem
+
+Since PR #5384 the `<!-- autopilot-meta branch:… pr:… -->` footer sets the task branch for any `pilot` issue, no longer gated by the `autopilot-fix` label. The parser in `cmd/pilot/handlers.go` (~56, `parseAutopilotBranch` and siblings) uses `<!-- autopilot-meta branch:(\S+).*?-->` on the whole body: it matches inside backticks and code fences and does no branch validation. Checked on issue #5379's own body, which quotes the footer with placeholders: it parses `branch="…"`, `pr=0`. Any bug report or task doc that quotes the format (this issue included, which is why the example below is described in words) would be dispatched onto a bogus branch.
+
+## Fix
+
+1. Only accept the footer when it is on its own line and is the last non-empty line of the body (the documented placement), outside code spans/fences (strip fenced blocks and inline code before matching).
+2. Validate the branch: must start with `pilot/` and contain only ref-safe characters; `pr` and `sha` must be numeric / 7-40 hex. Reject otherwise and log at Warn with the offending value, falling back to the default `pilot/GH-<issue>` branch.
+3. Delete the stale comment at ~785 that references the removed `handleGitHubIssueWithResult`.
+
+## Tests
+
+- Body with the footer quoted in backticks mid-body → default branch.
+- Body with the footer inside a fenced block → default branch.
+- Body with a valid footer as the last line → footer branch.
+- Footer with an invalid branch value (placeholder text) → default branch + Warn.
+
+## Acceptance
+
+- [x] Quoted or fenced footers never change the branch.
+- [x] Valid last-line footers still work with `--from-pr` and the SHA fallback.
+- [x] Existing handler tests green.
+
+## Acceptance Criteria
+

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -49,37 +49,130 @@ func resolveProjectBaseBranch(cfg *config.Config, projectPath string) string {
 	return cfg.FindProjectByPath(projectPath).ResolveBaseBranch()
 }
 
-// parseAutopilotBranch extracts the target branch from an autopilot-fix issue's metadata comment.
-// Returns empty string if no metadata found.
-// Supports both old format (branch:X) and new format (branch:X pr:N).
-func parseAutopilotBranch(body string) string {
-	re := regexp.MustCompile(`<!-- autopilot-meta branch:(\S+).*?-->`)
-	if m := re.FindStringSubmatch(body); len(m) > 1 {
-		return m[1]
+var (
+	// fencedCodeBlockRe strips ```...``` fenced code blocks (DOTALL) so a
+	// footer quoted inside one is never mistaken for the real trailing
+	// marker (GH-5390).
+	fencedCodeBlockRe = regexp.MustCompile("(?s)```.*?```")
+
+	// inlineCodeSpanRe strips single-line `...` inline code spans so a
+	// footer quoted inline (e.g. a bug report describing the format) is
+	// never mistaken for the real trailing marker (GH-5390).
+	inlineCodeSpanRe = regexp.MustCompile("`[^`\n]*`")
+
+	// autopilotMetaFooterLineRe matches the autopilot-meta HTML comment only
+	// when it is the *entire* content of a line (after trimming).
+	autopilotMetaFooterLineRe = regexp.MustCompile(`^<!-- autopilot-meta(.*)-->$`)
+
+	autopilotBranchFieldRe    = regexp.MustCompile(`\bbranch:(\S+)`)
+	autopilotPRFieldRe        = regexp.MustCompile(`\bpr:(\d+)`)
+	autopilotIterationFieldRe = regexp.MustCompile(`\biteration:(\d+)`)
+	autopilotSHAFieldRe       = regexp.MustCompile(`\bsha:(\S+)`)
+
+	// autopilotBranchCharsRe is the ref-safe character set a parsed branch
+	// value must be restricted to (GH-5390).
+	autopilotBranchCharsRe = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+)
+
+// extractAutopilotMetaFooter returns the raw `<!-- autopilot-meta ... -->`
+// comment text, but only when it is the last non-empty line of the body
+// (the documented placement) and lies outside any fenced code block or
+// inline code span. Returns "" otherwise.
+//
+// GH-5390: before this gate, the field regexes matched `<!-- autopilot-meta
+// ... -->` anywhere in the body with no positional or validation
+// constraints. An issue that merely quotes the documented footer format —
+// in backticks, in a fenced code block, or as a placeholder example, the
+// way a bug report or task doc naturally would — was parsed as if it
+// carried a real footer and got dispatched onto that bogus branch (this
+// issue's own body is an instance of the failure mode it describes).
+func extractAutopilotMetaFooter(body string) string {
+	stripped := fencedCodeBlockRe.ReplaceAllString(body, "")
+	stripped = inlineCodeSpanRe.ReplaceAllString(stripped, "")
+
+	lines := strings.Split(stripped, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if autopilotMetaFooterLineRe.MatchString(line) {
+			return line
+		}
+		// The last non-empty line isn't the footer — not the documented
+		// placement, so nothing earlier in the body counts either.
+		return ""
 	}
 	return ""
+}
+
+// isValidAutopilotBranch reports whether branch is a plausible pilot branch
+// name: it must start with "pilot/" and use only ref-safe characters
+// (GH-5390). Without this check, descriptive or placeholder text quoted
+// from the documented footer format (e.g. a literal "pilot/GH-<issue>" in
+// a bug report) would be accepted as a real git ref.
+func isValidAutopilotBranch(branch string) bool {
+	if !strings.HasPrefix(branch, "pilot/") {
+		return false
+	}
+	if strings.Contains(branch, "..") || strings.HasSuffix(branch, "/") || strings.HasSuffix(branch, ".lock") {
+		return false
+	}
+	return autopilotBranchCharsRe.MatchString(branch)
+}
+
+// parseAutopilotBranch extracts the target branch from an autopilot-fix issue's metadata comment.
+// Returns empty string if no metadata found, if the footer isn't the last
+// non-empty line of the body, or if the parsed branch value fails
+// isValidAutopilotBranch (logged at Warn — GH-5390).
+// Supports both old format (branch:X) and new format (branch:X pr:N).
+func parseAutopilotBranch(body string) string {
+	footer := extractAutopilotMetaFooter(body)
+	if footer == "" {
+		return ""
+	}
+	m := autopilotBranchFieldRe.FindStringSubmatch(footer)
+	if len(m) < 2 {
+		return ""
+	}
+	branch := m[1]
+	if !isValidAutopilotBranch(branch) {
+		logging.WithComponent("github").Warn("autopilot-meta footer branch failed validation, falling back to default branch",
+			slog.String("branch", branch),
+		)
+		return ""
+	}
+	return branch
 }
 
 // parseAutopilotPR extracts the PR number from an autopilot-fix issue's metadata comment.
 // Returns 0 if no PR metadata found. Used for --from-pr session resumption (GH-1267).
 func parseAutopilotPR(body string) int {
-	re := regexp.MustCompile(`<!-- autopilot-meta.*?pr:(\d+).*?-->`)
-	if m := re.FindStringSubmatch(body); len(m) > 1 {
-		n, _ := strconv.Atoi(m[1])
-		return n
+	footer := extractAutopilotMetaFooter(body)
+	if footer == "" {
+		return 0
 	}
-	return 0
+	m := autopilotPRFieldRe.FindStringSubmatch(footer)
+	if len(m) < 2 {
+		return 0
+	}
+	n, _ := strconv.Atoi(m[1])
+	return n
 }
 
 // parseAutopilotIteration extracts the CI fix iteration counter from an issue's metadata comment.
 // Returns 0 if no iteration metadata found (GH-1566).
 func parseAutopilotIteration(body string) int {
-	re := regexp.MustCompile(`<!-- autopilot-meta.*?iteration:(\d+).*?-->`)
-	if m := re.FindStringSubmatch(body); len(m) > 1 {
-		n, _ := strconv.Atoi(m[1])
-		return n
+	footer := extractAutopilotMetaFooter(body)
+	if footer == "" {
+		return 0
 	}
-	return 0
+	m := autopilotIterationFieldRe.FindStringSubmatch(footer)
+	if len(m) < 2 {
+		return 0
+	}
+	n, _ := strconv.Atoi(m[1])
+	return n
 }
 
 // parseAutopilotSHA extracts the original PR's full head commit SHA from an
@@ -101,8 +194,11 @@ func parseAutopilotIteration(body string) int {
 // the worktree can be recreated from that exact commit even with the branch
 // gone — see ResolveFixContinuationBaseRef.
 func parseAutopilotSHA(body string) string {
-	re := regexp.MustCompile(`<!-- autopilot-meta.*?sha:(\S+).*?-->`)
-	m := re.FindStringSubmatch(body)
+	footer := extractAutopilotMetaFooter(body)
+	if footer == "" {
+		return ""
+	}
+	m := autopilotSHAFieldRe.FindStringSubmatch(footer)
 	if len(m) < 2 {
 		return ""
 	}
@@ -782,14 +878,15 @@ func handleAzureDevOpsIssueWithResult(ctx context.Context, cfg *config.Config, e
 }
 
 // handleGithubIssueEventSDK processes a GitHub issue delivered as a studio-sdk core.IssueEvent
-// (M7 Phase 4a). It runs ALONGSIDE the legacy in-tree handleGitHubIssueWithResult (which takes a
-// *github.Issue) and is exercised only when the dormant SDK poller is enabled
-// (adapters.github.use_sdk_poller — see cmd/pilot/poller_github.go).
+// (M7 Phase 4a). The GitHub adapter always uses the studio-sdk poller now (the
+// legacy in-tree GitHub poller/handler was removed; adapters.github.use_sdk_poller
+// is deprecated and ignored — see internal/config/config.go), so this is the sole
+// GitHub issue handler.
 //
 // ev.SequenceID is already "GH-42" (prefixed by the SDK adapter) — used verbatim as the task ID to
-// avoid the GH-GH-42 double-prefix the legacy handler's fmt.Sprintf("GH-%d", ...) would create.
+// avoid a GH-GH-42 double-prefix.
 // Board sync is handled at the SDK-poller level (config-driven); the spec-guard gate runs below
-// (M7 4d.3). Sub-issue handling remains exclusive to the legacy in-tree handler until later phases.
+// (M7 4d.3).
 func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkcore.IssueEvent, projectPath string, repoFullName string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer, metrics *autopilot.Metrics) (*sdkcore.IssueResult, error) {
 	taskID := ev.SequenceID // "GH-42"; already prefixed by the SDK adapter — do NOT re-prefix
 	title := ev.Title

--- a/cmd/pilot/main_test.go
+++ b/cmd/pilot/main_test.go
@@ -340,6 +340,48 @@ func TestParseAutopilotBranch(t *testing.T) {
 			body: "<!-- autopilot-meta branch:pilot/GH-123",
 			want: "",
 		},
+		{
+			// GH-5390: a footer quoted inline in backticks mid-body (e.g. a
+			// bug report describing the format, like #5379's own body) must
+			// never be parsed as a real footer.
+			name: "footer quoted in backticks mid-body",
+			body: "This bug happens when the body contains `<!-- autopilot-meta branch:pilot/GH-999 pr:1 -->` inline.\n",
+			want: "",
+		},
+		{
+			// GH-5390: a footer quoted inside a fenced code block (e.g. a
+			// doc example) must never be parsed as a real footer.
+			name: "footer inside a fenced code block",
+			body: "Doc example of the format:\n\n```\n<!-- autopilot-meta branch:pilot/GH-999 pr:1 -->\n```\n",
+			want: "",
+		},
+		{
+			// GH-5390: the footer must be the last non-empty line, not just
+			// anywhere in the body.
+			name: "footer not on last line",
+			body: "<!-- autopilot-meta branch:pilot/GH-999 pr:1 -->\n\nSome trailing prose after the footer.\n",
+			want: "",
+		},
+		{
+			// GH-5390: a placeholder/descriptive branch value (not a real
+			// ref — contains "<" and ">") must be rejected even though it's
+			// on the documented last line.
+			name: "invalid branch value - placeholder text",
+			body: "Please fix the failing check.\n\n<!-- autopilot-meta branch:pilot/GH-<issue> pr:0 -->\n",
+			want: "",
+		},
+		{
+			// GH-5390: a branch value that doesn't start with "pilot/" is
+			// rejected even though the footer is well-formed and last.
+			name: "invalid branch value - missing pilot/ prefix",
+			body: "<!-- autopilot-meta branch:some-other-branch pr:1 -->",
+			want: "",
+		},
+		{
+			name: "valid footer as last line",
+			body: "Please fix the failing check.\n\n<!-- autopilot-meta branch:pilot/GH-5379 pr:5361 -->",
+			want: "pilot/GH-5379",
+		},
 	}
 
 	for _, tt := range tests {
@@ -349,6 +391,38 @@ func TestParseAutopilotBranch(t *testing.T) {
 				t.Errorf("parseAutopilotBranch() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestParseAutopilotBranch_InvalidValueWarns covers the GH-5390 requirement
+// that an invalid footer branch value is not just silently dropped but
+// logged at Warn with the offending value, so a bad footer is diagnosable.
+func TestParseAutopilotBranch_InvalidValueWarns(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "warn.log")
+	if err := logging.Init(&logging.Config{Level: "warn", Format: "text", Output: logPath}); err != nil {
+		t.Fatalf("logging.Init: %v", err)
+	}
+	t.Cleanup(func() { _ = logging.Init(logging.DefaultConfig()) })
+
+	readLog := func() string {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return ""
+			}
+			t.Fatalf("ReadFile: %v", err)
+		}
+		return string(data)
+	}
+
+	body := "Please fix the failing check.\n\n<!-- autopilot-meta branch:pilot/GH-<issue> pr:0 -->\n"
+	if got := parseAutopilotBranch(body); got != "" {
+		t.Fatalf("parseAutopilotBranch() = %q, want empty (invalid branch)", got)
+	}
+	got := readLog()
+	if !strings.Contains(got, "autopilot-meta footer branch failed validation") || !strings.Contains(got, "pilot/GH-<issue>") {
+		t.Errorf("invalid branch value should warn with the offending value, got log:\n%s", got)
 	}
 }
 
@@ -384,9 +458,12 @@ func TestParseAutopilotPR(t *testing.T) {
 			want: 0,
 		},
 		{
-			name: "multiple metadata comments - first match wins",
+			// GH-5390: only the last non-empty line of the body is honored as
+			// the footer now, so an earlier footer-shaped line is inert prose
+			// and the trailing one wins — not "first match" as before the fix.
+			name: "multiple metadata comments - only the last line counts",
 			body: "<!-- autopilot-meta branch:pilot/GH-1 pr:100 -->\nSome text\n<!-- autopilot-meta branch:pilot/GH-2 pr:200 -->",
-			want: 100,
+			want: 200,
 		},
 		{
 			name: "malformed - no closing comment",
@@ -461,6 +538,32 @@ func TestResolveAutopilotFixBranch(t *testing.T) {
 			name:        "autopilot-fix label without a footer does not match",
 			labels:      []string{"pilot", "autopilot-fix"},
 			body:        "No metadata comment here.",
+			wantMatched: false,
+		},
+		{
+			// GH-5390 regression: a `pilot`-labeled issue that merely quotes
+			// the footer format in backticks (the way this very issue's body
+			// does, to describe the bug) must not be dispatched onto that
+			// quoted branch — it must fall back to the default branch.
+			name:        "footer quoted in backticks does not match",
+			labels:      []string{"pilot"},
+			body:        "The parser matches `<!-- autopilot-meta branch:pilot/GH-5379 pr:0 -->` anywhere in the body, which is the bug.",
+			wantMatched: false,
+		},
+		{
+			// GH-5390 regression: a footer quoted inside a fenced code block
+			// (e.g. a task doc showing the format) must not match either.
+			name:        "footer inside fenced block does not match",
+			labels:      []string{"pilot"},
+			body:        "Example footer:\n\n```\n<!-- autopilot-meta branch:pilot/GH-5379 pr:0 -->\n```\n",
+			wantMatched: false,
+		},
+		{
+			// GH-5390 regression: an invalid/placeholder branch value on the
+			// documented last line is rejected, falling back to default.
+			name:        "invalid branch value falls back to default",
+			labels:      []string{"pilot"},
+			body:        "Please fix the failing check.\n\n<!-- autopilot-meta branch:pilot/GH-<issue> pr:0 -->\n",
 			wantMatched: false,
 		},
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5390.

Closes #5390

## Changes

GitHub Issue GH-5390: fix(handlers): autopilot-meta footer regex matches anywhere in the body — a pilot issue that quotes the footer in backticks is dispatched onto that branch

## Problem

Since PR #5384 the `<!-- autopilot-meta branch:… pr:… -->` footer sets the task branch for any `pilot` issue, no longer gated by the `autopilot-fix` label. The parser in `cmd/pilot/handlers.go` (~56, `parseAutopilotBranch` and siblings) uses `<!-- autopilot-meta branch:(\S+).*?-->` on the whole body: it matches inside backticks and code fences and does no branch validation. Checked on issue #5379's own body, which quotes the footer with placeholders: it parses `branch="…"`, `pr=0`. Any bug report or task doc that quotes the format (this issue included, which is why the example below is described in words) would be dispatched onto a bogus branch.

## Fix

1. Only accept the footer when it is on its own line and is the last non-empty line of the body (the documented placement), outside code spans/fences (strip fenced blocks and inline code before matching).
2. Validate the branch: must start with `pilot/` and contain only ref-safe characters; `pr` and `sha` must be numeric / 7-40 hex. Reject otherwise and log at Warn with the offending value, falling back to the default `pilot/GH-<issue>` branch.
3. Delete the stale comment at ~785 that references the removed `handleGitHubIssueWithResult`.

## Tests

- Body with the footer quoted in backticks mid-body → default branch.
- Body with the footer inside a fenced block → default branch.
- Body with a valid footer as the last line → footer branch.
- Footer with an invalid branch value (placeholder text) → default branch + Warn.

## Acceptance

- [ ] Quoted or fenced footers never change the branch.
- [ ] Valid last-line footers still work with `--from-pr` and the SHA fallback.
- [ ] Existing handler tests green.