### PR TITLE
fix(rearm): body-edit re-arm via GraphQL lastEditedAt, not Timeline edited events

### DIFF
--- a/cmd/pilot/gh5381_stalled_rearm_test.go
+++ b/cmd/pilot/gh5381_stalled_rearm_test.go
@@ -15,28 +15,6 @@ import (
 	"github.com/qf-studio/pilot/internal/testutil"
 )
 
-// resetBotLoginCacheForTest clears resolveBotLogin's package-level cache —
-// without this, whichever test in this package resolves a bot login first
-// would leak that login into every later test's resolveBotLogin call
-// (cachedBotLogin/botLoginResolved are cached for the process lifetime by
-// design, since terminalCompletionChecker has no field to hold it — see
-// resolveBotLogin's doc comment). Each test that exercises Timeline
-// edited-event evidence must start from a clean cache so it only ever talks
-// to its own mock server.
-func resetBotLoginCacheForTest(t *testing.T) {
-	t.Helper()
-	botLoginMu.Lock()
-	cachedBotLogin = ""
-	botLoginResolved = false
-	botLoginMu.Unlock()
-	t.Cleanup(func() {
-		botLoginMu.Lock()
-		cachedBotLogin = ""
-		botLoginResolved = false
-		botLoginMu.Unlock()
-	})
-}
-
 // TestTryRearmStalled_BotCommentAndLabelOnly_NotRearmed is GH-5381's core
 // regression test for the reverted PR #5380: the ONLY post-stall activity on
 // the issue is exactly what the dispatcher's own stall surfacing produces
@@ -46,8 +24,9 @@ func resetBotLoginCacheForTest(t *testing.T) {
 // treated issue.UpdatedAt moving past the stall as re-arm evidence, so this
 // exact fixture re-armed itself every single sweep pass (GH-5381's incident).
 // Neither event qualifies as real evidence: the labeled event names
-// pilot-blocked, not the trigger label or a retry-ready label, and nothing
-// in the (empty) Timeline shows an "edited" event.
+// pilot-blocked, not the trigger label or a retry-ready label, and GraphQL
+// reports no lastEditedAt at all (newRearmTestServer's default /graphql
+// response).
 func TestTryRearmStalled_BotCommentAndLabelOnly_NotRearmed(t *testing.T) {
 	store := newTerminalCompletionCheckerTestStore(t)
 	stallTime := time.Now().Add(-time.Hour)
@@ -92,44 +71,45 @@ func TestTryRearmStalled_BotCommentAndLabelOnly_NotRearmed(t *testing.T) {
 	}
 }
 
-// TestTryRearmStalled_TimelineEditByOperator_Rearms is GH-5381's real
-// body-edit evidence acceptance test: a Timeline "edited" event authored by
-// someone other than the bot, timestamped after the stall, counts as
-// evidence even with zero label/reopen events — the classic Events API
-// (ListIssueEvents) never emits "edited" at all, so this is only observable
-// via ListIssueTimeline.
-func TestTryRearmStalled_TimelineEditByOperator_Rearms(t *testing.T) {
-	resetBotLoginCacheForTest(t)
-	store := newTerminalCompletionCheckerTestStore(t)
-	stallTime := time.Now().Add(-time.Hour)
-	editTime := stallTime.Add(30 * time.Minute)
-
+// graphQLLastEditServer serves a fixed Issue at GET .../issues/{n}, a fixed
+// classic event list at GET .../issues/{n}/events, and a GraphQL
+// lastEditedAt/editor response derived from lastEditedAt (nil means "never
+// edited") at POST /graphql — GH-5398's real evidence source, replacing the
+// GH-5381 Timeline-based approach the ListIssueTimeline endpoint never
+// actually supported for body/title edits.
+func graphQLLastEditServer(t *testing.T, issueNum int, issue *github.Issue, events []*github.IssueEvent, lastEditedAt *time.Time, editorLogin string, blockedLabelRemoved *bool) *httptest.Server {
+	t.Helper()
+	issuePath := "/repos/owner/repo/issues/" + strconv.Itoa(issueNum)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/user" && r.Method == http.MethodGet:
-			_ = json.NewEncoder(w).Encode(&github.User{Login: "pilot-bot"})
-		case r.URL.Path == "/repos/owner/repo/issues/5139" && r.Method == http.MethodGet:
-			_ = json.NewEncoder(w).Encode(&github.Issue{
-				Number: 5139, State: "open",
-				Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelRetry1}},
-			})
-		case r.URL.Path == "/repos/owner/repo/issues/5139/events" && r.Method == http.MethodGet:
-			// No labeled/reopened event after the stall — a body edit alone
-			// is not surfaced as a labeled/reopened classic event.
-			_ = json.NewEncoder(w).Encode([]*github.IssueEvent{
-				{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
-				{Event: "labeled", CreatedAt: stallTime.Add(-23 * time.Hour), Label: &github.Label{Name: github.LabelRetry1}},
-			})
-		case r.URL.Path == "/repos/owner/repo/issues/5139/timeline" && r.Method == http.MethodGet:
-			_ = json.NewEncoder(w).Encode([]*github.TimelineEvent{
-				{Event: "edited", CreatedAt: editTime, Actor: &github.User{Login: "operator-jane"}},
-			})
-		case r.URL.Path == "/repos/owner/repo/issues/5139/labels/"+github.LabelBlocked && r.Method == http.MethodDelete:
-			// A successful re-arm always tries to clear pilot-blocked,
-			// regardless of which evidence type triggered it (this fixture
-			// carries pilot-retry-1, not pilot-blocked, but the removal call
-			// still fires unconditionally — see tryRearmStalled).
+		case r.URL.Path == issuePath && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(issue)
+		case r.URL.Path == issuePath+"/events" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(events)
+		case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"repository": map[string]interface{}{
+						"issue": map[string]interface{}{
+							"lastEditedAt": nil,
+							"editor":       nil,
+						},
+					},
+				},
+			}
+			if lastEditedAt != nil {
+				issueData := resp["data"].(map[string]interface{})["repository"].(map[string]interface{})["issue"].(map[string]interface{})
+				issueData["lastEditedAt"] = lastEditedAt.Format(time.RFC3339)
+				if editorLogin != "" {
+					issueData["editor"] = map[string]interface{}{"login": editorLogin}
+				}
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == issuePath+"/labels/"+github.LabelBlocked && r.Method == http.MethodDelete:
+			if blockedLabelRemoved != nil {
+				*blockedLabelRemoved = true
+			}
 			w.WriteHeader(http.StatusOK)
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -137,14 +117,42 @@ func TestTryRearmStalled_TimelineEditByOperator_Rearms(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestTryRearmStalled_GraphQLLastEditedAtAfterStall_Rearms is GH-5398's real
+// body-edit evidence acceptance test: GitHub's GraphQL lastEditedAt,
+// timestamped after the stall, counts as evidence even with zero
+// label/reopen events — the classic Events API and the Timeline API both
+// never emit anything for a body edit at all (verified read-only against
+// real issues with confirmed GraphQL userContentEdits history).
+func TestTryRearmStalled_GraphQLLastEditedAtAfterStall_Rearms(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+	editTime := stallTime.Add(30 * time.Minute)
+
+	var blockedLabelRemoved bool
+	srv := graphQLLastEditServer(t, 5139,
+		&github.Issue{
+			Number: 5139, State: "open",
+			Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelRetry1}},
+		},
+		// No labeled/reopened event after the stall — a body edit alone is
+		// not surfaced as a labeled/reopened/renamed classic event.
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+			{Event: "labeled", CreatedAt: stallTime.Add(-23 * time.Hour), Label: &github.Label{Name: github.LabelRetry1}},
+		},
+		&editTime, "operator-jane", &blockedLabelRemoved,
+	)
 
 	checker := terminalCompletionChecker{
 		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
 		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
 	}
 
-	taskID, projectPath := "GH-5139", "/project-gh5381-timeline-edit"
-	seedStalledRow(t, store, "exec-stalled-timeline-edit", taskID, projectPath, stallTime)
+	taskID, projectPath := "GH-5139", "/project-gh5398-lastedited"
+	seedStalledRow(t, store, "exec-stalled-lastedited", taskID, projectPath, stallTime)
 	key := repickBackoffKey(projectPath, taskID)
 	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
 	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
@@ -154,10 +162,17 @@ func TestTryRearmStalled_TimelineEditByOperator_Rearms(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !rearmed {
-		t.Fatal("expected rearmed=true — a non-bot Timeline 'edited' event postdates the stall")
+		t.Fatal("expected rearmed=true — GraphQL lastEditedAt postdates the stall")
+	}
+	// A successful re-arm always tries to clear pilot-blocked, regardless of
+	// which evidence type triggered it (this fixture carries pilot-retry-1,
+	// not pilot-blocked, but the removal call still fires unconditionally —
+	// see tryRearmStalled).
+	if !blockedLabelRemoved {
+		t.Error("expected the pilot-blocked label removal to be invoked")
 	}
 
-	exec, err := store.GetExecution("exec-stalled-timeline-edit")
+	exec, err := store.GetExecution("exec-stalled-lastedited")
 	if err != nil {
 		t.Fatalf("GetExecution: %v", err)
 	}
@@ -166,50 +181,34 @@ func TestTryRearmStalled_TimelineEditByOperator_Rearms(t *testing.T) {
 	}
 }
 
-// TestTryRearmStalled_TimelineEditByBot_NotRearmed proves the actor filter:
-// an "edited" event authored by the bot account itself (e.g. an
-// autopilot-meta footer rewrite) must NOT count as re-arm evidence — this is
-// exactly the class of self-inflicted signal GH-5381 fixes forward from
-// (PR #5380 used issue.UpdatedAt, which can't distinguish the bot's own
-// edits from an operator's).
-func TestTryRearmStalled_TimelineEditByBot_NotRearmed(t *testing.T) {
-	resetBotLoginCacheForTest(t)
+// TestTryRearmStalled_GraphQLLastEditedAtBeforeStall_NotRearmed proves the
+// timestamp comparison direction: an issue that was edited at some point in
+// its history, but not since the stall, must not re-arm — an edit is only
+// evidence of a deliberate post-stall operator gesture when it postdates
+// exec.CompletedAt.
+func TestTryRearmStalled_GraphQLLastEditedAtBeforeStall_NotRearmed(t *testing.T) {
 	store := newTerminalCompletionCheckerTestStore(t)
 	stallTime := time.Now().Add(-time.Hour)
-	editTime := stallTime.Add(30 * time.Minute)
+	editTime := stallTime.Add(-2 * time.Hour)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/user" && r.Method == http.MethodGet:
-			_ = json.NewEncoder(w).Encode(&github.User{Login: "pilot-bot"})
-		case r.URL.Path == "/repos/owner/repo/issues/5139" && r.Method == http.MethodGet:
-			_ = json.NewEncoder(w).Encode(&github.Issue{
-				Number: 5139, State: "open",
-				Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}},
-			})
-		case r.URL.Path == "/repos/owner/repo/issues/5139/events" && r.Method == http.MethodGet:
-			_ = json.NewEncoder(w).Encode([]*github.IssueEvent{
-				{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
-			})
-		case r.URL.Path == "/repos/owner/repo/issues/5139/timeline" && r.Method == http.MethodGet:
-			_ = json.NewEncoder(w).Encode([]*github.TimelineEvent{
-				{Event: "edited", CreatedAt: editTime, Actor: &github.User{Login: "pilot-bot"}},
-			})
-		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	t.Cleanup(srv.Close)
+	srv := graphQLLastEditServer(t, 5139,
+		&github.Issue{
+			Number: 5139, State: "open",
+			Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}},
+		},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+		},
+		&editTime, "operator-jane", nil,
+	)
 
 	checker := terminalCompletionChecker{
 		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
 		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
 	}
 
-	taskID, projectPath := "GH-5139", "/project-gh5381-timeline-bot-edit"
-	seedStalledRow(t, store, "exec-stalled-timeline-bot-edit", taskID, projectPath, stallTime)
+	taskID, projectPath := "GH-5139", "/project-gh5398-stale-edit"
+	seedStalledRow(t, store, "exec-stalled-stale-edit", taskID, projectPath, stallTime)
 	key := repickBackoffKey(projectPath, taskID)
 	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
 	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
@@ -219,7 +218,56 @@ func TestTryRearmStalled_TimelineEditByBot_NotRearmed(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if rearmed {
-		t.Fatal("expected rearmed=false — the 'edited' event was authored by the bot account itself, not an operator")
+		t.Fatal("expected rearmed=false — lastEditedAt predates the stall, so it isn't evidence of a post-stall gesture")
+	}
+}
+
+// TestTryRearmStalled_RenamedEventAfterStall_Rearms is GH-5398's title-edit
+// evidence test: unlike a body edit, a title edit DOES surface as a classic
+// Events "renamed" event, so it's evidence via latestRearmEvent without ever
+// needing the GraphQL fallback.
+func TestTryRearmStalled_RenamedEventAfterStall_Rearms(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+	renameTime := stallTime.Add(15 * time.Minute)
+
+	srv := graphQLLastEditServer(t, 5139,
+		&github.Issue{
+			Number: 5139, State: "open",
+			Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}},
+		},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+			{Event: "renamed", CreatedAt: renameTime},
+		},
+		nil, "", nil,
+	)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5139", "/project-gh5398-renamed"
+	seedStalledRow(t, store, "exec-stalled-renamed", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+	t.Cleanup(func() { stalledRearmNoEvidenceStreaks.reset(key) })
+
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rearmed {
+		t.Fatal("expected rearmed=true — a 'renamed' event postdates the stall on an open, labeled issue")
+	}
+
+	exec, err := store.GetExecution("exec-stalled-renamed")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected the stalled row to be reclassified to status=failed, got %q", exec.Status)
 	}
 }
 
@@ -296,8 +344,8 @@ func newGH5381EscalationServer(t *testing.T, issueNum int, initialLabels []strin
 			})
 		case r.URL.Path == issuePath+"/events" && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode(state.events)
-		case r.URL.Path == issuePath+"/timeline" && r.Method == http.MethodGet:
-			_ = json.NewEncoder(w).Encode([]*github.TimelineEvent{})
+		case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"data":{"repository":{"issue":{"lastEditedAt":null,"editor":null}}}}`))
 		case r.URL.Path == issuePath+"/comments" && r.Method == http.MethodPost:
 			state.commentCalls++
 			_ = json.NewEncoder(w).Encode(&github.Comment{ID: 1})
@@ -326,7 +374,6 @@ func newGH5381EscalationServer(t *testing.T, issueNum int, initialLabels []strin
 // escalate to pilot-needs-human with an explanatory comment instead, and
 // never repeat the escalation or resume probing on subsequent passes.
 func TestSweepStalledRearm_NoEvidenceThreeTimes_EscalatesAndStops(t *testing.T) {
-	resetBotLoginCacheForTest(t)
 	store := newTerminalCompletionCheckerTestStore(t)
 	stallTime := time.Now().Add(-time.Hour)
 
@@ -427,7 +474,6 @@ func TestSweepStalledRearm_NoEvidenceThreeTimes_EscalatesAndStops(t *testing.T) 
 // escalate to pilot-needs-human exactly like three consecutive no-evidence
 // sweeps, rather than calling recordClaimLostDrop forever with no backstop.
 func TestSweepStalledRearm_ProbeErrorThreeTimes_EscalatesLikeNoEvidence(t *testing.T) {
-	resetBotLoginCacheForTest(t)
 	store := newTerminalCompletionCheckerTestStore(t)
 	stallTime := time.Now().Add(-time.Hour)
 

--- a/cmd/pilot/rearm_canceled.go
+++ b/cmd/pilot/rearm_canceled.go
@@ -92,13 +92,14 @@ func (c terminalCompletionChecker) tryRearmCanceled(taskID, projectPath, backoff
 }
 
 // latestRearmEvent scans events (as returned by ListIssueEvents, oldest
-// first) for the most recent "reopened" event, or "labeled" event naming any
-// of labels, whose CreatedAt is strictly after since (the terminal-state
-// timestamp). Either event type alone is sufficient evidence of a deliberate
-// operator gesture post-terminal-state — the caller separately confirms
-// whatever "currently open (+labeled)" state it requires, so this only needs
-// to establish that one of those state changes happened after the terminal
-// timestamp, not both.
+// first) for the most recent "reopened" event, "renamed" event (a title
+// edit — GH-5398: unlike a body edit, the classic Events API DOES emit this
+// one), or "labeled" event naming any of labels, whose CreatedAt is strictly
+// after since (the terminal-state timestamp). Any of those event types alone
+// is sufficient evidence of a deliberate operator gesture post-terminal-state
+// — the caller separately confirms whatever "currently open (+labeled)"
+// state it requires, so this only needs to establish that one of those state
+// changes happened after the terminal timestamp, not all of them.
 //
 // labels is variadic so tryRearmStalled (GH-5272) can accept re-arm evidence
 // from any label in the pilot-retry-ready/-1/-2 family, on top of the base
@@ -113,6 +114,7 @@ func latestRearmEvent(events []*github.IssueEvent, since time.Time, labels ...st
 		}
 		switch ev.Event {
 		case "reopened":
+		case "renamed":
 		case "labeled":
 			if ev.Label == nil || !containsLabelFold(labels, ev.Label.Name) {
 				continue

--- a/cmd/pilot/rearm_canceled_test.go
+++ b/cmd/pilot/rearm_canceled_test.go
@@ -16,9 +16,10 @@ import (
 // event list at GET .../issues/{n}/events, and fails the test if any other
 // path is hit — used to prove HasCompletedExecution makes NO GitHub calls at
 // all for genuine completed/no_op rows (only a canceled row should ever be
-// probed). The timeline route always returns an empty list — callers that
-// need GH-5381 Timeline "edited"-event evidence use a custom inline server
-// instead (newRearmTestServer's shared fixture has no case for it).
+// probed). The GraphQL route always answers with no body/title edit
+// (lastEditedAt: null) — callers that need GH-5398 lastEditedAt evidence use
+// a custom inline server instead (newRearmTestServer's shared fixture has no
+// case for that).
 func newRearmTestServer(t *testing.T, issue *github.Issue, events []*github.IssueEvent) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -28,8 +29,8 @@ func newRearmTestServer(t *testing.T, issue *github.Issue, events []*github.Issu
 			_ = json.NewEncoder(w).Encode(issue)
 		case r.URL.Path == "/repos/owner/repo/issues/5139/events" && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode(events)
-		case r.URL.Path == "/repos/owner/repo/issues/5139/timeline" && r.Method == http.MethodGet:
-			_ = json.NewEncoder(w).Encode([]*github.TimelineEvent{})
+		case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"data":{"repository":{"issue":{"lastEditedAt":null,"editor":null}}}}`))
 		case r.URL.Path == "/repos/owner/repo/issues/5139/labels/"+github.LabelBlocked && r.Method == http.MethodDelete:
 			// Only exercised by GH-5212 stalled-rearm tests (tryRearmCanceled
 			// never removes labels) — kept here since this fixture is shared.

--- a/cmd/pilot/rearm_stalled.go
+++ b/cmd/pilot/rearm_stalled.go
@@ -123,37 +123,40 @@ func (c terminalCompletionChecker) tryRearmStalled(taskID, projectPath, backoffK
 	if rearmEvent := latestRearmEvent(events, *exec.CompletedAt, append([]string{c.triggerLabel}, retryReadyRearmLabels...)...); rearmEvent != nil {
 		kind, evidenceAt = rearmEvent.Event, rearmEvent.CreatedAt
 	} else {
-		// GH-5381: no label/reopen evidence found via the classic Events API
-		// — fall back to the Timeline API, the only endpoint that surfaces a
-		// body/title "edited" event at all (confirmed during the GH-5376
-		// incident; the classic Events API never emits one). This is
-		// deliberately NOT issue.UpdatedAt (PR #5380's approach, reverted in
-		// f8532806): UpdatedAt moves on ANY mutation, including the
-		// dispatcher's own stall comment + pilot-blocked label
-		// (surfaceStalledIssue, internal/executor/dispatcher.go), so it
-		// re-armed every stalled task on the very next sweep. An "edited"
-		// timeline event authored by anyone other than the bot itself is a
-		// much narrower, deliberate-operator-gesture signal.
-		timeline, timelineErr := c.ghClient.ListIssueTimeline(ctx, c.repoOwner, c.repoName, issueNum)
-		if timelineErr != nil {
-			return false, fmt.Errorf("listing issue #%d timeline: %w", issueNum, timelineErr)
+		// GH-5398: no label/reopen/renamed evidence found via the classic
+		// Events API — query GraphQL for lastEditedAt, the only reliable
+		// signal for a body edit. GH-5381 originally tried the Timeline API
+		// (`/issues/{n}/timeline`) here on the assumption that it surfaces an
+		// "edited" event for body edits; verified read-only against real
+		// issues with confirmed body-edit history (via GraphQL
+		// userContentEdits) and zero matching Timeline "edited" entries —
+		// that assumption was wrong, and the Timeline lookup was dead code
+		// that could never match. This is deliberately NOT issue.UpdatedAt
+		// (PR #5380's approach, reverted in f8532806): UpdatedAt moves on ANY
+		// mutation, including the dispatcher's own stall comment +
+		// pilot-blocked label (surfaceStalledIssue,
+		// internal/executor/dispatcher.go), so it re-armed every stalled
+		// task on the very next sweep.
+		//
+		// No actor filtering here (unlike the reverted Timeline approach):
+		// nothing in this codebase ever edits an issue body or title — the
+		// dispatcher only adds comments/labels — so a body/title edit is an
+		// operator gesture by definition. Filtering by actor would also be
+		// unsound on a same-account deployment (the founder box runs Pilot
+		// on the operator's own PAT, so resolveBotLogin's token identity IS
+		// the operator's login).
+		editInfo, editErr := c.ghClient.GetIssueLastEdit(ctx, c.repoOwner, c.repoName, issueNum)
+		if editErr != nil {
+			return false, fmt.Errorf("querying issue #%d last edit: %w", issueNum, editErr)
 		}
-		// Only spend a GetAuthenticatedUser call resolving the bot login
-		// (resolveBotLogin) when there's at least one "edited" event that
-		// could possibly qualify — the common case (no edit at all since the
-		// stall) has nothing to filter by actor, so this skips an API call
-		// on every ordinary no-evidence sweep pass.
-		if hasEditedEventAfter(timeline, *exec.CompletedAt) {
-			botLogin := resolveBotLogin(ctx, c.ghClient)
-			if at, ok := stalledTimelineRearmEvidence(timeline, *exec.CompletedAt, botLogin); ok {
-				kind, evidenceAt = "edited", at
-			}
+		if editInfo.LastEditedAt != nil && editInfo.LastEditedAt.After(*exec.CompletedAt) {
+			kind, evidenceAt = "edited", *editInfo.LastEditedAt
 		}
 	}
 	if kind == "" {
 		// Open + labeled, but nothing observed shows that state was reached
 		// AFTER the stall (no base-label relabel/reopen, no
-		// pilot-retry-ready/-1/-2 label add, no non-bot body/title edit) —
+		// pilot-retry-ready/-1/-2 label add, no renamed/edited body/title) —
 		// not a deliberate re-arm gesture.
 		return false, nil
 	}
@@ -184,99 +187,6 @@ func (c terminalCompletionChecker) tryRearmStalled(taskID, projectPath, backoffK
 	logging.WithComponent("dispatch").Info("GH-5212: stalled task re-armed via GitHub reopen/relabel/edit",
 		slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.String("evidence", kind))
 	return true, nil
-}
-
-// hasEditedEventAfter reports whether events contains any "edited" entry
-// timestamped after since, with no actor filtering — a cheap pre-check so
-// tryRearmStalled only pays for resolveBotLogin's GetAuthenticatedUser call
-// when there's actually something that could qualify as evidence.
-func hasEditedEventAfter(events []*github.TimelineEvent, since time.Time) bool {
-	for _, ev := range events {
-		if ev != nil && ev.Event == "edited" && ev.CreatedAt.After(since) {
-			return true
-		}
-	}
-	return false
-}
-
-// stalledTimelineRearmEvidence is GH-5381's real body-edit evidence check.
-// GitHub's classic Events API never emits an "edited" event for a body/title
-// edit (the GH-5376 incident and the now-reverted PR #5380 confirmed this —
-// #5380 substituted issue.UpdatedAt instead, which broke worse: the
-// dispatcher's OWN stall comment + pilot-blocked label bump UpdatedAt
-// seconds after CompletedAt, so every stalled task re-armed itself on the
-// very next sweep — see commit f8532806's revert). The Timeline API DOES
-// surface "edited" events, each with an actor, so a genuine operator body
-// edit can be told apart from the bot's own activity by actor login alone —
-// no timestamp heuristic needed.
-//
-// botLogin is the authenticated token identity (resolveBotLogin, cached); an
-// edited event whose actor matches it (case-insensitive) is excluded — it's
-// Pilot's own doing (e.g. an autopilot-meta footer rewrite), never a
-// deliberate operator re-arm gesture. An empty botLogin (resolution failed)
-// accepts NO edited-event evidence this pass — fail closed, since accepting
-// one without an actor filter risks reintroducing exactly the self-re-arm
-// bug this function exists to avoid. Label/reopen evidence (checked first,
-// unconditionally, in tryRearmStalled) is unaffected by this fallback.
-func stalledTimelineRearmEvidence(events []*github.TimelineEvent, since time.Time, botLogin string) (at time.Time, ok bool) {
-	if botLogin == "" {
-		return time.Time{}, false
-	}
-	var latest *github.TimelineEvent
-	for _, ev := range events {
-		if ev == nil || ev.Event != "edited" || !ev.CreatedAt.After(since) {
-			continue
-		}
-		if ev.Actor != nil && strings.EqualFold(ev.Actor.Login, botLogin) {
-			continue
-		}
-		if latest == nil || ev.CreatedAt.After(latest.CreatedAt) {
-			latest = ev
-		}
-	}
-	if latest == nil {
-		return time.Time{}, false
-	}
-	return latest.CreatedAt, true
-}
-
-// botLoginMu/cachedBotLogin/botLoginResolved cache the authenticated GitHub
-// login for the Pilot token, mirroring internal/autopilot.Controller's
-// getBotLogin — package-level here because terminalCompletionChecker is a
-// value type constructed fresh per call (see sweepStalledRearm's doc
-// comment), so an instance-level cache would never survive across sweep
-// passes.
-var (
-	botLoginMu       sync.Mutex
-	cachedBotLogin   string
-	botLoginResolved bool
-)
-
-// resolveBotLogin returns the authenticated GitHub login for client's token,
-// resolved lazily on first call and cached for the process lifetime. Returns
-// "" when it can't be determined (e.g. a transient GetAuthenticatedUser
-// failure); callers must treat that as "exclude nothing can be confirmed
-// safe" — see stalledTimelineRearmEvidence's fail-closed handling.
-func resolveBotLogin(ctx context.Context, client *github.Client) string {
-	botLoginMu.Lock()
-	if botLoginResolved {
-		login := cachedBotLogin
-		botLoginMu.Unlock()
-		return login
-	}
-	botLoginMu.Unlock()
-
-	user, err := client.GetAuthenticatedUser(ctx)
-	if err != nil {
-		logging.WithComponent("dispatch").Warn("GH-5381: could not resolve bot login for edited-event actor exclusion — Timeline edited-event evidence disabled until this succeeds",
-			slog.Any("error", err))
-		return ""
-	}
-	botLoginMu.Lock()
-	cachedBotLogin = user.Login
-	botLoginResolved = true
-	botLoginMu.Unlock()
-	return user.Login
 }
 
 // sweepStalledRearm scans repoOwner/repoName for open issues currently
@@ -468,7 +378,7 @@ func (c terminalCompletionChecker) escalateStalledRearmNoEvidence(ctx context.Co
 		"⚠️ **Pilot could not confirm this stalled task was re-armed**\n\n"+
 			"This issue was checked %d times with no evidence of a deliberate re-arm gesture since it stalled. "+
 			"Re-arm evidence is any of: re-adding the `%s` label, adding one of `%s`, reopening the issue, "+
-			"or editing the issue body/title as a human (not Pilot itself) — all timestamped after the stall.\n\n"+
+			"or editing the issue body or title — all timestamped after the stall.\n\n"+
 			"Applying `%s` so this stops being silently re-checked. Remove it and repeat one of the above to re-arm.",
 		streak, c.triggerLabel, strings.Join(retryReadyRearmLabels, "`, `"), labelPilotNeedsHumanSDK,
 	)

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -1455,6 +1455,59 @@ func (c *Client) GetIssueNodeID(ctx context.Context, owner, repo string, number 
 	return issue.NodeID, nil
 }
 
+// IssueEditInfo is GH-5398's real body/title-edit evidence: GitHub's
+// lastEditedAt/editor fields, only available via GraphQL. LastEditedAt is
+// nil when the issue has never been edited since creation. EditorLogin is
+// the login of whoever made the most recent edit ("" when LastEditedAt is
+// nil, or when GitHub omits editor for some other reason).
+type IssueEditInfo struct {
+	LastEditedAt *time.Time
+	EditorLogin  string
+}
+
+// GetIssueLastEdit queries lastEditedAt/editor for an issue via GraphQL.
+// GH-5398: the classic Events API (ListIssueEvents) never emits an "edited"
+// event for a body/title edit at all, and neither does the Timeline API
+// (`/issues/{n}/timeline`) — verified read-only against real issues with
+// confirmed GraphQL userContentEdits history and zero matching Timeline
+// "edited" entries at those timestamps (the GH-5381 fix that introduced the
+// Timeline lookup was built on an incorrect assumption about what that
+// endpoint surfaces). lastEditedAt/editor are the only fields GitHub
+// actually populates for this.
+func (c *Client) GetIssueLastEdit(ctx context.Context, owner, repo string, number int) (*IssueEditInfo, error) {
+	const query = `query($owner: String!, $repo: String!, $number: Int!) {
+		repository(owner: $owner, name: $repo) {
+			issue(number: $number) {
+				lastEditedAt
+				editor { login }
+			}
+		}
+	}`
+
+	var result struct {
+		Repository struct {
+			Issue struct {
+				LastEditedAt *time.Time `json:"lastEditedAt"`
+				Editor       *struct {
+					Login string `json:"login"`
+				} `json:"editor"`
+			} `json:"issue"`
+		} `json:"repository"`
+	}
+
+	if err := c.ExecuteGraphQL(ctx, query, map[string]interface{}{
+		"owner": owner, "repo": repo, "number": number,
+	}, &result); err != nil {
+		return nil, fmt.Errorf("query last edit for %s/%s#%d: %w", owner, repo, number, err)
+	}
+
+	info := &IssueEditInfo{LastEditedAt: result.Repository.Issue.LastEditedAt}
+	if result.Repository.Issue.Editor != nil {
+		info.EditorLogin = result.Repository.Issue.Editor.Login
+	}
+	return info, nil
+}
+
 // LinkSubIssue links a child issue to a parent issue using the addSubIssue GraphQL mutation.
 // Both issue numbers are resolved to node IDs first.
 func (c *Client) LinkSubIssue(ctx context.Context, owner, repo string, parentNum, childNum int) error {


### PR DESCRIPTION
## Summary
- GH-5381's stalled re-arm probe checked GitHub's Timeline API for an "edited" event as body/title-edit evidence, but GitHub never emits that event for a body edit — verified read-only against real issues (#5346, #5381) with confirmed GraphQL `userContentEdits` history and zero matching Timeline entries. The check was dead code: operators who edited the body per the escalation comment's own instructions never re-armed, and eventually hit `pilot-needs-human` on an issue they'd already acted on.
- Replace the Timeline lookup with a GraphQL query for `lastEditedAt`/`editor`, GitHub's actual signal for a body/title edit.
- Also accept a classic Events `renamed` event (title edit) as re-arm evidence, shared via `latestRearmEvent`.
- Drop actor filtering on edit evidence: nothing in this codebase ever edits an issue body/title (the dispatcher only comments/labels), so a body/title edit is an operator gesture by definition. This also fixes a second bug: on the founder box, Pilot runs on the operator's own PAT, so the old bot-login-based actor filter would have excluded the operator's own edits even if Timeline had worked.
- Updated the stalled-no-evidence escalation comment to stop referencing the (removed) bot-vs-human distinction.
- Removed the now-dead `ListIssueTimeline`-based helpers (`hasEditedEventAfter`, `stalledTimelineRearmEvidence`, `resolveBotLogin` cache) from `cmd/pilot/rearm_stalled.go`.

Fixes GH-5398.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/pilot/... ./internal/adapters/github/...`
- [x] New/updated fixtures: GraphQL `lastEditedAt` after stall → re-armed; before stall → not re-armed; classic `renamed` event after stall → re-armed; bot comment + `pilot-blocked` label only (#5393 fixture) → still not re-armed.