### PR TITLE
GH-5407: chore(deps): bump studio-sdk to v0.38.2 and implement ExecutionCheckerV2 so the poller logs the real skip reason for stalled tasks

### DIFF
--- a/.agent/tasks/gh-5407.md
+++ b/.agent/tasks/gh-5407.md
@@ -1,0 +1,31 @@
+# GH-5407
+
+**Created:** 2026-09-09
+
+## Problem
+
+GitHub Issue GH-5407: chore(deps): bump studio-sdk to v0.38.2 and implement ExecutionCheckerV2 so the poller logs the real skip reason for stalled tasks
+
+## Context
+
+studio-sdk v0.38.2 (PR #143, issue studio-sdk#142) adds `core.ExecutionCheckerV2` with `HasCompletedExecutionReason(taskID, projectPath) (skip bool, reason string, err error)`. When the host implements it, the poller logs `Skipping re-dispatch reason=<host reason>` instead of the misleading "completed execution exists" for tasks that are only in repick backoff. Pilot pins v0.38.1 (`go.mod`) and its `terminalCompletionChecker` in `cmd/pilot/main.go` (~4334) still uses the old interface plus the GH-5230 workaround INFO line ("the SDK poller's next log line is misleading").
+
+## Implementation
+
+1. `go.mod`: bump `github.com/qf-studio/studio-sdk` to v0.38.2; `go mod tidy`; commit `go.mod` and `go.sum`. No other dependency changes.
+2. Implement `HasCompletedExecutionReason` on `terminalCompletionChecker` in `cmd/pilot/main.go`: return the same `skip` as today with a reason string from the dispatch-side classification (`repick-backoff cooldown`, `stalled: awaiting re-arm evidence`, `completed execution exists`, etc.). Keep `HasCompletedExecution` delegating to it.
+3. Remove the GH-5230 workaround INFO line now that the SDK prints the reason, or downgrade it to Debug.
+4. Add `var _ core.ExecutionCheckerV2 = (*terminalCompletionChecker)(nil)` (or the equivalent compile-time assertion used elsewhere in `cmd/pilot`).
+
+## Tests
+
+- Unit test: checker returns `skip=true, reason="repick-backoff cooldown"` for a stalled row inside its backoff window; `reason="completed execution exists"` for a genuinely terminal completed row.
+- `go build ./... && go test -short ./cmd/pilot/...` green.
+
+## Acceptance
+
+- [x] `go.mod` pins v0.38.2; build green.
+- [ ] Box log for a backoff-gated stalled task shows `Skipping re-dispatch reason=repick-backoff cooldown` and no "completed execution exists". (requires observing the live box post-deploy; verified locally via unit test instead — see `TestTerminalCompletionChecker_HasCompletedExecutionReason_BackoffCooldown`)
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -4314,14 +4314,17 @@ func (s storeTaskChecker) IsTaskQueued(taskID string) bool {
 // the old "canceled is permanent" behavior — see the nil-ghClient branch in
 // HasCompletedExecution.
 //
-// GH-5230: "looks identical to the poller" above is deliberate and stays
-// that way — dispatch behavior (this function still returns true, still
-// gates the same tasks) is unchanged. What changed is the OPERATOR-facing
-// side: the backoff branch now also emits its own unconditional INFO log
-// line naming the real reason (cooldown, not completion) before returning,
-// so the SDK's "completed execution exists" message is never the only
-// explanation on offer. See the backoff branch below for the log line
-// itself.
+// GH-5230/GH-142: "looks identical to the poller" above is deliberate and
+// stays that way — dispatch behavior (this function still returns true,
+// still gates the same tasks) is unchanged. What changed is the
+// OPERATOR-facing side: studio-sdk v0.38.2 (studio-sdk#142/PR#143) added
+// core.ExecutionCheckerV2, letting a host hand back a reason string
+// alongside the skip verdict — the vendored poller now logs
+// "Skipping re-dispatch reason=<host reason>" verbatim instead of always
+// claiming "completed execution exists". HasCompletedExecutionReason below
+// implements that interface and supersedes the old GH-5230 workaround INFO
+// line (kept at Debug for the extra backoff/drop-count detail the SDK's
+// plain reason string doesn't carry — see the backoff branch below).
 type terminalCompletionChecker struct {
 	store *memory.Store
 
@@ -4331,27 +4334,25 @@ type terminalCompletionChecker struct {
 	triggerLabel string
 }
 
-func (c terminalCompletionChecker) HasCompletedExecution(taskID, projectPath string) (bool, error) {
+// HasCompletedExecutionReason implements sdkCore.ExecutionCheckerV2
+// (studio-sdk v0.38.2+): same skip verdict as HasCompletedExecution, plus a
+// reason string classified at the point of decision so the poller's skip
+// log line names the real cause (repick-backoff cooldown, a stalled task
+// still awaiting GH-5139/GH-5249 re-arm evidence, or a genuinely completed
+// execution) instead of a single generic message.
+func (c terminalCompletionChecker) HasCompletedExecutionReason(taskID, projectPath string) (bool, string, error) {
 	key := repickBackoffKey(projectPath, taskID)
 	if gated, shouldLog := repickBackoff.gateStatus(key); gated {
 		if shouldLog {
 			logging.WithComponent("dispatch").Debug("task in repick backoff window, skipping poller candidacy entirely",
 				slog.String("task_id", taskID))
 		}
-		// GH-5230: returning true here makes the vendored SDK poller log
-		// "Skipping re-dispatch — completed execution exists" on THIS tick
-		// and every tick until the window expires — that message is false;
-		// there is no completed execution row, only a cooldown. The debug
-		// line above fires once per window and never says how long the gate
-		// lasts, so an operator reading only the poller's log sees a
-		// misleading "completed" verdict repeated with nothing to correct
-		// it (confirmed on pilot-cloud-infra GH-33: three ledger rows —
-		// stalled, failed, stalled — no commit, no PR, no completed status,
-		// yet the misleading message was the only thing in the log). Emit
-		// an unconditional INFO line, every gated tick, naming the real
-		// reason plus the remaining cooldown and drop counts, so the truth
-		// always precedes the SDK's misleading message rather than being
-		// buried in a once-per-window DEBUG line.
+		// GH-5230: the SDK poller's own skip log line now carries this same
+		// "repick-backoff cooldown" reason (returned below), so the
+		// once-misleading "completed execution exists" message is no longer
+		// the only explanation on offer. This Debug line just adds the
+		// remaining cooldown and drop counts the SDK's plain reason string
+		// doesn't carry.
 		remaining, consecutiveDrops, claimLostDrops, ok := repickBackoff.gateDetail(key)
 		attrs := []any{
 			slog.String("task_id", taskID),
@@ -4364,15 +4365,15 @@ func (c terminalCompletionChecker) HasCompletedExecution(taskID, projectPath str
 				slog.Int("claim_lost_drops", claimLostDrops),
 			)
 		}
-		logging.WithComponent("dispatch").Info(
-			"skip reason: repick-backoff cooldown, NOT a completed execution — the SDK poller's next log line (\"completed execution exists\") is misleading for this task",
+		logging.WithComponent("dispatch").Debug(
+			"skip reason: repick-backoff cooldown, NOT a completed execution",
 			attrs...)
-		return true, nil
+		return true, "repick-backoff cooldown", nil
 	}
 
 	done, err := executor.HasTerminalCompletion(c.store, taskID, projectPath)
 	if err != nil || !done {
-		return done, err
+		return done, "", err
 	}
 
 	// GH-5139/GH-5249: `done` may be a genuine completed/no_op row (never
@@ -4383,35 +4384,44 @@ func (c terminalCompletionChecker) HasCompletedExecution(taskID, projectPath str
 	// internally (via LatestCanceledExecution/LatestSupersededExecution) and
 	// only spend an API call when their own row type is present.
 	if c.ghClient == nil {
-		return true, nil
+		return true, "completed execution exists", nil
 	}
 	rearmed, probeErr := c.tryRearmCanceled(taskID, projectPath, key)
 	if probeErr != nil {
 		logging.WithComponent("dispatch").Warn("GH-5139 re-arm probe failed — treating canceled task as still terminal",
 			slog.String("task_id", taskID), slog.Any("error", probeErr))
 		repickBackoff.recordClaimLostDrop(key)
-		return true, nil
+		return true, "completed execution exists", nil
 	}
 	if rearmed {
-		return false, nil
+		return false, "", nil
 	}
 	rearmed, probeErr = c.tryRearmSuperseded(taskID, projectPath, key)
 	if probeErr != nil {
 		logging.WithComponent("dispatch").Warn("GH-5249 re-arm probe failed — treating superseded task as still terminal",
 			slog.String("task_id", taskID), slog.Any("error", probeErr))
 		repickBackoff.recordClaimLostDrop(key)
-		return true, nil
+		return true, "completed execution exists", nil
 	}
 	if !rearmed {
-		// Neither probe found a matching row + fresh re-arm evidence.
-		// Throttle via the same repick-backoff window GH-4469 already built,
-		// so an open+labeled-but-not-yet-relabeled canceled/superseded issue
-		// does not pay for a GetIssue+ListIssueEvents call on every ~30s poll
-		// tick.
+		// Neither probe found a matching row + fresh re-arm evidence — a
+		// canceled/superseded task sitting open+labeled (or not yet
+		// relabeled at all) without a qualifying reopen/relabel event since
+		// its terminal transition. Throttle via the same repick-backoff
+		// window GH-4469 already built, so this doesn't pay for a
+		// GetIssue+ListIssueEvents call on every ~30s poll tick.
 		repickBackoff.recordClaimLostDrop(key)
-		return true, nil
+		return true, "stalled: awaiting re-arm evidence", nil
 	}
-	return false, nil
+	return false, "", nil
+}
+
+// HasCompletedExecution implements sdkCore.ExecutionChecker. Delegates to
+// HasCompletedExecutionReason and discards the reason for callers (e.g.
+// pre-v0.38.2 SDK code paths, direct unit tests) that only need the verdict.
+func (c terminalCompletionChecker) HasCompletedExecution(taskID, projectPath string) (bool, error) {
+	skip, _, err := c.HasCompletedExecutionReason(taskID, projectPath)
+	return skip, err
 }
 
 // InvalidateCompletion delegates to the store unchanged — GH-4347 only
@@ -4422,6 +4432,13 @@ func (c terminalCompletionChecker) HasCompletedExecution(taskID, projectPath str
 func (c terminalCompletionChecker) InvalidateCompletion(taskID, projectPath string) error {
 	return c.store.InvalidateCompletion(taskID, projectPath)
 }
+
+// var _ sdkCore.ExecutionCheckerV2 assertion: fail the build if
+// terminalCompletionChecker ever stops satisfying ExecutionCheckerV2 (GH-142/
+// PR#143), so the vendored poller's type-assert (poller.go
+// hasCompletedExecution) can never silently regress to the reason-blind
+// ExecutionChecker fallback.
+var _ sdkCore.ExecutionCheckerV2 = terminalCompletionChecker{}
 
 // storeExecutionSaver adapts *memory.Store to the sdk core.ExecutionSaver /
 // core.ExecutionSaverV2 interfaces. GH-2802: Persists pre-flight rejection

--- a/cmd/pilot/main_test.go
+++ b/cmd/pilot/main_test.go
@@ -1452,19 +1452,19 @@ func TestTerminalCompletionChecker_RecognizesNoOp(t *testing.T) {
 	}
 }
 
-// TestHasCompletedExecution_SkipReasonDiffersByCause is the GH-5230
+// TestHasCompletedExecution_SkipReasonDiffersByCause is the GH-5230/GH-142
 // regression: HasCompletedExecution returns true (bool) for two very
 // different underlying reasons — a genuine completed/no_op execution row,
-// and a task merely cooling down in the repick-backoff window — and the
-// vendored SDK poller logs the SAME "completed execution exists" message for
-// both. Diagnosing a stalled task cost real operator time (pilot-cloud-infra
-// GH-33: ledger showed stalled/failed/stalled, no commit, no PR, no
-// completed status, yet the log insisted a completed execution existed)
-// because the two cases were indistinguishable in the logs. This pins that
-// the backoff-gated branch now emits its own INFO line naming the real
-// reason plus the remaining cooldown and drop counts, and that a genuine
-// completion does NOT emit that line — so the two causes are distinguishable
-// by grepping the log, without changing what HasCompletedExecution returns.
+// and a task merely cooling down in the repick-backoff window. Since
+// studio-sdk v0.38.2 (GH-142/PR#143) the primary distinguishing signal is
+// the reason string HasCompletedExecutionReason now returns (see
+// terminal_completion_checker_test.go), which the vendored poller logs
+// verbatim instead of always claiming "completed execution exists". The
+// old GH-5230 workaround INFO line that used to be the only source of this
+// distinction is now redundant supplementary detail and lives at Debug —
+// this test pins that it still fires (with the remaining cooldown and drop
+// counts the SDK's plain reason string doesn't carry) for the backoff case,
+// and does NOT fire for a genuine completion.
 func TestHasCompletedExecution_SkipReasonDiffersByCause(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1522,7 +1522,7 @@ func TestHasCompletedExecution_SkipReasonDiffersByCause(t *testing.T) {
 			tc.setup(t, store, taskID, projectPath, key)
 
 			logPath := filepath.Join(tmpDir, "skip-reason.log")
-			if err := logging.Init(&logging.Config{Level: "info", Format: "json", Output: logPath}); err != nil {
+			if err := logging.Init(&logging.Config{Level: "debug", Format: "json", Output: logPath}); err != nil {
 				t.Fatalf("logging.Init: %v", err)
 			}
 			t.Cleanup(func() { _ = logging.Init(logging.DefaultConfig()) })

--- a/cmd/pilot/terminal_completion_checker_test.go
+++ b/cmd/pilot/terminal_completion_checker_test.go
@@ -130,3 +130,63 @@ func TestTerminalCompletionChecker_GenuineCompletion_StillReportsTrue(t *testing
 		t.Fatal("expected a genuinely completed task to still report true")
 	}
 }
+
+// TestTerminalCompletionChecker_HasCompletedExecutionReason_BackoffCooldown is
+// the GH-142/PR#143 regression test: studio-sdk v0.38.2's ExecutionCheckerV2
+// lets the poller log the real skip reason instead of always claiming
+// "completed execution exists". A task gated purely by repick backoff (no
+// completed row at all) must report skip=true with reason="repick-backoff
+// cooldown" — never the generic completed-execution message.
+func TestTerminalCompletionChecker_HasCompletedExecutionReason_BackoffCooldown(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	checker := terminalCompletionChecker{store: store}
+
+	taskID := "GH-142-BACKOFF"
+	projectPath := "/tmp/pilot-gh-142-backoff-reason-test-does-not-exist"
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	repickBackoff.recordDrop(key)
+
+	skip, reason, err := checker.HasCompletedExecutionReason(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !skip {
+		t.Fatal("expected skip=true while the repick backoff is armed")
+	}
+	if reason != "repick-backoff cooldown" {
+		t.Fatalf("expected reason %q, got %q", "repick-backoff cooldown", reason)
+	}
+}
+
+// TestTerminalCompletionChecker_HasCompletedExecutionReason_GenuineCompletion
+// verifies a genuinely terminal completed row (a real commit/PR deliverable,
+// no backoff involved) reports skip=true with reason="completed execution
+// exists" — the SDK poller's fallback message is still correct for this
+// case, it's just no longer the ONLY message on offer for other cases.
+func TestTerminalCompletionChecker_HasCompletedExecutionReason_GenuineCompletion(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	checker := terminalCompletionChecker{store: store}
+
+	taskID := "GH-142-GENUINE"
+	projectPath := "/tmp/pilot-gh-142-genuine-reason-test-does-not-exist"
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-gh-142-genuine", TaskID: taskID, ProjectPath: projectPath,
+		Status: "completed", PRUrl: "https://github.com/qf-studio/pilot-canary-sandbox/pull/1",
+	}); err != nil {
+		t.Fatalf("failed to seed completed execution: %v", err)
+	}
+
+	skip, reason, err := checker.HasCompletedExecutionReason(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !skip {
+		t.Fatal("expected skip=true for a genuinely completed task")
+	}
+	if reason != "completed execution exists" {
+		t.Fatalf("expected reason %q, got %q", "completed execution exists", reason)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/qf-studio/grom v0.2.0
-	github.com/qf-studio/studio-sdk v0.38.1
+	github.com/qf-studio/studio-sdk v0.38.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qf-studio/grom v0.2.0 h1:EefLLr794KGk8ihdpKBgJnmSyUc//b/n8zZ77VbeuXY=
 github.com/qf-studio/grom v0.2.0/go.mod h1:YVihqE0treA2091TLNhGWvGi5+vMYv/ZBlAlX7Mr/JI=
-github.com/qf-studio/studio-sdk v0.38.1 h1:qegWl7ZR3xouP4/3u/dInnFhr9r5bQ3+73rfuQW6GNk=
-github.com/qf-studio/studio-sdk v0.38.1/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
+github.com/qf-studio/studio-sdk v0.38.2 h1:JTqyCVPrGQZe5ADfqyM5Ub5YkPUsbiQhd6wGLowvGCg=
+github.com/qf-studio/studio-sdk v0.38.2/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5407.

Closes #5407

## Changes

GitHub Issue GH-5407: chore(deps): bump studio-sdk to v0.38.2 and implement ExecutionCheckerV2 so the poller logs the real skip reason for stalled tasks

## Context

studio-sdk v0.38.2 (PR #143, issue studio-sdk#142) adds `core.ExecutionCheckerV2` with `HasCompletedExecutionReason(taskID, projectPath) (skip bool, reason string, err error)`. When the host implements it, the poller logs `Skipping re-dispatch reason=<host reason>` instead of the misleading "completed execution exists" for tasks that are only in repick backoff. Pilot pins v0.38.1 (`go.mod`) and its `terminalCompletionChecker` in `cmd/pilot/main.go` (~4334) still uses the old interface plus the GH-5230 workaround INFO line ("the SDK poller's next log line is misleading").

## Implementation

1. `go.mod`: bump `github.com/qf-studio/studio-sdk` to v0.38.2; `go mod tidy`; commit `go.mod` and `go.sum`. No other dependency changes.
2. Implement `HasCompletedExecutionReason` on `terminalCompletionChecker` in `cmd/pilot/main.go`: return the same `skip` as today with a reason string from the dispatch-side classification (`repick-backoff cooldown`, `stalled: awaiting re-arm evidence`, `completed execution exists`, etc.). Keep `HasCompletedExecution` delegating to it.
3. Remove the GH-5230 workaround INFO line now that the SDK prints the reason, or downgrade it to Debug.
4. Add `var _ core.ExecutionCheckerV2 = (*terminalCompletionChecker)(nil)` (or the equivalent compile-time assertion used elsewhere in `cmd/pilot`).

## Tests

- Unit test: checker returns `skip=true, reason="repick-backoff cooldown"` for a stalled row inside its backoff window; `reason="completed execution exists"` for a genuinely terminal completed row.
- `go build ./... && go test -short ./cmd/pilot/...` green.

## Acceptance

- [ ] `go.mod` pins v0.38.2; build green.
- [ ] Box log for a backoff-gated stalled task shows `Skipping re-dispatch reason=repick-backoff cooldown` and no "completed execution exists".