### PR TITLE
fix(executor): needs_human terminal-status drift, GH5399 test flake, hold precondition

### DIFF
--- a/internal/adapters/github/cleanup.go
+++ b/internal/adapters/github/cleanup.go
@@ -21,8 +21,17 @@ import (
 // this codebase deliberately avoids elsewhere (see the cycle-avoidance
 // comment in internal/executor/contract_evidence.go). Duplicated here
 // rather than imported, same pattern.
+//
+// GH-5408: includes "needs_human" (holdPushedBranch's hand-off status,
+// GH-5399) and "superseded" — without them, isPilotTerminalStatus below
+// would not recognize a needs_human-parked or superseded issue's latest
+// execution as terminal, and the pilot-in-progress staleness gate above
+// (GH-5299) could wrongly treat the parked/superseded hand-off as a crash
+// orphan and re-admit it. Kept in sync with memory.terminalExecutionStatuses
+// and executor.terminalExecutionStatuses by
+// TestTerminalExecutionStatusSets_Match (internal/executor).
 var pilotTerminalExecutionStatuses = []string{
-	"completed", "failed", "cancelled", "canceled", "declined", "stalled", "no_op", "rate_limited", "infra", "skipped",
+	"completed", "failed", "cancelled", "canceled", "declined", "stalled", "no_op", "rate_limited", "infra", "skipped", "needs_human", "superseded",
 }
 
 func isPilotTerminalStatus(status string) bool {

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2873,9 +2873,17 @@ const holdPushBudget = 5 * time.Minute
 //
 // executionPath is included in the hold comment (and preserveWorktree is set)
 // when the push itself fails, so a human reviewing the parked issue — and
-// executeWithOptions's worktree-cleanup defer — both know the commits survive
-// only in that local worktree. Both may be zero-value (""/nil) for callers
-// that have no worktree to preserve (e.g. direct-commit-mode tasks).
+// executeWithOptions's worktree-cleanup defer — both know where to look for
+// the commits before the worktree is gone. GH-5408: the worktree is NOT the
+// durable copy, despite preserveWorktree's name — CleanupOrphanedWorktrees
+// (worktree.go) wipes every pilot-worktree-* directory unconditionally on
+// the next daemon start (it has no marker distinguishing "preserved for
+// human triage" from ordinary startup staleness), so the worktree only
+// survives until then. task.Branch — part of the repo's own .git, untouched
+// by that cleanup — is what actually survives long-term; the worktree path
+// is only a head start for triage that happens before the daemon restarts.
+// Both may be zero-value (""/nil) for callers that have no worktree to
+// preserve (e.g. direct-commit-mode tasks).
 func (r *Runner) holdPushedBranch(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, log *slog.Logger, reason string, executionPath string, preserveWorktree *bool) {
 	pushCtx, pushCancel := context.WithTimeout(context.WithoutCancel(ctx), holdPushBudget)
 	defer pushCancel()
@@ -2924,8 +2932,11 @@ func (r *Runner) holdPushedBranch(ctx context.Context, task *Task, git *GitOpera
 				// GH-5399: the push failed and the worktree cleanup defer has
 				// been told to preserve it — name both so a human can recover
 				// the commits directly from the Pilot host instead of assuming
-				// they're gone.
-				outcomeNote = fmt.Sprintf("The branch could not be pushed either — the commits are preserved only in the local worktree at `%s` (branch `%s`) on the Pilot host; check the worktree/logs before retrying.", executionPath, task.Branch)
+				// they're gone. GH-5408: branch `%s` (not the worktree) is the
+				// durable copy — CleanupOrphanedWorktrees wipes the worktree
+				// unconditionally on the next Pilot restart, so it's only a
+				// head start for triage before then.
+				outcomeNote = fmt.Sprintf("The branch could not be pushed either — the commits are on branch `%s` (the durable copy) and still on disk in the worktree at `%s` on the Pilot host, but that worktree is wiped on the next Pilot restart; check the worktree/logs before retrying, ideally before any restart.", task.Branch, executionPath)
 			}
 			commentBody := fmt.Sprintf("Pilot parked this task under `pilot-needs-human`: %s\n\n%s", reason, outcomeNote)
 			if commentErr := ghIssueComment(holdCtx, task.ProjectPath, issueNum, commentBody); commentErr != nil {
@@ -3490,7 +3501,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	if cleanupWorktree != nil {
 		defer func() {
 			if preserveWorktreeOnPushFailure {
-				r.log.Warn("GH-5399: preserving worktree and local branch after a push failure during timeout salvage — commits exist only here",
+				r.log.Warn("GH-5399: preserving worktree and local branch after a push failure during timeout salvage — branch is the durable copy, worktree is a head start for triage only until the next Pilot restart (GH-5408)",
 					slog.String("task_id", task.ID),
 					slog.String("worktree", executionPath),
 					slog.String("branch", task.Branch),
@@ -5506,15 +5517,31 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					// recorder.Finish call here — matches attemptBackendTimeoutSalvage's
 					// call site (line ~4698), which also returns bare after a
 					// successful hold/salvage and lets the caller finalize.
-					if taskCtxWasDone {
+					//
+					// GH-5408: only take the hold branch when there is actually
+					// something for holdPushedBranch to push/park — the same
+					// precondition attemptBackendTimeoutSalvage applies on the error
+					// path (~2776: git == nil || task.Branch == "" || task.DirectCommit
+					// || !task.CreatePR). A LocalMode/direct-commit/no-PR task has no
+					// branch worth pushing or a PR-driven issue to hand off under
+					// pilot-needs-human; without this guard it was parked there anyway,
+					// hiding it from the ordinary failure ladder below (TaskFailed
+					// alert, webhook, recorder.Finish("failed")) that every other
+					// exhausted-retries task goes through.
+					canHoldBranch := git != nil && task.Branch != "" && !task.DirectCommit && task.CreatePR
+					if taskCtxWasDone && canHoldBranch {
 						r.holdPushedBranch(ctx, task, git, result, log,
 							"quality gates failed and the task's deadline had already passed before the backend returned, so Pilot will not re-invoke Claude Code for a retry",
 							executionPath, &preserveWorktreeOnPushFailure)
 						return result, nil
 					}
 
-					// Check if we should retry with Claude Code
-					if outcome.ShouldRetry && retryAttempt < maxAutoRetries {
+					// Check if we should retry with Claude Code. GH-5408: taskCtxWasDone
+					// still forbids re-invoking Claude Code even when canHoldBranch was
+					// false above — the deadline already passed, so falling through here
+					// must skip straight to the unconditional "no more retries" fail
+					// block below rather than looping.
+					if !taskCtxWasDone && outcome.ShouldRetry && retryAttempt < maxAutoRetries {
 						totalQualityRetries++ // Track total retries across all gates (GH-209)
 						r.recordRetryAttemptEvent(task.LogExecutionID(), "quality_gate_retry", totalQualityRetries)
 						r.reportProgress(task.ID, "Quality Retry", 92,

--- a/internal/executor/runner_gh5399_test.go
+++ b/internal/executor/runner_gh5399_test.go
@@ -23,10 +23,26 @@ import (
 // gate-retry loop and re-invoke the backend via a fresh context.Background()
 // timeout — exactly the unbounded second invocation GH-5346 closed for the
 // error path. This test drives that exact shape: a backend that ignores ctx,
-// sleeps past the task's deadline, commits real work, and returns success;
-// paired with a quality checker that always fails with ShouldRetry:true. The
-// backend must be invoked exactly once, and the salvaged commit must be
-// pushed and held under pilot-needs-human rather than retried.
+// commits real work, and returns success only after the task ctx has
+// already been canceled; paired with a quality checker that always fails
+// with ShouldRetry:true. The backend must be invoked exactly once, and the
+// salvaged commit must be pushed and held under pilot-needs-human rather
+// than retried.
+//
+// GH-5408: the deadline is an explicitly-canceled context.WithCancel,
+// canceled from inside the backend's own call, rather than a fixed-duration
+// context.WithTimeout the backend had to out-sleep. The prior version used a
+// 50ms timeout and had the backend sleep 150ms past it, racing that fixed
+// budget against however long setupFreshnessRepo/checkout takes on the test
+// host — on macOS the branch switch alone routinely exceeded 50ms, so the
+// ctx (derived from the same 50ms parent inside executeWithOptions, which
+// keeps a parent's already-elapsed deadline) was sometimes already Done()
+// before the backend was even invoked, failing 6/6 locally while passing on
+// (faster) Linux CI. Canceling from inside the mock backend — which ignores
+// ctx entirely (mockGH4964Backend.Execute takes `_ context.Context`), so
+// cancellation here has no side effect beyond flipping ctx.Err() — makes
+// "the deadline elapses after the backend was called but before it
+// returned" a deterministic ordering instead of a wall-clock race.
 func TestSuccessPath_TaskCtxExpired_GatesFail_HoldsBranchNoReinvocation(t *testing.T) {
 	capturedTitleFile, capturedLabelEditsFile := setUpFakeGhPRCreateAndLabelPATH(t)
 
@@ -34,15 +50,17 @@ func TestSuccessPath_TaskCtxExpired_GatesFail_HoldsBranchNoReinvocation(t *testi
 	dir, _ := setupFreshnessRepo(t)
 	runGit(t, dir, "checkout", "-b", branch)
 
+	var cancel context.CancelFunc
 	backend := &mockGH4964Backend{
 		perCall: func(_ int, _ ExecuteOptions) *BackendResult {
 			// Simulate a backend that ignores the ctx it was handed (e.g.
 			// already mid an uninterruptible tool call) and only returns
-			// once the task's own deadline has already elapsed.
+			// once the task's own deadline has already elapsed — deterministically,
+			// by canceling that deadline from here rather than out-sleeping a timer.
 			writeUncommittedFile(t, dir, "salvaged.go")
 			runGit(t, dir, "add", "salvaged.go")
 			runGit(t, dir, "commit", "-m", "real work landed after the task deadline elapsed")
-			time.Sleep(150 * time.Millisecond)
+			cancel()
 			return &BackendResult{Success: true}
 		},
 	}
@@ -53,9 +71,8 @@ func TestSuccessPath_TaskCtxExpired_GatesFail_HoldsBranchNoReinvocation(t *testi
 
 	task := newGH4964Task("GH-5399", branch, dir)
 
-	// A short deadline that will have elapsed by the time the ctx-ignoring
-	// backend above returns (it sleeps 150ms past its call).
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	var ctx context.Context
+	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 
 	result, err := runner.Execute(ctx, task)
@@ -90,6 +107,77 @@ func TestSuccessPath_TaskCtxExpired_GatesFail_HoldsBranchNoReinvocation(t *testi
 	}
 	if !strings.Contains(string(labelEdits), labelPilotNeedsHuman) {
 		t.Errorf("expected the captured `gh issue edit` call to add %q, got:\n%s", labelPilotNeedsHuman, labelEdits)
+	}
+}
+
+// TestSuccessPath_TaskCtxExpired_GatesFail_NoPR_FailsNormally is the GH-5408
+// regression guard for Fix 3: the success-path hold above (Fix 1 of GH-5399)
+// called holdPushedBranch whenever taskCtxWasDone was true, without the
+// error path's precondition (attemptBackendTimeoutSalvage, ~2776: git == nil
+// || task.Branch == "" || task.DirectCommit || !task.CreatePR). A task with
+// CreatePR=false (LocalMode and other non-PR code tasks) has no PR-driven
+// issue hand-off for holdPushedBranch's pilot-needs-human comment/label to
+// mean anything, but was parked there anyway — hiding it from the ordinary
+// failure ladder (TaskFailed alert, webhook, recorder.Finish("failed")) that
+// every other exhausted-retries task goes through. This drives the same
+// ctx-expired-mid-backend-call, gates-keep-failing shape as
+// TestSuccessPath_TaskCtxExpired_GatesFail_HoldsBranchNoReinvocation above,
+// but with CreatePR=false: the backend must still be invoked exactly once
+// (taskCtxWasDone forbids the retry regardless of whether the hold
+// precondition holds), but the task must fail normally instead of being
+// parked needs_human.
+func TestSuccessPath_TaskCtxExpired_GatesFail_NoPR_FailsNormally(t *testing.T) {
+	capturedTitleFile, capturedLabelEditsFile := setUpFakeGhPRCreateAndLabelPATH(t)
+
+	const branch = "pilot/GH-5408-taskctx-expired-nopr"
+	dir, _ := setupFreshnessRepo(t)
+	runGit(t, dir, "checkout", "-b", branch)
+
+	var cancel context.CancelFunc
+	backend := &mockGH4964Backend{
+		perCall: func(_ int, _ ExecuteOptions) *BackendResult {
+			writeUncommittedFile(t, dir, "salvaged.go")
+			runGit(t, dir, "add", "salvaged.go")
+			runGit(t, dir, "commit", "-m", "real work landed after the task deadline elapsed")
+			cancel()
+			return &BackendResult{Success: true}
+		},
+	}
+	runner := newGH4964Runner(backend)
+	runner.qualityCheckerFactory = func(string, string) QualityChecker {
+		return &stubQualityChecker{outcome: &QualityOutcome{Passed: false, ShouldRetry: true}}
+	}
+
+	task := newGH4964Task("GH-5408", branch, dir)
+	task.CreatePR = false // no-PR task: nothing for holdPushedBranch to hand off
+
+	var ctx context.Context
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+
+	if backend.callCount() != 1 {
+		t.Errorf("expected backend called exactly once (taskCtxWasDone must still forbid re-invocation even when the hold precondition fails), got %d", backend.callCount())
+	}
+	if result.Success {
+		t.Errorf("expected Success=false when post-deadline quality gates fail, got true")
+	}
+	if result.Outcome == "needs_human" {
+		t.Errorf("expected a no-PR task never to be parked needs_human, got Outcome=%q (error=%q)", result.Outcome, result.Error)
+	}
+	if result.PRUrl != "" {
+		t.Errorf("expected no PR URL (gates failed), got %q", result.PRUrl)
+	}
+	if _, statErr := os.Stat(capturedTitleFile); statErr == nil {
+		t.Error("gh pr create must not be invoked when post-deadline quality gates fail")
+	}
+	if _, statErr := os.Stat(capturedLabelEditsFile); statErr == nil {
+		labelEdits, _ := os.ReadFile(capturedLabelEditsFile)
+		t.Errorf("expected no pilot-needs-human label edit for a no-PR task, got:\n%s", labelEdits)
 	}
 }
 

--- a/internal/executor/terminal_status_inventory_test.go
+++ b/internal/executor/terminal_status_inventory_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -108,4 +109,108 @@ func TestTerminalStatusInventory_NoStrayStatusSets(t *testing.T) {
 			return true
 		})
 	}
+}
+
+// terminalExecutionStatusMirror names an unexported package-level
+// `var name = []string{...}` in another package that intentionally
+// duplicates this package's terminalExecutionStatuses (dispatcher.go) rather
+// than importing it — the cross-package-coupling-avoidance pattern each
+// mirror's own doc comment explains (see pilotTerminalExecutionStatuses in
+// internal/adapters/github/cleanup.go and terminalExecutionStatuses in
+// internal/memory/store.go).
+type terminalExecutionStatusMirror struct {
+	path    string // relative to this package's directory
+	varName string
+}
+
+var terminalExecutionStatusMirrors = []terminalExecutionStatusMirror{
+	{path: "../memory/store.go", varName: "terminalExecutionStatuses"},
+	{path: "../adapters/github/cleanup.go", varName: "pilotTerminalExecutionStatuses"},
+}
+
+// TestTerminalExecutionStatusSets_Match is the GH-5408 regression guard: PR
+// #5402 added "needs_human" to this package's terminalExecutionStatuses
+// (dispatcher.go) but not to either of its two intentional duplicates —
+// memory.terminalExecutionStatuses (internal/memory/store.go) or
+// github.pilotTerminalExecutionStatuses
+// (internal/adapters/github/cleanup.go). The result: a needs_human row's CAS
+// guard (store.go's UpdateExecutionStatusIfNotTerminal) silently stopped
+// protecting itself against a later terminal write clobbering it, and the
+// github cleaner's pilot-in-progress staleness gate (GH-5299) stopped
+// recognizing a needs_human-parked issue as terminal.
+// TestTerminalStatusInventory_NoStrayStatusSets above only scans this
+// package's own directory for stray copies, so it never caught either
+// drift — this test instead parses the other two files' literal string
+// slices directly (without importing them — they're unexported, and that
+// cross-package coupling is exactly what the duplication avoids) and diffs
+// them against this package's own terminalExecutionStatuses map.
+func TestTerminalExecutionStatusSets_Match(t *testing.T) {
+	want := make(map[string]bool, len(terminalExecutionStatuses))
+	for k := range terminalExecutionStatuses {
+		want[k] = true
+	}
+
+	for _, mirror := range terminalExecutionStatusMirrors {
+		got, err := parseStringSliceVar(mirror.path, mirror.varName)
+		if err != nil {
+			t.Fatalf("%s: %v", mirror.path, err)
+		}
+
+		for status := range want {
+			if !got[status] {
+				t.Errorf("%s's %s is missing %q, which dispatcher.go's terminalExecutionStatuses treats as terminal (GH-5408 drift class)", mirror.path, mirror.varName, status)
+			}
+		}
+		for status := range got {
+			if !want[status] {
+				t.Errorf("%s's %s has extra status %q that dispatcher.go's terminalExecutionStatuses does not treat as terminal (GH-5408 drift class)", mirror.path, mirror.varName, status)
+			}
+		}
+	}
+}
+
+// parseStringSliceVar extracts the string-literal elements of a top-level
+// `var name = []string{"a", "b", ...}` declaration from a Go source file,
+// via AST rather than an import — the whole point is inspecting an
+// unexported var in a package this one deliberately does not import.
+func parseStringSliceVar(path, name string) (map[string]bool, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("ParseFile: %w", err)
+	}
+
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok || len(valueSpec.Names) != 1 || valueSpec.Names[0].Name != name {
+				continue
+			}
+			if len(valueSpec.Values) != 1 {
+				continue
+			}
+			lit, ok := valueSpec.Values[0].(*ast.CompositeLit)
+			if !ok {
+				continue
+			}
+			result := map[string]bool{}
+			for _, elt := range lit.Elts {
+				basicLit, ok := elt.(*ast.BasicLit)
+				if !ok || basicLit.Kind != token.STRING {
+					continue
+				}
+				val, unquoteErr := strconv.Unquote(basicLit.Value)
+				if unquoteErr != nil {
+					continue
+				}
+				result[val] = true
+			}
+			return result, nil
+		}
+	}
+	return nil, fmt.Errorf("var %s not found in %s", name, path)
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2527,8 +2527,26 @@ func (s *Store) GetQueuedTasksForProject(projectPath string, limit int) ([]*Exec
 // collide — "canceled" means "operator terminated this on purpose, never
 // re-pick", the opposite intent of "cancelled"'s historical retry-worthy
 // connotation.
+//
+// GH-5408: "needs_human" (holdPushedBranch's hand-off status, GH-5399) was
+// added to executor/dispatcher.go's terminalExecutionStatuses and
+// adapters/github/cleanup.go's pilotTerminalExecutionStatuses but never
+// landed here, so UpdateExecutionStatusIfNotTerminal(id, "needs_human", ...)
+// left completed_at NULL and a later terminal write (e.g. "failed") could
+// still overwrite the row through this package's own CAS guard — the exact
+// clobber GH-4423 built that guard to prevent. "superseded" had the same gap
+// (present in dispatcher.go's set, absent here) — it happened not to bite in
+// practice because every production writer of status='superseded' uses the
+// raw UPDATE queries in ReclassifyCompletionAsSuperseded /
+// TerminateNonTerminalExecutionAsSuperseded rather than the CAS-guarded
+// UpdateExecutionStatusIfNotTerminal, but closing it keeps this list an
+// honest superset instead of relying on every future superseded-writer
+// remembering to bypass the guard too. executor's
+// TestTerminalExecutionStatusSets_Match parses this list, dispatcher.go's,
+// and cleanup.go's out of their source and asserts they stay identical so
+// the three copies can't drift apart again.
 var terminalExecutionStatuses = []string{
-	"completed", "failed", "cancelled", "canceled", "declined", "stalled", "no_op", "rate_limited", "infra", "skipped",
+	"completed", "failed", "cancelled", "canceled", "declined", "stalled", "no_op", "rate_limited", "infra", "skipped", "needs_human", "superseded",
 }
 
 func isTerminalExecutionStatus(status string) bool {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -6255,6 +6255,63 @@ func TestUpdateExecutionStatusIfNotTerminal_RejectsWhenAlreadyCanceled(t *testin
 	}
 }
 
+// TestUpdateExecutionStatusIfNotTerminal_NeedsHuman is the GH-5408
+// regression test: "needs_human" (holdPushedBranch's hand-off status,
+// GH-5399) was added to executor/dispatcher.go's terminalExecutionStatuses
+// but not to this package's own terminalExecutionStatuses, so writing
+// needs_human through the CAS-guarded path left completed_at NULL and a
+// later terminal write (e.g. "failed") silently clobbered the row — the
+// exact clobber GH-4423 built this guard to prevent. Asserts both halves:
+// the write itself stamps completed_at, and a subsequent terminal write is
+// rejected.
+func TestUpdateExecutionStatusIfNotTerminal_NeedsHuman(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "cas-needs-human", TaskID: "GH-5408-CAS", ProjectPath: "/proj", Status: "running"})
+
+	applied, err := store.UpdateExecutionStatusIfNotTerminal("cas-needs-human", "needs_human", "quality gates failed after the task deadline passed")
+	if err != nil {
+		t.Fatalf("UpdateExecutionStatusIfNotTerminal: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected applied=true — a running row must accept the needs_human hand-off write")
+	}
+
+	exec, err := store.GetExecution("cas-needs-human")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "needs_human" {
+		t.Fatalf("expected status 'needs_human', got %q", exec.Status)
+	}
+	if exec.CompletedAt == nil {
+		t.Error("expected completed_at to be stamped on the needs_human write — a nil completed_at is the GH-5408 symptom (needs_human missing from terminalExecutionStatuses)")
+	}
+
+	// A later terminal write (e.g. a salvage-path "failed" landing after the
+	// hand-off already happened) must be rejected, not silently overwrite
+	// the parked row.
+	applied, err = store.UpdateExecutionStatusIfNotTerminal("cas-needs-human", "failed", "unrelated later write")
+	if err != nil {
+		t.Fatalf("UpdateExecutionStatusIfNotTerminal (second write): %v", err)
+	}
+	if applied {
+		t.Error("expected applied=false — a needs_human row must never be resurrected/overwritten by a later terminal write")
+	}
+
+	exec, err = store.GetExecution("cas-needs-human")
+	if err != nil {
+		t.Fatalf("GetExecution (after second write): %v", err)
+	}
+	if exec.Status != "needs_human" {
+		t.Errorf("expected status to remain 'needs_human', got %q", exec.Status)
+	}
+}
+
 // TestLatestCanceledExecution_FindsMostRecentCanceledRow is GH-5139's coverage
 // for the lookup the re-arm probe (cmd/pilot/rearm_canceled.go) uses to find
 // the cancel timestamp it compares GitHub issue-event times against.


### PR DESCRIPTION
## Summary

Four post-merge follow-ups from review of PR #5402 (GH-5399), tracked in #5408:

- **needs_human missing from memory's terminal set**: `memory.terminalExecutionStatuses` (store.go) was missing `needs_human` and `superseded`, so `UpdateExecutionStatusIfNotTerminal`'s CAS guard could let a `needs_human` row get silently overwritten by a later terminal write and leave `completed_at` unset. `github.cleanup.go`'s `pilotTerminalExecutionStatuses` had the same gap, which could make the GH-5299 staleness gate mistake a `needs_human`-parked issue for a crash orphan. Added both statuses to each mirror plus a new `TestTerminalExecutionStatusSets_Match` test that AST-diffs `dispatcher.go`'s terminal set against both mirrors so they can't drift apart silently again.
- **macOS-fragile 50ms deadline test**: `runner_gh5399_test.go`'s task-deadline test raced a wall-clock timer against variable-speed git setup, flaky on macOS. Replaced with an explicit `context.WithCancel`, cancelled from inside the mock backend callback.
- **Success-path hold missing error-path's precondition**: the quality-gate-retry hold in `executeWithOptions` parked LocalMode/no-PR tasks as `needs_human` instead of running them through the ordinary failure ladder, because it lacked the error path's precondition (`git != nil && branch != "" && !DirectCommit && CreatePR`). Applied the same precondition; added `TestSuccessPath_TaskCtxExpired_GatesFail_NoPR_FailsNormally` as a regression guard.
- **Misleading worktree-only comment**: reworded the worktree-preservation comments/log line in `holdPushedBranch` and its cleanup defer — they claimed commits exist "only" in the worktree, but `CleanupOrphanedWorktrees` wipes it unconditionally on the next daemon restart while `task.Branch` (in the repo's own `.git`) is the actual durable copy.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short ./internal/executor/... ./internal/memory/... ./internal/adapters/github/...` — all green
- [x] New regression test `TestSuccessPath_TaskCtxExpired_GatesFail_NoPR_FailsNormally` confirmed to fail against pre-fix source (verified via `git stash`), passes with the fix
- [x] New regression test `TestUpdateExecutionStatusIfNotTerminal_NeedsHuman` confirms `needs_human` rows get `completed_at` set and can't be overwritten by a later terminal write
- [x] `TestTerminalExecutionStatusSets_Match` confirms `dispatcher.go`, `store.go`, and `cleanup.go`'s terminal-status sets are identical