### PR TITLE
GH-5404: feat(docs): edge cache headers for pilot-docs behind CloudFront — s-maxage on HTML routes, drop the stale Traefik comment (Nelya B-07)

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -5,7 +5,9 @@ const withNextra = nextra({})
 export default withNextra({
   output: 'standalone',
   poweredByHeader: false,
-  // Compression is handled by the Traefik compress middleware; standalone
+  // pilot.quantflow.studio is served through CloudFront (since 2026-09-06);
+  // the edge only compresses uncompressed origin responses, so leaving Next's
+  // own compression off is what lets CloudFront apply Brotli. standalone
   // server.js does not honour this flag anyway (Next.js self-hosting docs §2.5).
   compress: false,
   // Docs ship static, pre-sized assets — the on-server image optimizer adds no
@@ -19,12 +21,19 @@ export default withNextra({
     return [
       {
         // All routes except /_next/static (immutable, content-hashed by Next)
-        // and favicon paths: force browser revalidation on every visit.
-        // ETag already set by Next saves the body on unchanged pages (→ 304).
+        // and favicon paths: force browser revalidation on every visit
+        // (max-age=0 — ETag already set by Next saves the body on unchanged
+        // pages via 304), while letting the CloudFront edge cache the page
+        // for a day (s-maxage=86400) and serve stale for an hour during
+        // revalidation. Deploys invalidate CloudFront's cache anyway, so this
+        // doesn't risk serving outdated content after a release.
         // Image/font rules below override Cache-Control for those asset types.
         source: '/((?!_next/static|_next/image|favicon).*)',
         headers: [
-          { key: 'Cache-Control', value: 'public, max-age=0, must-revalidate' },
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=0, s-maxage=86400, stale-while-revalidate=3600',
+          },
         ],
       },
       {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5404.

Closes #5404

## Changes

GitHub Issue GH-5404: feat(docs): edge cache headers for pilot-docs behind CloudFront — s-maxage on HTML routes, drop the stale Traefik comment (Nelya B-07)

## Context

`pilot.quantflow.studio` is served through CloudFront since 2026-09-06 (one distribution with quantflow.studio; every deploy invalidates `/*`). The docs source is this repo's `docs/` folder, synced to `qf-studio/pilot-docs` on release. Today every docs page still goes to the Frankfurt origin because `docs/next.config.mjs` (`headers()`, ~18-30) sends `Cache-Control: public, max-age=0, must-revalidate` for all non-asset routes; live check: `x-cache: Miss from cloudfront` on every request. Tracking issue on the synced repo: qf-studio/pilot-docs#1.

## Implementation

1. In `docs/next.config.mjs` `headers()`, change the catch-all route rule (`/((?!_next/static|_next/image|favicon).*)`) to `public, max-age=0, s-maxage=86400, stale-while-revalidate=3600`. Browsers keep revalidating (`max-age=0`, ETag → 304); the edge holds pages for a day and deploys invalidate anyway.
2. Leave the image/font rule (`max-age=604800, stale-while-revalidate=86400`) and the favicon rule unchanged; `/_next/static` is already immutable.
3. Keep `compress: false` (~10) — CloudFront compresses only uncompressed origin responses, so this is what enables Brotli at the edge — but replace the stale comment above it ("Compression is handled by the Traefik compress middleware") with the CloudFront truth.
4. Grep the docs folder for the word Traefik and update any deployment note that still describes the old Traefik/compose cache policy.

## Verification

- `npm run build` in `docs/` green (do not modify `package.json`).
- After the next release + docs sync + Nelya's deploy: `curl -sI -H 'Accept-Encoding: br' https://pilot.quantflow.studio/` twice → second response `x-cache: Hit from cloudfront`, `content-encoding: br`, `cache-control` carrying `s-maxage=86400`. Markdown negotiation (`Accept: text/markdown`) still returns markdown.

## Acceptance

- [ ] HTML routes send `s-maxage=86400` + `stale-while-revalidate=3600` with `max-age=0`.
- [ ] Asset and favicon rules unchanged; `compress: false` kept with a correct comment.
- [ ] Docs build green.