### PR TITLE
fix(executor): abort declined executions and stop crediting fix issues with their origin PR (GH-5400)

### DIFF
--- a/cmd/pilot/execution_saver_cancel_gh5400_test.go
+++ b/cmd/pilot/execution_saver_cancel_gh5400_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdkCore "github.com/qf-studio/studio-sdk/sdk/core"
+
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// blockingCancelBackend is a minimal executor.Backend whose Execute blocks
+// until ctx is canceled, then returns ctx.Err(). It lets this test park a
+// "task" in a live, in-flight state and assert that canceling it actually
+// unblocks Execute — mirroring internal/executor's own unexported
+// blockingBackend test helper (dispatcher_test.go), reimplemented here since
+// package main cannot reach that unexported type directly.
+type blockingCancelBackend struct{}
+
+func (b *blockingCancelBackend) Name() string      { return "test-blocking-cancel" }
+func (b *blockingCancelBackend) IsAvailable() bool { return true }
+func (b *blockingCancelBackend) Execute(ctx context.Context, _ executor.ExecuteOptions) (*executor.BackendResult, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// waitUntil polls cond every 10ms until it returns true or timeout elapses,
+// failing the test if it never does.
+func waitUntil(t *testing.T, timeout time.Duration, msg string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for: %s", msg)
+}
+
+// TestSaveDeclinedExecutionRecord_CancelsLiveExecution is the GH-5400
+// regression test for defect #1 (the incident behind issue #5386): a
+// preflight decline firing while taskID's execution is still genuinely
+// running (e.g. a stale-label re-pick race lets the poller re-evaluate a
+// task whose original dispatch never stopped, exactly #5386's 15:22Z
+// label-strip -> 15:43:53Z re-pick -> 15:49:20Z decline timeline) must abort
+// that execution instead of letting it run straight through to a commit and
+// PR while pilot-needs-clarification sits on the issue.
+//
+// Before the GH-5400 fix, storeExecutionSaver.SaveDeclinedExecutionRecord's
+// runner.IsRunning/runner.Cancel calls were wired up but silently never
+// fired for a real execution: Runner.running (a map[string]*exec.Cmd) is
+// only ever populated by direct test manipulation, never by the actual
+// ClaudeCodeBackend/OpenCode/etc. execution path, which owns its subprocess
+// entirely internally (see execCancel field doc, runner.go). This test uses
+// a fake Backend instead of a real subprocess specifically so it can prove
+// the cancellation signal reaches a genuinely in-flight Execute call end to
+// end, through the real (non-test-only) production code path.
+func TestSaveDeclinedExecutionRecord_CancelsLiveExecution(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	runner := executor.NewRunnerWithBackend(&blockingCancelBackend{})
+	runner.SetSkipPreflightChecks(true)
+
+	task := &executor.Task{
+		ID:          "GH-9100",
+		Title:       "fix(ci): resolve post-merge CI failure",
+		ProjectPath: t.TempDir(),
+	}
+
+	resultCh := make(chan *executor.ExecutionResult, 1)
+	go func() {
+		result, _ := runner.Execute(context.Background(), task)
+		resultCh <- result
+	}()
+
+	waitUntil(t, 2*time.Second, "runner reports task as running", func() bool {
+		return runner.IsRunning(task.ID)
+	})
+
+	saver := storeExecutionSaver{store: store, runner: runner}
+	if err := saver.SaveDeclinedExecutionRecord(sdkCore.DeclinedExecutionRecord{
+		TaskID:      task.ID,
+		ProjectPath: task.ProjectPath,
+		Status:      "declined-preflight",
+		Reason:      "reject_vague",
+	}); err != nil {
+		t.Fatalf("SaveDeclinedExecutionRecord failed: %v", err)
+	}
+
+	var result *executor.ExecutionResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Execute did not return after preflight decline canceled it — the live execution was not actually aborted")
+	}
+
+	if result.Success {
+		t.Error("result.Success = true, want false — a canceled execution must not report success")
+	}
+	if result.PRUrl != "" {
+		t.Errorf("result.PRUrl = %q, want empty — a declined/canceled execution must not produce a PR", result.PRUrl)
+	}
+	if runner.IsRunning(task.ID) {
+		t.Error("runner.IsRunning(task.ID) = true after Execute returned, want false")
+	}
+}
+
+// TestSaveDeclinedExecutionRecord_NoRunner_DoesNotPanic verifies the nil
+// runner case (a repo with no in-process runner wired) is a no-op, not a
+// crash — SaveDeclinedExecutionRecord must keep working for the many
+// existing callers that never had a runner reference to begin with.
+func TestSaveDeclinedExecutionRecord_NoRunner_DoesNotPanic(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	saver := storeExecutionSaver{store: store}
+	if err := saver.SaveDeclinedExecutionRecord(sdkCore.DeclinedExecutionRecord{
+		TaskID:      "GH-9101",
+		ProjectPath: "/tmp/gh-5400-no-runner",
+		Status:      "declined-preflight",
+		Reason:      "reject_vague",
+	}); err != nil {
+		t.Fatalf("SaveDeclinedExecutionRecord failed: %v", err)
+	}
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -4441,6 +4441,16 @@ type storeExecutionSaver struct {
 	// reacts via the owner-death path (GH-4842) instead of only being
 	// recorded for observability.
 	controller *autopilot.Controller
+	// runner is optional (nil for a repo with no in-process runner wired) —
+	// when set, a preflight decline that fires while taskID is still actively
+	// executing kills that execution (GH-5400) instead of letting it run
+	// straight through to a PR while pilot-needs-clarification sits on the
+	// issue. Safe only because this hook runs in the same daemon process as
+	// the Runner it cancels — unlike the standalone `pilot task cancel` CLI
+	// (ExecutionLifecycle.Cancel, commands.go), which refuses a running row
+	// because a separate CLI invocation has no handle on the daemon's live
+	// subprocess.
+	runner *executor.Runner
 }
 
 // ownerDeathReactTimeout bounds the synchronous owner-death reaction
@@ -4477,8 +4487,9 @@ func (s storeExecutionSaver) SaveDeclinedExecutionRecord(rec sdkCore.DeclinedExe
 		}
 	}
 
+	execID := fmt.Sprintf("%s-preflight-%d", rec.TaskID, now.UnixNano())
 	err := s.store.SaveExecution(&memory.Execution{
-		ID:          fmt.Sprintf("%s-preflight-%d", rec.TaskID, now.UnixNano()),
+		ID:          execID,
 		TaskID:      rec.TaskID,
 		ProjectPath: rec.ProjectPath,
 		Status:      rec.Status,
@@ -4487,6 +4498,28 @@ func (s storeExecutionSaver) SaveDeclinedExecutionRecord(rec sdkCore.DeclinedExe
 		CompletedAt: &now,
 		IsCanary:    isCanary,
 	})
+
+	// GH-5400: the SDK poller's admission loop calls its pre-flight judge
+	// synchronously before dispatch, so under ordinary operation a decline
+	// here always precedes any execution for taskID. But a stale-label/rearm
+	// race (e.g. an in-progress label wrongly stripped mid-run, GH-5386's
+	// #5386 timeline) can make the same task_id look admissible again while
+	// its original dispatch is still alive — the poller then re-evaluates
+	// and declines an issue that already has a live execution running.
+	// Without this, that execution runs straight through the decline: it can
+	// still commit, open a PR, and land pilot-done with pilot-needs-clarification
+	// sitting on the issue the whole time (the exact defect this guards). Kill
+	// the live subprocess so the decline is authoritative — this hook runs
+	// in-process with the Runner it cancels, unlike the CLI cancel path.
+	if rec.Status == "declined-preflight" && s.runner != nil && s.runner.IsRunning(rec.TaskID) {
+		if cancelErr := s.runner.Cancel(rec.TaskID); cancelErr != nil {
+			slog.Warn("preflight decline: task was reported running but cancel failed",
+				slog.String("task_id", rec.TaskID), slog.String("execution_id", execID), slog.Any("error", cancelErr))
+		} else {
+			slog.Warn("preflight decline: canceled in-flight execution to prevent a declined issue from shipping",
+				slog.String("task_id", rec.TaskID), slog.String("execution_id", execID), slog.String("reason", rec.Reason))
+		}
+	}
 
 	// GH-4842: a preflight decline is owner death for a Pilot-spawned fix
 	// issue — react (re-arm/escalate its source) using the same signal the

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -611,7 +611,11 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 				// GH-4842: wire the per-repo controller (may be nil) so a
 				// preflight decline of a Pilot-spawned fix issue can react
 				// via the owner-death path.
-				pollerDeps.ExecutionSaver = storeExecutionSaver{store: deps.Store, cfg: deps.Cfg, controller: controller}
+				// GH-5400: also wire the in-process Runner (may be nil) so a
+				// decline that fires against a task_id with a live execution
+				// (stale-label/rearm race) cancels it instead of letting it
+				// run straight through to a PR.
+				pollerDeps.ExecutionSaver = storeExecutionSaver{store: deps.Store, cfg: deps.Cfg, controller: controller, runner: deps.Runner}
 			}
 		}
 	}

--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -973,6 +975,51 @@ func parseFirstPRURL(jsonOutput []byte) string {
 		return ""
 	}
 	return prs[0].URL
+}
+
+// prURLNumberRe extracts the numeric PR id from a GitHub PR URL
+// (".../pull/123" or ".../pulls/123"). Mirrors adapters/github.ExtractPRNumber
+// byte-for-byte; duplicated locally because internal/executor cannot import
+// internal/adapters/github without an import cycle (see issue_state.go's
+// doc comment for the same constraint on this package).
+var prURLNumberRe = regexp.MustCompile(`/pulls?/(\d+)`)
+
+// extractPRNumberFromURL parses the PR number out of a GitHub pull-request
+// URL, returning ok=false if none could be found.
+func extractPRNumberFromURL(prURL string) (num int, ok bool) {
+	m := prURLNumberRe.FindStringSubmatch(prURL)
+	if len(m) < 2 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// isBorrowedOriginPR reports whether prURL points at task.FromPR — the
+// origin PR whose branch a fix-issue task is continuing (resolveAutopilotFixBranch
+// in cmd/pilot/handlers.go reuses the origin PR's branch name and records its
+// number as FromPR for --from-pr session resumption, GH-1267/GH-5379).
+//
+// GH-5400: FindMergedPRByBranch/FindOpenPRByBranch key purely on branch name.
+// For a fresh dispatch of a fix issue that has not yet pushed a single commit
+// of its own, that reused branch's merged/open PR is still task.FromPR itself
+// — evidence the ORIGIN issue's work shipped, not this fix issue's. Treating
+// it as "my own work is already done" (the pre-GH-5400 behavior of every
+// FindMergedPRByBranch/FindOpenPRByBranch call site in this file) let a fix
+// issue with no PR of its own short-circuit to "Completed" on its very first
+// dispatch tick and get closed citing the origin PR — the incident behind
+// fix issue #5385 closing "done" against PR #5384's merge. A merged/open PR
+// found on the branch that is NOT task.FromPR is still trusted as evidence of
+// this task's own (possibly retried) work, unchanged from prior behavior.
+func isBorrowedOriginPR(task *Task, prURL string) bool {
+	if task == nil || task.FromPR <= 0 {
+		return false
+	}
+	num, ok := extractPRNumberFromURL(prURL)
+	return ok && num == task.FromPR
 }
 
 // GetCurrentBranch returns the current branch name

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -971,15 +971,32 @@ type Runner struct {
 	// that assigns ExecuteOptions.ProjectPath and guards against it
 	// silently collapsing to task.ProjectPath when worktree isolation was
 	// expected. A direct r.backend.Execute call bypasses that guard.
-	backend                Backend // AI execution backend
-	config                 *BackendConfig
-	onProgress             ProgressCallback
-	progressCallbacks      map[string]ProgressCallback // Named callbacks for multi-listener support
-	progressMu             sync.RWMutex                // Protects progressCallbacks
-	tokenCallbacks         map[string]TokenCallback    // Named callbacks for token usage updates
-	tokenMu                sync.RWMutex                // Protects tokenCallbacks
-	mu                     sync.Mutex
-	running                map[string]*exec.Cmd
+	backend           Backend // AI execution backend
+	config            *BackendConfig
+	onProgress        ProgressCallback
+	progressCallbacks map[string]ProgressCallback // Named callbacks for multi-listener support
+	progressMu        sync.RWMutex                // Protects progressCallbacks
+	tokenCallbacks    map[string]TokenCallback    // Named callbacks for token usage updates
+	tokenMu           sync.RWMutex                // Protects tokenCallbacks
+	mu                sync.Mutex
+	running           map[string]*exec.Cmd
+	// execCancel holds the context.CancelFunc for each task.ID currently
+	// inside executeWithOptions, guarded by mu alongside running. GH-5400:
+	// `running` is populated only by direct exec.Cmd tracking, which nothing
+	// in the current Claude Code / OpenCode / etc. backend path ever writes
+	// to (ClaudeCodeBackend.executeWithFromPR owns its *exec.Cmd entirely
+	// internally) — Cancel/IsRunning were therefore always no-ops for a real
+	// execution despite reading like they worked (see lifecycle.go's Cancel,
+	// which documents the same gap: "no PID/handle is tracked anywhere for a
+	// running row"). execCancel closes that gap without touching the Backend
+	// interface: executeWithOptions wraps its ctx in context.WithCancel and
+	// registers the cancel func here for the lifetime of the call, so
+	// canceling it propagates down through backendExecute's ctx into
+	// exec.CommandContext, which SIGKILLs the whole process group (see
+	// cmd.Cancel override in backend_claudecode.go). Cancel/IsRunning check
+	// this map first and fall back to the legacy running map so any existing
+	// caller that does populate running directly keeps working unchanged.
+	execCancel             map[string]context.CancelFunc
 	log                    *slog.Logger
 	recordingsPath         string                                                          // Path to recordings directory (empty = default)
 	enableRecording        bool                                                            // Whether to record executions
@@ -1141,6 +1158,7 @@ func NewRunner() *Runner {
 	return &Runner{
 		backend:           NewClaudeCodeBackend(nil),
 		running:           make(map[string]*exec.Cmd),
+		execCancel:        make(map[string]context.CancelFunc),
 		progressCallbacks: make(map[string]ProgressCallback),
 		tokenCallbacks:    make(map[string]TokenCallback),
 		taskProgress:      make(map[string]int),
@@ -1161,6 +1179,7 @@ func NewRunnerWithBackend(backend Backend) *Runner {
 	return &Runner{
 		backend:           backend,
 		running:           make(map[string]*exec.Cmd),
+		execCancel:        make(map[string]context.CancelFunc),
 		progressCallbacks: make(map[string]ProgressCallback),
 		tokenCallbacks:    make(map[string]TokenCallback),
 		taskProgress:      make(map[string]int),
@@ -2279,7 +2298,10 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 
 	// TASK-359 Layer 1 (Shape C): if this branch's work is already merged, do not
 	// open a duplicate PR. Record the existing merged PR's URL and finish.
-	if mergedURL, mergedErr := git.FindMergedPRByBranch(ctx, task.Branch); mergedErr == nil && mergedURL != "" {
+	// GH-5400: skip when the merged PR found is task.FromPR itself — that's
+	// the origin PR this fix-issue branch was continued from, not evidence
+	// this epic's own work already shipped (see isBorrowedOriginPR).
+	if mergedURL, mergedErr := git.FindMergedPRByBranch(ctx, task.Branch); mergedErr == nil && mergedURL != "" && !isBorrowedOriginPR(task, mergedURL) {
 		result.PRUrl = mergedURL
 		r.log.Info("Epic branch already merged, skipping duplicate PR",
 			slog.String("task_id", task.ID),
@@ -2402,6 +2424,23 @@ func (r *Runner) checkAlreadyMergedBranch(ctx context.Context, git *GitOperation
 	if mergedErr != nil || mergedURL == "" {
 		return false
 	}
+	// GH-5400: a fix-issue task's branch is often borrowed from the origin
+	// PR it continues (task.FromPR) via resolveAutopilotFixBranch. That
+	// origin PR being merged already is not evidence THIS task's own work
+	// shipped — it's the reason this fix issue exists in the first place.
+	// Without this check, a fresh fix-issue dispatch that hasn't pushed a
+	// single commit yet short-circuited here on tick one, reported the
+	// origin PR as its own deliverable, and got closed "done" citing
+	// someone else's merge (incident behind fix issue #5385 / PR #5384).
+	if isBorrowedOriginPR(task, mergedURL) {
+		r.log.Info("Branch's merged PR is the origin PR this fix-issue branch was continued from, not this task's own deliverable — proceeding with push+PR creation",
+			slog.String("task_id", task.ID),
+			slog.String("branch", task.Branch),
+			slog.Int("from_pr", task.FromPR),
+			slog.String("origin_pr_url", mergedURL),
+		)
+		return false
+	}
 	result.PRUrl = mergedURL
 	r.log.Info("Branch already merged, skipping push and PR creation",
 		slog.String("task_id", task.ID),
@@ -2428,6 +2467,19 @@ func (r *Runner) checkAlreadyMergedBranch(ctx context.Context, git *GitOperation
 func (r *Runner) adoptOpenBranchPR(ctx context.Context, git *GitOperations, task *Task, result *ExecutionResult, recorder *replay.Recorder) bool {
 	openURL, openErr := git.FindOpenPRByBranch(ctx, task.Branch)
 	if openErr != nil || openURL == "" {
+		return false
+	}
+	// GH-5400: an open PR still equal to task.FromPR is the origin PR this
+	// fix-issue branch was continued from (see isBorrowedOriginPR /
+	// checkAlreadyMergedBranch above), not evidence this task already has
+	// its own PR — do not adopt it.
+	if isBorrowedOriginPR(task, openURL) {
+		r.log.Info("Branch's open PR is the origin PR this fix-issue branch was continued from, not this task's own PR — not adopting",
+			slog.String("task_id", task.ID),
+			slog.String("branch", task.Branch),
+			slog.Int("from_pr", task.FromPR),
+			slog.String("origin_pr_url", openURL),
+		)
 		return false
 	}
 	result.PRUrl = openURL
@@ -2508,7 +2560,7 @@ func (r *Runner) resolveEmptyBranchWithFallback(ctx context.Context, git *GitOpe
 	}
 
 	if task.Branch != "" {
-		if url, prErr := git.FindOpenPRByBranch(ctx, task.Branch); prErr == nil && url != "" {
+		if url, prErr := git.FindOpenPRByBranch(ctx, task.Branch); prErr == nil && url != "" && !isBorrowedOriginPR(task, url) {
 			r.log.Info("PR guard: an open PR already exists for the branch, treating as having commits",
 				slog.String("task_id", task.ID),
 				slog.String("branch", task.Branch),
@@ -2930,8 +2982,9 @@ func (r *Runner) pushAndCreatePRAfterTimeout(ctx context.Context, task *Task, gi
 
 	// TASK-359 Layer 1 (Shape C) parity: don't open a duplicate PR for work
 	// that is already merged (e.g. a retried dispatch of a branch salvaged
-	// once already).
-	if mergedURL, mergedErr := git.FindMergedPRByBranch(ctx, task.Branch); mergedErr == nil && mergedURL != "" {
+	// once already). GH-5400: excludes a match on task.FromPR — the origin
+	// PR this fix-issue branch was continued from, not this task's own work.
+	if mergedURL, mergedErr := git.FindMergedPRByBranch(ctx, task.Branch); mergedErr == nil && mergedURL != "" && !isBorrowedOriginPR(task, mergedURL) {
 		result.PRUrl = mergedURL
 		result.Success = true
 		log.Info("timeout salvage: branch already merged, adopting existing PR",
@@ -3207,6 +3260,23 @@ func (r *Runner) resumeDecomposedParent(ctx context.Context, task *Task, executi
 // This prevents recursive worktree creation in sub-issues and decomposed tasks.
 func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktree bool) (outResult *ExecutionResult, outErr error) {
 	start := time.Now()
+
+	// GH-5400: make this task's execution externally cancelable via
+	// Cancel(task.ID) (see execCancel field doc). Every ctx derived from
+	// this one below (backendExecute's stallExecutionCtx/retryCtx/
+	// reviewCtx, git operations, ...) is a child of it, so canceling here
+	// reaches all of them, including the live backend subprocess via
+	// exec.CommandContext's cmd.Cancel override (backend_claudecode.go) —
+	// this is what actually stops a task whose preflight was declined
+	// after dispatch instead of letting it run straight through.
+	var execCtxCancel context.CancelFunc
+	ctx, execCtxCancel = context.WithCancel(ctx)
+	r.registerExecCancel(task.ID, execCtxCancel)
+	defer func() {
+		r.unregisterExecCancel(task.ID)
+		execCtxCancel()
+	}()
+
 	defer func() {
 		// GH-4240: canary executions are still fully logged, just excluded
 		// from the live Prometheus metrics they'd otherwise pollute.
@@ -6693,14 +6763,49 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 	return result, nil
 }
 
-// Cancel terminates a running task by killing its Claude Code process.
-// Returns an error if the task is not currently running.
+// registerExecCancel records cancel as the way to abort taskID's in-flight
+// executeWithOptions call. GH-5400. Guarded by mu alongside running/execCancel.
+func (r *Runner) registerExecCancel(taskID string, cancel context.CancelFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.execCancel == nil {
+		r.execCancel = make(map[string]context.CancelFunc)
+	}
+	r.execCancel[taskID] = cancel
+}
+
+// unregisterExecCancel removes taskID's cancel func once its
+// executeWithOptions call returns. GH-5400.
+func (r *Runner) unregisterExecCancel(taskID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.execCancel, taskID)
+}
+
+// Cancel terminates a running task, aborting its execution and killing its
+// Claude Code process. Returns an error if the task is not currently running.
+//
+// GH-5400: prefers the execCancel context-cancel path (registered by
+// executeWithOptions for every real execution, including sub-tasks/decomposed
+// children) over the legacy running exec.Cmd map, which nothing in the
+// current backend path (ClaudeCodeBackend et al.) ever populates — see the
+// execCancel field doc for why that map alone was never sufficient. Canceling
+// the execCtx propagates into backendExecute's ctx and from there into
+// exec.CommandContext, which SIGKILLs the whole process group via the
+// cmd.Cancel override in backend_claudecode.go, so this still kills the
+// subprocess, not just the Go-level call.
 func (r *Runner) Cancel(taskID string) error {
 	r.mu.Lock()
-	cmd, ok := r.running[taskID]
+	cancel, execOK := r.execCancel[taskID]
+	cmd, cmdOK := r.running[taskID]
 	r.mu.Unlock()
 
-	if !ok {
+	if execOK {
+		cancel()
+		return nil
+	}
+
+	if !cmdOK {
 		return fmt.Errorf("task %s is not running", taskID)
 	}
 
@@ -6901,10 +7006,15 @@ func (r *Runner) CancelAll() {
 	})
 }
 
-// IsRunning returns true if the specified task is currently being executed.
+// IsRunning reports whether taskID is currently inside executeWithOptions
+// (GH-5400: checks execCancel, the map that is actually populated by real
+// executions) or has a directly-tracked exec.Cmd in the legacy running map.
 func (r *Runner) IsRunning(taskID string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if _, ok := r.execCancel[taskID]; ok {
+		return true
+	}
 	_, ok := r.running[taskID]
 	return ok
 }

--- a/internal/executor/runner_gh5400_test.go
+++ b/internal/executor/runner_gh5400_test.go
@@ -1,0 +1,182 @@
+package executor
+
+import (
+	"context"
+	"testing"
+)
+
+// TestExtractPRNumberFromURL covers the local mirror of
+// adapters/github.ExtractPRNumber used by isBorrowedOriginPR (GH-5400).
+func TestExtractPRNumberFromURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantNum int
+		wantOK  bool
+	}{
+		{"pull url", "https://github.com/o/r/pull/5384", 5384, true},
+		{"pulls url", "https://github.com/o/r/pulls/42", 42, true},
+		{"no number", "https://github.com/o/r/pull/", 0, false},
+		{"empty", "", 0, false},
+		{"garbage", "not a url", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			num, ok := extractPRNumberFromURL(tt.url)
+			if ok != tt.wantOK || num != tt.wantNum {
+				t.Errorf("extractPRNumberFromURL(%q) = (%d, %v), want (%d, %v)", tt.url, num, ok, tt.wantNum, tt.wantOK)
+			}
+		})
+	}
+}
+
+// TestIsBorrowedOriginPR covers the GH-5400 discriminator: a fix-issue task
+// (task.FromPR > 0) reuses its origin PR's branch, so a merged/open PR found
+// on that branch is only evidence of the origin's already-known work when its
+// number matches FromPR — any other PR number is a genuinely new/retried PR
+// for this task and must still be trusted, exactly like before this fix.
+func TestIsBorrowedOriginPR(t *testing.T) {
+	tests := []struct {
+		name  string
+		task  *Task
+		prURL string
+		want  bool
+	}{
+		{
+			name:  "fix-issue task, PR matches FromPR (origin PR) — borrowed",
+			task:  &Task{ID: "GH-5385", Branch: "pilot/GH-5379", FromPR: 5384},
+			prURL: "https://github.com/o/r/pull/5384",
+			want:  true,
+		},
+		{
+			name:  "fix-issue task, PR differs from FromPR — this task's own PR",
+			task:  &Task{ID: "GH-5385", Branch: "pilot/GH-5379", FromPR: 5384},
+			prURL: "https://github.com/o/r/pull/5401",
+			want:  false,
+		},
+		{
+			name:  "ordinary task, no FromPR — never borrowed",
+			task:  &Task{ID: "GH-100", Branch: "pilot/GH-100"},
+			prURL: "https://github.com/o/r/pull/100",
+			want:  false,
+		},
+		{
+			name:  "nil task",
+			task:  nil,
+			prURL: "https://github.com/o/r/pull/1",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBorrowedOriginPR(tt.task, tt.prURL); got != tt.want {
+				t.Errorf("isBorrowedOriginPR() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCheckAlreadyMergedBranch_SkipsBorrowedOriginPR is the GH-5400
+// regression test for the incident behind fix issue #5385: a fix issue's
+// task reuses its origin PR's branch (resolveAutopilotFixBranch), and that
+// origin PR (task.FromPR) already merged before this task ever pushed a
+// commit of its own. Pre-fix, checkAlreadyMergedBranch treated the origin
+// PR's merge as this task's own completed deliverable and short-circuited on
+// the very first dispatch tick — reporting PR #5384 as #5385's own PR and
+// letting the fix issue close "done" citing someone else's merge, with no PR
+// of its own. It must now fall through so the caller proceeds to push+create
+// a genuine PR for this task instead.
+func TestCheckAlreadyMergedBranch_SkipsBorrowedOriginPR(t *testing.T) {
+	setUpFakeGhPATH(t,
+		[]byte(`[{"url":"https://github.com/o/r/pull/5384"}]`), // merged: the origin PR
+		[]byte(`[]`),
+	)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	r := newSilentRunnerTask359()
+	r.SetLogStore(store)
+	git := NewGitOperations(t.TempDir())
+	task := &Task{
+		ID:       "GH-5385",
+		Title:    "fix(ci): resolve post-merge CI failure from PR #5384",
+		Branch:   "pilot/GH-5379", // borrowed from the origin PR's branch
+		CreatePR: true,
+		FromPR:   5384, // the origin PR this fix issue was spawned to continue
+	}
+	result := &ExecutionResult{TaskID: task.ID, Success: true}
+
+	if handled := r.checkAlreadyMergedBranch(context.Background(), git, task, result, nil); handled {
+		t.Fatalf("checkAlreadyMergedBranch short-circuited on the origin PR (FromPR=%d) — expected it to fall through so the fix issue's own work still gets pushed and its own PR created", task.FromPR)
+	}
+	if result.PRUrl != "" {
+		t.Errorf("result.PRUrl = %q, want empty — the origin PR must not be reported as this task's deliverable", result.PRUrl)
+	}
+}
+
+// TestCheckAlreadyMergedBranch_TrustsGenuinelyDifferentMergedPR verifies the
+// FromPR guard does not overreach: when the merged PR found on the branch is
+// NOT the origin PR (e.g. a retried dispatch of this exact fix-issue task
+// that already pushed and merged its own PR), the pre-GH-5400 short-circuit
+// behavior is unchanged.
+func TestCheckAlreadyMergedBranch_TrustsGenuinelyDifferentMergedPR(t *testing.T) {
+	setUpFakeGhPATH(t,
+		[]byte(`[{"url":"https://github.com/o/r/pull/5401"}]`), // merged: this task's own (retried) PR
+		[]byte(`[]`),
+	)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	r := newSilentRunnerTask359()
+	r.SetLogStore(store)
+	git := NewGitOperations(t.TempDir())
+	task := &Task{
+		ID:       "GH-5385",
+		Title:    "fix(ci): resolve post-merge CI failure from PR #5384",
+		Branch:   "pilot/GH-5379",
+		CreatePR: true,
+		FromPR:   5384,
+	}
+	result := &ExecutionResult{TaskID: task.ID, Success: true}
+
+	if handled := r.checkAlreadyMergedBranch(context.Background(), git, task, result, nil); !handled {
+		t.Fatal("expected checkAlreadyMergedBranch to short-circuit on a genuinely different merged PR")
+	}
+	if result.PRUrl != "https://github.com/o/r/pull/5401" {
+		t.Errorf("result.PRUrl = %q, want the task's own merged PR (5401)", result.PRUrl)
+	}
+}
+
+// TestAdoptOpenBranchPR_SkipsBorrowedOriginPR mirrors
+// TestCheckAlreadyMergedBranch_SkipsBorrowedOriginPR for the open-PR adoption
+// checkpoint (GH-5400): an open PR that is still task.FromPR must not be
+// adopted as this task's own PR.
+func TestAdoptOpenBranchPR_SkipsBorrowedOriginPR(t *testing.T) {
+	setUpFakeGhPATH(t,
+		[]byte(`[]`),
+		[]byte(`[{"url":"https://github.com/o/r/pull/5384"}]`), // open: the origin PR
+	)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	r := newSilentRunnerTask359()
+	r.SetLogStore(store)
+	git := NewGitOperations(t.TempDir())
+	task := &Task{
+		ID:       "GH-5385",
+		Branch:   "pilot/GH-5379",
+		CreatePR: true,
+		FromPR:   5384,
+	}
+	result := &ExecutionResult{TaskID: task.ID, Success: true}
+
+	if handled := r.adoptOpenBranchPR(context.Background(), git, task, result, nil); handled {
+		t.Fatal("adoptOpenBranchPR adopted the origin PR — expected it to skip and let the fix issue create its own PR")
+	}
+	if result.PRUrl != "" {
+		t.Errorf("result.PRUrl = %q, want empty", result.PRUrl)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two pipeline defects observed 2026-09-08 with autopilot's post-merge fix issues (GH-5400):

1. **Preflight decline didn't stop the execution (#5386).** `storeExecutionSaver.SaveDeclinedExecutionRecord` called `Runner.IsRunning`/`Runner.Cancel` on decline, but those only ever consulted `Runner.running` (`map[string]*exec.Cmd`) — a map nothing in the real backend path (`ClaudeCodeBackend` et al.) ever populates, since the backend owns its subprocess entirely internally. The guard was wired up but silently a no-op. `executeWithOptions` now wraps its `ctx` in `context.WithCancel` and registers the cancel func per `task.ID` (`execCancel`); `Cancel`/`IsRunning` check that first. Canceling now genuinely propagates through `backendExecute`'s ctx into `exec.CommandContext`, which kills the whole subprocess process group.

2. **A fix issue with no PR of its own got auto-closed as delivered by its origin PR (#5385).** A fix issue's branch is deliberately borrowed from its origin PR's branch (`resolveAutopilotFixBranch`, for `--from-pr` session resumption). Every branch-keyed "is this already done" check in the executor (`checkAlreadyMergedBranch`, `adoptOpenBranchPR`, `resolveEmptyBranchWithFallback`, `finalizeEpicBranchPR`, `pushAndCreatePRAfterTimeout`) found the origin PR already merged on that shared branch and treated it as this task's own completed deliverable — on the very first dispatch tick, before a single commit was pushed. This also explains the "picked and dropped in ~1s" cycles (defect #3): each tick hit the same short-circuit. A new `isBorrowedOriginPR` discriminator excludes a branch's merged/open PR from all five checks when it's exactly `task.FromPR` (the origin PR), while still trusting a genuinely different PR on that branch (e.g. a retried dispatch of the fix issue's own work) exactly as before.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] New test: preflight decline against a genuinely live execution (fake blocking backend) cancels it — `Execute` returns promptly with `Success=false`, no PR (`cmd/pilot/execution_saver_cancel_gh5400_test.go`)
- [x] New tests: fix issue whose origin PR (`FromPR`) is merged/open but has no PR of its own falls through instead of short-circuiting; a genuinely different merged/open PR is still trusted (`internal/executor/runner_gh5400_test.go`)
- [x] `gofmt -l` clean on all changed files