### PR TITLE
fix(executor): close needs_human status gap and salvage-push budget (GH-5399)

### DIFF
--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -601,9 +601,12 @@ func classifyWaitedExecution(taskID string, exec *memory.Execution) (result *exe
 // GH-4794: a terminal-by-design execution (superseded or canceled) is the
 // success path for "this work is no longer wanted" — it must not produce a
 // TaskFailed alert (it isn't a failure) or a TaskCompleted one (no PR/commit
-// exists), so the terminalByDesign case falls through to nil. A hard
-// execErr (queue/wait failure) always pages regardless of terminalByDesign,
-// since that's a pipeline failure, not a classified execution status.
+// exists), so the terminalByDesign case falls through to nil. GH-5399:
+// needs_human joins this set for the same reason — holdPushedBranch already
+// posted its own hand-off comment/label, so this must not page a duplicate
+// failure alert on top of it. A hard execErr (queue/wait failure) always
+// pages regardless of terminalByDesign, since that's a pipeline failure, not
+// a classified execution status.
 func classifyResultAlert(taskID, title, projectPath string, execErr error, result *executor.ExecutionResult, terminalByDesign bool) *alerts.Event {
 	now := time.Now()
 	switch {

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -49,6 +49,9 @@ var terminalExecutionStatuses = map[string]bool{
 	// by ExecutionLifecycle.Cancel. Distinct from the dead "cancelled"
 	// (double-L) above — see ExecStatusCanceled's doc comment.
 	"canceled": true,
+	// "needs_human" (GH-5399): holdPushedBranch's hand-off status — salvaged
+	// work was pushed and is awaiting manual review. No longer in flight.
+	"needs_human": true,
 }
 
 // isTerminalExecutionStatus reports whether status is one of
@@ -68,14 +71,22 @@ func isTerminalExecutionStatus(status string) bool {
 // per-adapter translations in cmd/pilot/handlers.go) consults this so these
 // statuses never produce a failure report/alert or trigger a vendored-SDK
 // poller's "no PR, unmarking for retry" branch.
+//
+// GH-5399: needs_human joins this set for the same reason. holdPushedBranch
+// already pushed the salvaged branch and posted its own hand-off comment —
+// treating it as a genuine failure here would stack a duplicate
+// "❌ Pilot execution failed" comment/TaskFailed alert on top of that, and
+// would let the vendored SDK poller unmark the issue for a retry that
+// HasTerminalCompletion/nextRetryGeneration have already decided not to grant.
 var terminalByDesignExecutionStatuses = map[string]bool{
 	string(ExecStatusSuperseded): true,
 	string(ExecStatusCanceled):   true,
+	string(ExecStatusNeedsHuman): true,
 }
 
 // IsTerminalByDesignStatus reports whether status is a terminal-by-design
-// non-failure (superseded or canceled) rather than a genuine completion or
-// failure.
+// non-failure (superseded, canceled, or needs_human) rather than a genuine
+// completion or failure.
 func IsTerminalByDesignStatus(status string) bool {
 	return terminalByDesignExecutionStatuses[status]
 }
@@ -3950,6 +3961,10 @@ func dispatchSuccessStage(prURL string) (memory.Stage, bool) {
 // regardless of the underlying stage (internal/dashboard/stage_strip.go), so
 // reusing it produces no behavior change there. declined/rate_limited still
 // have no Stage enum equivalent, so they're skipped rather than mismapped.
+// needs_human (GH-5399) is deliberately left unmapped here too, for the same
+// reason as stalled: holdPushedBranch already writes its own StageFailed
+// ledger event directly at its detection site in runner.go, so adding a case
+// here would double-write the event.
 func dispatchTerminalStage(status string) (memory.Stage, bool) {
 	switch status {
 	case "no_op":
@@ -4011,6 +4026,8 @@ func terminalPhaseLabel(status string) string {
 		return "Declined"
 	case "superseded":
 		return "Superseded"
+	case "needs_human":
+		return "Needs Human"
 	default:
 		return "Failed"
 	}

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -5461,6 +5461,65 @@ func TestNextRetryGeneration_CanceledVsStalled(t *testing.T) {
 	})
 }
 
+// TestNextRetryGeneration_NeedsHuman is the GH-5399 regression guard for Fix
+// 2: a needs_human row (holdPushedBranch's hand-off — salvaged work already
+// pushed and parked for manual review) must never be handed a fresh retry
+// generation, exactly like canceled/superseded. Before terminalExecutionStatuses
+// and HasTerminalCompletion both learned about needs_human, this status fell
+// through to the "not terminal" default: a live owner check that (once the
+// claim's own execution row aged out) would eventually treat it as a dead,
+// not-done owner and re-arm a fresh generation on top of a branch a human is
+// already supposed to be reviewing.
+func TestNextRetryGeneration_NeedsHuman(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-5399-NEEDS-HUMAN", ProjectPath: "/project-needs-human"}
+	execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("setup Begin: %v", err)
+	}
+	if _, err := store.UpdateExecutionStatusIfNotTerminal(execID, "needs_human", "quality gates failed after the task deadline passed"); err != nil {
+		t.Fatalf("setup needs_human: %v", err)
+	}
+
+	dispatcher := NewDispatcher(store, NewRunner(), nil)
+	for i := 0; i < 5; i++ {
+		gen, retry, err := dispatcher.nextRetryGeneration(task.ID, task.ProjectPath)
+		if err != nil {
+			t.Fatalf("nextRetryGeneration (cycle %d): %v", i, err)
+		}
+		if retry {
+			t.Fatalf("cycle %d: expected retry=false for a needs_human execution, got retry=true (generation %d)", i, gen)
+		}
+		if gen != 0 {
+			t.Errorf("cycle %d: expected generation 0 (no growth) for a needs_human execution, got %d", i, gen)
+		}
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "needs_human" {
+		t.Fatalf("expected status 'needs_human', got %q", exec.Status)
+	}
+}
+
+// TestIsTerminalByDesignStatus_NeedsHuman verifies the GH-5399 labeling
+// invariant directly at its source: a needs_human outcome must be classified
+// terminal-by-design so per-adapter handlers apply only pilot-needs-human and
+// never stack pilot-failed on top of it (mirroring canceled/superseded, which
+// this same map already protected before GH-5399).
+func TestIsTerminalByDesignStatus_NeedsHuman(t *testing.T) {
+	if !IsTerminalByDesignStatus("needs_human") {
+		t.Error("expected needs_human to be terminal-by-design (no pilot-failed stacking, no duplicate TaskFailed alert)")
+	}
+	if IsTerminalByDesignStatus("failed") {
+		t.Error("a genuine 'failed' status must NOT be terminal-by-design — it still needs the ordinary pilot-failed/retry-ladder path")
+	}
+}
+
 // TestStore_GetQueuedProjectPaths verifies the distinct-project query backing
 // restart adoption: only queued/pending rows count, duplicates collapse, and
 // completed/running rows are excluded. GH-3732.

--- a/internal/executor/lifecycle.go
+++ b/internal/executor/lifecycle.go
@@ -67,6 +67,17 @@ const (
 	// (GH-4655 was cancel-by-abusing-"stalled", which does the opposite:
 	// grants fresh generations exempt from the repick hard cap forever).
 	ExecStatusCanceled Status = "canceled"
+	// ExecStatusNeedsHuman marks an execution whose salvaged work was pushed
+	// and held for manual review by holdPushedBranch (GH-5399), because the
+	// backend timed out (or the task's own deadline had already passed) and
+	// automated quality gates could not be satisfied without re-invoking the
+	// backend past its deadline. Terminal like ExecStatusCanceled/Superseded:
+	// nextRetryGeneration never grants a fresh generation for it, and it
+	// counts as done for HasTerminalCompletion — but unlike ExecStatusFailed
+	// it must NOT stack a pilot-failed label on top of pilot-needs-human,
+	// since the work is not a genuine failure awaiting retry, it's a
+	// deliberate hand-off awaiting a human.
+	ExecStatusNeedsHuman Status = "needs_human"
 )
 
 // ErrExecutionNotFound is returned by Cancel when taskID has no execution

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -471,6 +471,8 @@ func TerminalStatus(result *ExecutionResult) string {
 		return "skipped"
 	case "superseded":
 		return "superseded"
+	case "needs_human":
+		return "needs_human"
 	}
 	for _, c := range outcomeClassifiers {
 		if containsAny(result.Error, c.signatures) {
@@ -869,12 +871,15 @@ type ExecutionResult struct {
 	// DeclinedReason is the human-readable reason Claude provided for the decline.
 	DeclinedReason string
 	// Outcome is a fine-grained terminal classification ("declined", "no_op",
-	// "no_commits", "stalled", "budget_exceeded", "superseded") used by the
-	// dispatcher to pick the persisted execution status instead of collapsing
-	// every !Success result into "failed". Empty means "classify from
-	// Success/Declined/Error". TASK-358. "superseded" (GH-4656): the
+	// "no_commits", "stalled", "budget_exceeded", "superseded", "needs_human")
+	// used by the dispatcher to pick the persisted execution status instead of
+	// collapsing every !Success result into "failed". Empty means "classify
+	// from Success/Declined/Error". TASK-358. "superseded" (GH-4656): the
 	// PR-creation preflight found the task's GitHub issue already closed —
-	// another run delivered this scope first.
+	// another run delivered this scope first. "needs_human" (GH-5399): set by
+	// holdPushedBranch when salvaged work was pushed but automated gates
+	// couldn't run/pass without re-invoking the backend past its deadline —
+	// a human needs to review the held branch.
 	Outcome string
 	// PeakRSSMB is the peak subprocess RSS in MiB collected by the RSS sampler. GH-3028.
 	// Zero on non-Linux/darwin platforms or when the sampler had no data.
@@ -2715,7 +2720,7 @@ func (r *Runner) ensureQualityCheckerFactory(executionPath string, log *slog.Log
 // caller in executeWithOptions should return immediately). Returns false if
 // there was nothing to salvage (no commits on the branch) — the caller
 // should fall through to its normal "task failed" return.
-func (r *Runner) attemptBackendTimeoutSalvage(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, executionPath string, log *slog.Logger, recorder *replay.Recorder) bool {
+func (r *Runner) attemptBackendTimeoutSalvage(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, executionPath string, log *slog.Logger, recorder *replay.Recorder, preserveWorktree *bool) bool {
 	if git == nil || task.Branch == "" || task.DirectCommit || !task.CreatePR {
 		// Direct-commit tasks push straight to main with no branch/PR to
 		// salvage this way, and a task that never wanted a PR/branch has
@@ -2743,7 +2748,8 @@ func (r *Runner) attemptBackendTimeoutSalvage(ctx context.Context, task *Task, g
 	}
 	if countErr != nil {
 		r.holdPushedBranch(finCtx, task, git, result, log,
-			fmt.Sprintf("task ended by %v and commit count could not be verified after a retry: %v", ctx.Err(), countErr))
+			fmt.Sprintf("task ended by %v and commit count could not be verified after a retry: %v", ctx.Err(), countErr),
+			executionPath, preserveWorktree)
 		return true
 	}
 	if commitCount == 0 {
@@ -2767,11 +2773,13 @@ func (r *Runner) attemptBackendTimeoutSalvage(ctx context.Context, task *Task, g
 			switch {
 			case qErr != nil:
 				r.holdPushedBranch(finCtx, task, git, result, log,
-					fmt.Sprintf("timeout salvage: quality gate error: %v", qErr))
+					fmt.Sprintf("timeout salvage: quality gate error: %v", qErr),
+					executionPath, preserveWorktree)
 				return true
 			case outcome == nil || !outcome.Passed:
 				r.holdPushedBranch(finCtx, task, git, result, log,
-					"timeout salvage: quality gates failed after task timeout")
+					"timeout salvage: quality gates failed after task timeout",
+					executionPath, preserveWorktree)
 				return true
 			default:
 				result.QualityGates = r.buildQualityGatesResult(outcome, 0)
@@ -2780,9 +2788,20 @@ func (r *Runner) attemptBackendTimeoutSalvage(ctx context.Context, task *Task, g
 		}
 	}
 
-	r.pushAndCreatePRAfterTimeout(finCtx, task, git, result, recorder, log)
+	r.pushAndCreatePRAfterTimeout(finCtx, task, git, result, recorder, log, executionPath, preserveWorktree)
 	return true
 }
+
+// holdPushBudget is the push-specific timeout holdPushedBranch gives
+// git.Push, separate from (and much longer than) the comment/label window
+// that follows it. GH-5399: a 30s window sized for a couple of GitHub API
+// calls previously also had to cover the push itself — a large salvaged
+// diff can legitimately take longer than that, and timing it out there
+// produced a false "push failed" that then let the worktree cleanup defer
+// force-delete the local branch, destroying the only remaining copy of the
+// work. 5 minutes comfortably covers realistic salvage-diff pushes without
+// blocking the run indefinitely.
+const holdPushBudget = 5 * time.Minute
 
 // holdPushedBranch pushes task.Branch (if it is not already on the remote)
 // and parks the source issue under pilot-needs-human instead of silently
@@ -2791,21 +2810,32 @@ func (r *Runner) attemptBackendTimeoutSalvage(ctx context.Context, task *Task, g
 // above, which uses the same push/comment/label idiom for a "no more
 // automatic progress possible" state. GH-5346.
 //
-// Uses a fresh, value-preserving 30s window for the push/comment/label calls
-// (context.WithoutCancel(ctx), not ctx directly) — by the time this runs,
-// ctx itself is very often already exhausted (that is frequently WHY this is
-// being called), and building the escalation calls on a dead ctx would fail
-// them before they start.
-func (r *Runner) holdPushedBranch(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, log *slog.Logger, reason string) {
-	holdCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-	defer cancel()
+// The push and the comment/label calls run on two separate fresh,
+// value-preserving contexts (context.WithoutCancel(ctx), not ctx directly) —
+// by the time this runs, ctx itself is very often already exhausted (that is
+// frequently WHY this is being called), and building the escalation calls on
+// a dead ctx would fail them before they start. GH-5399: they are separate
+// budgets (holdPushBudget for the push, 30s for comment/label) rather than
+// one shared window, so a slow-but-successful push can no longer starve the
+// comment/label calls (or vice versa) of time.
+//
+// executionPath is included in the hold comment (and preserveWorktree is set)
+// when the push itself fails, so a human reviewing the parked issue — and
+// executeWithOptions's worktree-cleanup defer — both know the commits survive
+// only in that local worktree. Both may be zero-value (""/nil) for callers
+// that have no worktree to preserve (e.g. direct-commit-mode tasks).
+func (r *Runner) holdPushedBranch(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, log *slog.Logger, reason string, executionPath string, preserveWorktree *bool) {
+	pushCtx, pushCancel := context.WithTimeout(context.WithoutCancel(ctx), holdPushBudget)
+	defer pushCancel()
 
 	pushed := false
+	pushFailed := false
 	if git != nil && task.Branch != "" {
-		if pushErr := git.Push(holdCtx, task.Branch); pushErr != nil {
-			if git.RemoteBranchExists(holdCtx, task.Branch) {
+		if pushErr := git.Push(pushCtx, task.Branch); pushErr != nil {
+			if git.RemoteBranchExists(pushCtx, task.Branch) {
 				pushed = true
 			} else {
+				pushFailed = true
 				log.Warn("timeout salvage: failed to push branch for human hold",
 					slog.String("task_id", task.ID),
 					slog.String("branch", task.Branch),
@@ -2818,6 +2848,10 @@ func (r *Runner) holdPushedBranch(ctx context.Context, task *Task, git *GitOpera
 		}
 	}
 
+	if pushFailed && preserveWorktree != nil {
+		*preserveWorktree = true
+	}
+
 	log.Warn("timeout salvage: holding branch for human triage",
 		slog.String("task_id", task.ID),
 		slog.String("branch", task.Branch),
@@ -2825,11 +2859,21 @@ func (r *Runner) holdPushedBranch(ctx context.Context, task *Task, git *GitOpera
 		slog.String("reason", reason),
 	)
 
+	holdCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
 	if task.SourceAdapter == "" || task.SourceAdapter == "github" {
 		if issueNum := task.GHIssueRef(); issueNum != "" {
 			outcomeNote := "The branch could not be pushed either — check the worktree/logs before retrying."
-			if pushed {
+			switch {
+			case pushed:
 				outcomeNote = fmt.Sprintf("Branch `%s` was pushed with the commits Pilot completed before this happened — review and finish it manually, or clear the label to let Pilot retry.", task.Branch)
+			case executionPath != "":
+				// GH-5399: the push failed and the worktree cleanup defer has
+				// been told to preserve it — name both so a human can recover
+				// the commits directly from the Pilot host instead of assuming
+				// they're gone.
+				outcomeNote = fmt.Sprintf("The branch could not be pushed either — the commits are preserved only in the local worktree at `%s` (branch `%s`) on the Pilot host; check the worktree/logs before retrying.", executionPath, task.Branch)
 			}
 			commentBody := fmt.Sprintf("Pilot parked this task under `pilot-needs-human`: %s\n\n%s", reason, outcomeNote)
 			if commentErr := ghIssueComment(holdCtx, task.ProjectPath, issueNum, commentBody); commentErr != nil {
@@ -2860,7 +2904,7 @@ func (r *Runner) holdPushedBranch(ctx context.Context, task *Task, git *GitOpera
 // call already burned its full budget, not the place to add more
 // finalization work. Any failure here falls back to holdPushedBranch so the
 // commits are never silently lost. GH-5346.
-func (r *Runner) pushAndCreatePRAfterTimeout(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, recorder *replay.Recorder, log *slog.Logger) {
+func (r *Runner) pushAndCreatePRAfterTimeout(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, recorder *replay.Recorder, log *slog.Logger, executionPath string, preserveWorktree *bool) {
 	baseBranch := task.BaseBranch
 	if baseBranch == "" {
 		baseBranch, _ = git.GetDefaultBranch(ctx)
@@ -2872,7 +2916,8 @@ func (r *Runner) pushAndCreatePRAfterTimeout(ctx context.Context, task *Task, gi
 	if err := git.Push(ctx, task.Branch); err != nil {
 		if !git.RemoteBranchExists(ctx, task.Branch) {
 			r.holdPushedBranch(ctx, task, git, result, log,
-				fmt.Sprintf("timeout salvage: branch push failed: %v", err))
+				fmt.Sprintf("timeout salvage: branch push failed: %v", err),
+				executionPath, preserveWorktree)
 			return
 		}
 		log.Warn("timeout salvage: push reported error but branch exists on remote, continuing",
@@ -2902,7 +2947,8 @@ func (r *Runner) pushAndCreatePRAfterTimeout(ctx context.Context, task *Task, gi
 	normalizedTitle, titleErr := normalizeTitle(task.Title, task.Labels, diffStats)
 	if titleErr != nil {
 		r.holdPushedBranch(ctx, task, git, result, log,
-			fmt.Sprintf("timeout salvage: PR title normalization failed: %v", titleErr))
+			fmt.Sprintf("timeout salvage: PR title normalization failed: %v", titleErr),
+			executionPath, preserveWorktree)
 		return
 	}
 	prTitle := fmt.Sprintf("%s: %s", task.ID, normalizedTitle)
@@ -2931,7 +2977,8 @@ func (r *Runner) pushAndCreatePRAfterTimeout(ctx context.Context, task *Task, gi
 	}
 	if createErr != nil {
 		r.holdPushedBranch(ctx, task, git, result, log,
-			fmt.Sprintf("timeout salvage: PR creation failed: %v", createErr))
+			fmt.Sprintf("timeout salvage: PR creation failed: %v", createErr),
+			executionPath, preserveWorktree)
 		return
 	}
 
@@ -3354,11 +3401,32 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		r.reportProgress(task.ID, "Worktree", 2, "Worktree ready")
 	}
 
+	// GH-5399: set to true by holdPushedBranch when it could not push the
+	// salvaged branch to the remote even after its own extended push budget
+	// — in that case the worktree (and its local branch) hold the ONLY copy
+	// of the salvaged commits, and cleanupWorktreeAndBranch's `git branch -D`
+	// would destroy them. Declared here, before the cleanup defer below,
+	// because Go resolves a defer closure's free variables by lexical
+	// position at compile time: a variable declared later in this function's
+	// source (e.g. the `result` returned near the bottom) cannot be read by
+	// a defer written above it, even though the defer itself runs after that
+	// later declaration executes. Threaded by pointer through
+	// attemptBackendTimeoutSalvage/pushAndCreatePRAfterTimeout/holdPushedBranch.
+	preserveWorktreeOnPushFailure := false
+
 	// Ensure worktree cleanup on exit (handles panic, early return, success).
 	// before_remove hook fires just before worktree teardown (TASK-305).
 	var beforeRemoveHookFn func()
 	if cleanupWorktree != nil {
 		defer func() {
+			if preserveWorktreeOnPushFailure {
+				r.log.Warn("GH-5399: preserving worktree and local branch after a push failure during timeout salvage — commits exist only here",
+					slog.String("task_id", task.ID),
+					slog.String("worktree", executionPath),
+					slog.String("branch", task.Branch),
+				)
+				return
+			}
 			if beforeRemoveHookFn != nil {
 				beforeRemoveHookFn()
 			}
@@ -4690,7 +4758,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		// unconditionally. Only reachable via the timedOut branch above —
 		// ordinary classified backend failures (rate limit, API error,
 		// refusal, ...) always fall through here exactly as before.
-		if timedOut && r.attemptBackendTimeoutSalvage(ctx, task, git, result, executionPath, log, recorder) {
+		if timedOut && r.attemptBackendTimeoutSalvage(ctx, task, git, result, executionPath, log, recorder, &preserveWorktreeOnPushFailure) {
 			return result, nil
 		}
 
@@ -5355,6 +5423,25 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 						slog.Int("attempt", outcome.Attempt),
 						slog.Int("retry_attempt", retryAttempt),
 					)
+
+					// GH-5399: taskCtxWasDone (captured before finalizeCtx ran, at the
+					// top of this block) means the task's own deadline had already
+					// passed before the backend even returned from its first pass —
+					// re-invoking it here for a quality-gate retry would be exactly
+					// the unbounded second invocation GH-5346 closed for the error
+					// path (attemptBackendTimeoutSalvage never re-invokes either).
+					// Run gates only once in that case: push whatever this single
+					// pass produced and hand it to a human instead of looping,
+					// mirroring holdPushedBranch's role on the error path. No
+					// recorder.Finish call here — matches attemptBackendTimeoutSalvage's
+					// call site (line ~4698), which also returns bare after a
+					// successful hold/salvage and lets the caller finalize.
+					if taskCtxWasDone {
+						r.holdPushedBranch(ctx, task, git, result, log,
+							"quality gates failed and the task's deadline had already passed before the backend returned, so Pilot will not re-invoke Claude Code for a retry",
+							executionPath, &preserveWorktreeOnPushFailure)
+						return result, nil
+					}
 
 					// Check if we should retry with Claude Code
 					if outcome.ShouldRetry && retryAttempt < maxAutoRetries {

--- a/internal/executor/runner_gh5399_test.go
+++ b/internal/executor/runner_gh5399_test.go
@@ -1,0 +1,206 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSuccessPath_TaskCtxExpired_GatesFail_HoldsBranchNoReinvocation is the
+// GH-5399 regression guard for Fix 1: GH-5346 forbade re-invoking Claude Code
+// once the backend has already burned the task's full budget — but that
+// guarantee only covered the *error* path (attemptBackendTimeoutSalvage,
+// reached when the backend itself returns a ctx-deadline error). It did not
+// cover the *success* path: a backend that ignores the ctx it's handed (as
+// some backend implementations effectively do once they've already started
+// an uninterruptible tool call) can return Success:true well after the
+// task's own deadline has passed. Before this fix, a failing post-hoc
+// quality-gate check on that stale success would still fall into the normal
+// gate-retry loop and re-invoke the backend via a fresh context.Background()
+// timeout — exactly the unbounded second invocation GH-5346 closed for the
+// error path. This test drives that exact shape: a backend that ignores ctx,
+// sleeps past the task's deadline, commits real work, and returns success;
+// paired with a quality checker that always fails with ShouldRetry:true. The
+// backend must be invoked exactly once, and the salvaged commit must be
+// pushed and held under pilot-needs-human rather than retried.
+func TestSuccessPath_TaskCtxExpired_GatesFail_HoldsBranchNoReinvocation(t *testing.T) {
+	capturedTitleFile, capturedLabelEditsFile := setUpFakeGhPRCreateAndLabelPATH(t)
+
+	const branch = "pilot/GH-5399-taskctx-expired-gates-fail"
+	dir, _ := setupFreshnessRepo(t)
+	runGit(t, dir, "checkout", "-b", branch)
+
+	backend := &mockGH4964Backend{
+		perCall: func(_ int, _ ExecuteOptions) *BackendResult {
+			// Simulate a backend that ignores the ctx it was handed (e.g.
+			// already mid an uninterruptible tool call) and only returns
+			// once the task's own deadline has already elapsed.
+			writeUncommittedFile(t, dir, "salvaged.go")
+			runGit(t, dir, "add", "salvaged.go")
+			runGit(t, dir, "commit", "-m", "real work landed after the task deadline elapsed")
+			time.Sleep(150 * time.Millisecond)
+			return &BackendResult{Success: true}
+		},
+	}
+	runner := newGH4964Runner(backend)
+	runner.qualityCheckerFactory = func(string, string) QualityChecker {
+		return &stubQualityChecker{outcome: &QualityOutcome{Passed: false, ShouldRetry: true}}
+	}
+
+	task := newGH4964Task("GH-5399", branch, dir)
+
+	// A short deadline that will have elapsed by the time the ctx-ignoring
+	// backend above returns (it sleeps 150ms past its call).
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+
+	if backend.callCount() != 1 {
+		t.Errorf("expected backend called exactly once (GH-5399: a failing gate check after the task's deadline already passed must never re-invoke Claude Code), got %d", backend.callCount())
+	}
+	if result.Success {
+		t.Errorf("expected Success=false when post-deadline quality gates fail, got true")
+	}
+	if result.Outcome != "needs_human" {
+		t.Errorf("expected Outcome=%q, got %q (error=%q)", "needs_human", result.Outcome, result.Error)
+	}
+	if result.PRUrl != "" {
+		t.Errorf("expected no PR URL (gates failed), got %q", result.PRUrl)
+	}
+	if _, statErr := os.Stat(capturedTitleFile); statErr == nil {
+		t.Error("gh pr create must not be invoked when post-deadline quality gates fail")
+	}
+
+	remoteBranches := gitOutput(t, dir, "ls-remote", "origin", branch)
+	if strings.TrimSpace(remoteBranches) == "" {
+		t.Errorf("expected branch %q to still be pushed to origin even though gates failed, ls-remote returned nothing", branch)
+	}
+
+	labelEdits, readErr := os.ReadFile(capturedLabelEditsFile)
+	if readErr != nil {
+		t.Fatalf("expected a `gh issue edit` call applying pilot-needs-human, got no captured calls: %v", readErr)
+	}
+	if !strings.Contains(string(labelEdits), labelPilotNeedsHuman) {
+		t.Errorf("expected the captured `gh issue edit` call to add %q, got:\n%s", labelPilotNeedsHuman, labelEdits)
+	}
+}
+
+// TestBackendTimeoutSalvage_PushFailure_PreservesWorktreeAndBranch is the
+// GH-5399 regression guard for Fix 3: previously holdPushedBranch shared one
+// 30s context.WithoutCancel(ctx) window across the branch push AND the
+// comment/label calls, and — regardless of budget — a push that still ended
+// up failing simply fell through to executeWithOptions's ordinary worktree
+// cleanup defer, which force-deletes the local branch (`git branch -D`) and
+// removes the worktree directory. That destroys the ONLY remaining copy of
+// the salvaged commits: they were never reachable from the remote (the push
+// failed) and now they're gone locally too. This test drives a real push
+// failure (a broken origin remote) through the full Execute() pipeline with
+// worktree isolation enabled, and asserts the worktree directory and its
+// local branch both survive on disk, and the needs-human comment names them.
+func TestBackendTimeoutSalvage_PushFailure_PreservesWorktreeAndBranch(t *testing.T) {
+	ghLogPath := filepath.Join(t.TempDir(), "gh-calls.log")
+	ghAppendLogScript(t, ghLogPath)
+
+	const branch = "pilot/GH-5399-push-failure-preserve"
+	dir, _ := setupFreshnessRepo(t)
+
+	var mu sync.Mutex
+	var capturedWorktreePath string
+
+	backend := &ctxRespectingBackend{
+		run: func(ctx context.Context, _ int, opts ExecuteOptions) (*BackendResult, error) {
+			mu.Lock()
+			capturedWorktreePath = opts.ProjectPath
+			mu.Unlock()
+
+			// Break the shared origin remote (worktrees share the main
+			// repo's .git config) from inside the callback, once the
+			// worktree — and its own fetch of origin/main — already
+			// exist, so the later salvage push genuinely fails.
+			runGit(t, opts.ProjectPath, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "unreachable-remote"))
+
+			writeUncommittedFile(t, opts.ProjectPath, "salvaged.go")
+			runGit(t, opts.ProjectPath, "add", "salvaged.go")
+			runGit(t, opts.ProjectPath, "commit", "-m", "real work before the deadline hit")
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	runner := newGH4964Runner(backend)
+	runner.config.UseWorktree = true
+	runner.qualityCheckerFactory = func(string, string) QualityChecker {
+		return &stubQualityChecker{outcome: &QualityOutcome{Passed: true}}
+	}
+
+	task := newGH4964Task("GH-5399", branch, dir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+
+	mu.Lock()
+	worktreePath := capturedWorktreePath
+	mu.Unlock()
+	if worktreePath == "" {
+		t.Fatal("backend was never invoked with a worktree ProjectPath — test setup is broken")
+	}
+
+	if result.Success {
+		t.Errorf("expected Success=false when the salvage push fails, got true")
+	}
+	if result.Outcome != "needs_human" {
+		t.Errorf("expected Outcome=%q, got %q (error=%q)", "needs_human", result.Outcome, result.Error)
+	}
+
+	if _, statErr := os.Stat(worktreePath); statErr != nil {
+		t.Errorf("expected the worktree directory %q to survive a failed salvage push, but it's gone: %v", worktreePath, statErr)
+	}
+
+	branchList := gitOutput(t, dir, "branch", "--list", branch)
+	if strings.TrimSpace(branchList) == "" {
+		t.Errorf("expected local branch %q to survive a failed salvage push, but `git branch --list` found nothing", branch)
+	}
+
+	calls := parseGhInvocations(t, ghLogPath)
+	var commentBody string
+	for _, args := range calls {
+		if len(args) >= 3 && args[0] == "issue" && args[1] == "comment" {
+			for i, a := range args {
+				if a == "--body" && i+1 < len(args) {
+					commentBody = args[i+1]
+				}
+			}
+		}
+	}
+	if commentBody == "" {
+		t.Fatalf("expected a `gh issue comment` call recording the needs-human hold, got calls: %v", calls)
+	}
+	if !strings.Contains(commentBody, worktreePath) {
+		t.Errorf("expected the needs-human comment to name the preserved worktree path %q, got:\n%s", worktreePath, commentBody)
+	}
+	if !strings.Contains(commentBody, branch) {
+		t.Errorf("expected the needs-human comment to name the branch %q, got:\n%s", branch, commentBody)
+	}
+
+	var labelCall string
+	for _, args := range calls {
+		if len(args) >= 3 && args[0] == "issue" && args[1] == "edit" {
+			labelCall = strings.Join(args, " ")
+		}
+	}
+	if !strings.Contains(labelCall, labelPilotNeedsHuman) {
+		t.Errorf("expected a `gh issue edit` call adding %q, got:\n%s", labelPilotNeedsHuman, labelCall)
+	}
+}

--- a/internal/executor/terminal_status_test.go
+++ b/internal/executor/terminal_status_test.go
@@ -22,6 +22,7 @@ func TestTerminalStatus(t *testing.T) {
 		{"rate_limited outcome", &ExecutionResult{Outcome: "rate_limited"}, "rate_limited"},
 		{"infra outcome", &ExecutionResult{Outcome: "infra"}, "infra"},
 		{"skipped outcome", &ExecutionResult{Outcome: "skipped"}, "skipped"},
+		{"needs_human outcome (GH-5399)", &ExecutionResult{Outcome: "needs_human"}, "needs_human"},
 		{
 			"no-op via error signature (phantom no-op, work already on base)",
 			&ExecutionResult{Error: "no new commit produced — post-push SHA matches base branch"},
@@ -140,11 +141,12 @@ func TestTerminalStatus(t *testing.T) {
 // TestTerminalPhaseLabel verifies the dashboard progress phase matches the status.
 func TestTerminalPhaseLabel(t *testing.T) {
 	cases := map[string]string{
-		"no_op":    "No-op",
-		"stalled":  "Stalled",
-		"declined": "Declined",
-		"failed":   "Failed",
-		"anything": "Failed",
+		"no_op":       "No-op",
+		"stalled":     "Stalled",
+		"declined":    "Declined",
+		"needs_human": "Needs Human",
+		"failed":      "Failed",
+		"anything":    "Failed",
 	}
 	for status, want := range cases {
 		if got := terminalPhaseLabel(status); got != want {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1322,6 +1322,14 @@ func (s *Store) HasCompletedExecution(taskID, projectPath string) (bool, error) 
 // row alongside an earlier no_op row — the fresh row would be "latest" and
 // would wrongly hide the terminal no_op if this used the same latest-only
 // definition. Scanning every row for the task avoids that ordering trap.
+//
+// GH-5399: 'needs_human' counts as terminal here too. A holdPushedBranch
+// row means salvaged work was pushed and handed off for manual review —
+// there is nothing left for a fresh retry generation to redo, and
+// nextRetryGeneration consults this function precisely to decide that.
+// Without this, a needs_human row (which TerminalStatus/terminalExecutionStatuses
+// now also treat as terminal) would still look "not done" here and could be
+// handed a brand new generation on top of the held branch.
 func (s *Store) HasTerminalCompletion(taskID, projectPath string) (bool, error) {
 	completed, err := s.HasCompletedExecution(taskID, projectPath)
 	if err != nil {
@@ -1338,6 +1346,7 @@ func (s *Store) HasTerminalCompletion(taskID, projectPath string) (bool, error) 
 			(status = 'no_op' AND (error IS NULL OR error = ''))
 			OR status = 'canceled'
 			OR status = 'superseded'
+			OR status = 'needs_human'
 		)
 	`, taskID, projectPath).Scan(&count)
 	if err != nil {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -6653,6 +6653,46 @@ func TestHasTerminalCompletion_CountsSupersededRow(t *testing.T) {
 	}
 }
 
+// TestHasTerminalCompletion_CountsNeedsHumanRow is GH-5399's coverage: a
+// row parked under status='needs_human' by holdPushedBranch (salvaged work
+// pushed and handed off for manual review after a backend timeout) must
+// count as terminal here too, mirroring the canceled/superseded cases above
+// — otherwise nextRetryGeneration (dispatcher.go), which consults this
+// function to decide whether a task is "already done", would grant a fresh
+// retry generation on top of a held branch a human is meant to review.
+func TestHasTerminalCompletion_CountsNeedsHumanRow(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	taskID, projectPath := "GH-5399-HTC", "/project-htc-needs-human"
+
+	done, err := store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion (before any row): %v", err)
+	}
+	if done {
+		t.Fatal("expected done=false before any execution row exists")
+	}
+
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-needs-human", TaskID: taskID, ProjectPath: projectPath,
+		Status: "needs_human", Error: "quality gates failed and the task's deadline had already passed",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	done, err = store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion (after needs_human): %v", err)
+	}
+	if !done {
+		t.Error("expected done=true once a needs_human row exists — GH-5399: no fresh retry generation should be granted on top of a held branch")
+	}
+}
+
 // TestLatestSupersededExecution_FindsMostRecentSupersededRow is GH-5249's
 // coverage for the lookup the re-arm probe (cmd/pilot/rearm_superseded.go)
 // uses to find the supersede timestamp it compares GitHub issue-event times


### PR DESCRIPTION
## Summary

Follow-ups from the post-merge review of PR #5392 (issue #5346, the #5342 finalization-ctx fix):

1. **No re-invocation after a backend timeout, success path.** GH-5346 forbade re-invoking Claude Code once the backend already burned its budget, but only on the error path (`attemptBackendTimeoutSalvage`). The success-path quality-gate retry loop in `internal/executor/runner.go` had no `taskCtxWasDone` guard, so a genuine gate failure re-invoked the backend on a fresh `context.Background()` timeout even after the task's own deadline had already passed. Fixed by checking `taskCtxWasDone` before retrying: run gates once, then push+hold the salvaged work via `holdPushedBranch` on failure, exactly like the error path.
2. **`needs_human` outcome unknown to the dispatcher.** `TerminalStatus`, `terminalExecutionStatuses`, `terminalByDesignExecutionStatuses`, `terminalPhaseLabel`, and `memory.HasTerminalCompletion` all learned about `needs_human` (set by `holdPushedBranch`), so it's recorded as its own status instead of collapsing into `failed`, never stacks `pilot-failed` on top of `pilot-needs-human`, and never gets handed a fresh retry generation.
3. **Salvage push budget.** `holdPushedBranch` previously shared one 30s window across the branch push and the comment/label calls. A push that legitimately takes longer than 30s was reported as failed, and the worktree cleanup defer then force-deleted the local branch — destroying the only remaining copy of the salvaged commits. The push now gets its own 5-minute budget, separate from the 30s comment/label window; if the push still fails, the worktree/branch cleanup is skipped for that run and the needs-human comment names the worktree path and branch.

## Test plan

- [x] `TestSuccessPath_TaskCtxExpired_GatesFail_HoldsBranchNoReinvocation` — success path with an already-expired task ctx and a failing gate: backend called exactly once, branch pushed and held under `pilot-needs-human`.
- [x] `TestNextRetryGeneration_NeedsHuman` / `TestIsTerminalByDesignStatus_NeedsHuman` — dispatcher never grants a retry generation for a `needs_human` row, and it's correctly classified terminal-by-design (no `pilot-failed` stacking).
- [x] `TestBackendTimeoutSalvage_PushFailure_PreservesWorktreeAndBranch` — a genuine push failure (broken origin remote) through the full `Execute()` pipeline with worktree isolation: worktree directory and local branch both survive on disk, and the needs-human comment names them.
- [x] `go build ./...`, `go test ./internal/executor/... ./internal/memory/... ./cmd/pilot/...`, `gofmt -l`, `golangci-lint run --new-from-rev=origin/main ./...` all clean.

Closes #5399