### PR TITLE
GH-5413: fix(autopilot): OnPRCreated branch/issue guard skips fix-issue PRs on a borrowed origin branch (PR #5412 follow-up)

### DIFF
--- a/.agent/tasks/gh-5413.md
+++ b/.agent/tasks/gh-5413.md
@@ -1,0 +1,47 @@
+# GH-5413
+
+**Created:** 2026-09-09
+
+## Problem
+
+GitHub Issue GH-5413: fix(autopilot): OnPRCreated branch/issue guard skips fix-issue PRs on a borrowed origin branch (PR #5412 follow-up)
+
+## Problem
+
+PR #5412 (GH-5409) added a defence-in-depth guard at the top of `OnPRCreated` in `internal/autopilot/controller.go`: if `parsePilotGHBranch(branchName)` yields an issue number different from the caller's `issueNumber`, registration is skipped with a warning. The guard assumes the branch always encodes the same issue as the task. Fix and revision issues break that assumption by design:
+
+- `resolveAutopilotFixBranch` in `cmd/pilot/handlers.go` makes a fix issue F run on the origin PR's branch, which is named after the ORIGIN issue O (the autopilot-meta footer flow, decision memory "Pilot never reads GH comments", precedent #5261).
+- `CreatePR` in `internal/executor/git.go` returns the existing PR's URL when the branch already has an open PR ("already exists" branch), and `adoptOpenBranchPR` in `internal/executor/runner.go` deliberately does not adopt the origin PR either, so the run's result carries PR = origin PR P (or a brand-new PR N when P was already closed) with branch = the origin branch.
+- `cmd/pilot/poller_github.go` line 666 then calls OnPRCreated with PR = P or N, issue = F, branch = the origin branch. The guard sees O != F and returns.
+
+While P is still in `activePRs` this changes nothing (the duplicate check right below already skipped the call). It bites exactly when P is NOT tracked: autopilot abandoned it at a failed stage (PR #5356 on 09-08, the case #5378 was filed for), the daemon restarted, or P was closed and the fix run opened a new PR N. Before #5412 those calls registered the PR under F. Now the PR is picked up only by `reconcileOrphanPRs` (same file, around lines 8454 and 8536), which derives the issue from the branch name, so it is registered under O. Consequences: F is never closed on merge and stays `pilot-in-progress`; the GH-1566 iteration check reads O's body instead of F's; O, already closed, gets the merge comment.
+
+Not yet on the box: #5412 merged after the 14:16Z v2.274.0 train. This fix should land before the next train.
+
+## Fix
+
+Keep the guard for the case it was written for (a mis-paired PR event) but let a caller that KNOWS the branch is borrowed say so. Preferred shape:
+
+1. Plumb "this task ran on a borrowed branch" from the runner result to the poller. The runner already knows it: `FromPR > 0` on the task (set by `resolveAutopilotFixBranch`). Expose it on the handler result that `cmd/pilot/handlers.go` builds (the struct that carries `BranchName` and `PRNumber`) and on the SDK-facing result at `cmd/pilot/poller_github.go` line 666.
+2. Add an explicit entry point on the controller, for example `OnPRCreatedForFixIssue(prNumber, prURL, fixIssue, originIssue, headSHA, branchName, issueNodeID)` or an options struct, that bypasses the branch/issue mismatch check but still records `BranchName` unchanged and sets `IssueNumber = fixIssue`. The plain `OnPRCreated` keeps the guard.
+3. Call the new entry point from the poller when the result says the branch was borrowed; otherwise call `OnPRCreated` as today.
+4. `reconcileOrphanPRs` should not silently re-home a fix issue's PR under the origin issue: when the branch's issue is closed and an open `pilot`-labeled issue carries an autopilot-meta footer naming that branch, prefer the fix issue. If that lookup is too expensive for the 60s ticker, log a warning naming both candidates instead of registering under O.
+
+## Tests
+
+- `internal/autopilot/controller_test.go`: the guard still rejects the mismatch case (`TestController_OnPRCreated_ForeignIssueNumberIgnored` unchanged); a new test registers a PR under fix issue F via the new entry point with branch encoding O, and asserts `IssueNumber == F` and `BranchName` preserved.
+- `cmd/pilot`: a poller-level test drives the real wiring at `cmd/pilot/poller_github.go` line 666 with a result whose task had `FromPR > 0` and asserts the controller tracks the PR under F (the GH-4211 lesson: test the handler production wires, not the controller method directly).
+- Regression: a result WITHOUT the borrowed flag and a mismatching branch still produces zero registrations.
+
+## Acceptance
+
+- A fix issue whose run pushes to an untracked origin branch ends up tracked under the fix issue, and merging closes the fix issue.
+- The mis-paired-event case from GH-5409 remains blocked.
+- Test command, must be green:
+
+```
+go test ./internal/autopilot/ ./cmd/pilot/
+```
+
+## Acceptance Criteria
+

--- a/cmd/pilot/gh5413_borrowed_branch_retry_test.go
+++ b/cmd/pilot/gh5413_borrowed_branch_retry_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/autopilot"
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/testutil"
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestQueueRetryIfRateLimited_SetsFromPRFromAutopilotMetaFooter is a
+// regression test for GH-5413's root cause: QueueRetryIfRateLimited
+// previously constructed the queued retry task without ever populating
+// FromPR, so pendingTask.Task.FromPR was always 0 downstream — githubRetryOnPRCreated
+// (and any future consumer) had no way to distinguish a borrowed-branch fix
+// dispatch from a mis-paired event once a rate-limited task was replayed.
+// This asserts the queued task's FromPR is recovered from the issue body's
+// autopilot-meta footer, mirroring how handleGithubIssueEventSDK resolves it
+// on the primary (non-retry) path.
+func TestQueueRetryIfRateLimited_SetsFromPRFromAutopilotMetaFooter(t *testing.T) {
+	scheduler := executor.NewScheduler(executor.DefaultSchedulerConfig(), nil)
+	s := sdkRateLimitScheduler{scheduler: scheduler}
+
+	body := "Please fix the failing check.\n\n<!-- autopilot-meta branch:pilot/GH-10 pr:5361 -->"
+	errText := "You've hit your limit \u00b7 resets 6am (UTC)"
+
+	if !s.QueueRetryIfRateLimited("GH-20", "Fix issue", body, errText) {
+		t.Fatal("QueueRetryIfRateLimited() = false, want true for a recognized rate-limit error")
+	}
+
+	pending := scheduler.Queue().List()
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 queued task, got %d", len(pending))
+	}
+	if pending[0].Task.FromPR != 5361 {
+		t.Errorf("queued task.FromPR = %d, want 5361 (parsed from the autopilot-meta footer's pr: field)", pending[0].Task.FromPR)
+	}
+}
+
+// TestQueueRetryIfRateLimited_NoFooter_FromPRStaysZero is the negative
+// control: an issue body without an autopilot-meta footer (the common case —
+// most issues aren't fix/revision issues) must not spuriously set FromPR.
+func TestQueueRetryIfRateLimited_NoFooter_FromPRStaysZero(t *testing.T) {
+	scheduler := executor.NewScheduler(executor.DefaultSchedulerConfig(), nil)
+	s := sdkRateLimitScheduler{scheduler: scheduler}
+
+	body := "Please implement this feature."
+	errText := "You've hit your limit \u00b7 resets 6am (UTC)"
+
+	if !s.QueueRetryIfRateLimited("GH-20", "Feature", body, errText) {
+		t.Fatal("QueueRetryIfRateLimited() = false, want true for a recognized rate-limit error")
+	}
+
+	pending := scheduler.Queue().List()
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 queued task, got %d", len(pending))
+	}
+	if pending[0].Task.FromPR != 0 {
+		t.Errorf("queued task.FromPR = %d, want 0 with no autopilot-meta footer in body", pending[0].Task.FromPR)
+	}
+}
+
+// TestGithubRetryOnPRCreated_BorrowedBranch_RegistersUnderFixIssue is the
+// poller-level test for GH-5413 (PR #5412 follow-up): githubRetryOnPRCreated
+// is the exact function githubRetryCallback — the callback production wires
+// into rateLimitScheduler.SetRetryCallback at cmd/pilot/poller_github.go —
+// invokes once a rate-limited retry produces a PR. It is extracted (mirroring
+// the GH-4211 lesson: test the handler production wires up, not a
+// lower-level controller method called directly) so this exact routing
+// decision can be driven without also running the full dispatcher/runner
+// pipeline through handleGithubIssueEventSDK just to get a *sdkcore.IssueResult.
+//
+// A fix issue F (here 20) that was dispatched onto its origin PR's branch
+// (resolveAutopilotFixBranch) carries FromPR > 0 on its retried task. The
+// issue actually fetched by GetIssue during retry is F itself (issueNumber =
+// 20), but the branch the resulting PR lands on is named after the ORIGIN
+// issue (10) — plain OnPRCreated's GH-5409 guard would silently drop
+// registration in that case. This asserts the PR ends up tracked under F,
+// with the borrowed branch name preserved.
+func TestGithubRetryOnPRCreated_BorrowedBranch_RegistersUnderFixIssue(t *testing.T) {
+	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
+	cfg := autopilot.DefaultConfig()
+	ctrl := autopilot.NewController(cfg, ghClient, nil, "owner", "repo")
+
+	const originIssue = 10
+	const fixIssue = 20
+	result := &sdkcore.IssueResult{
+		Success:    true,
+		PRNumber:   99,
+		PRURL:      "https://github.com/owner/repo/pull/99",
+		HeadSHA:    "deadbeef",
+		BranchName: "pilot/GH-10", // borrowed origin branch, not pilot/GH-20
+	}
+
+	githubRetryOnPRCreated(ctrl, result, fixIssue, "", originIssue)
+
+	prs := ctrl.GetActivePRs()
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 PR registered, got %d", len(prs))
+	}
+	state, ok := ctrl.GetPRState(99)
+	if !ok {
+		t.Fatal("PR 99 should be registered")
+	}
+	if state.IssueNumber != fixIssue {
+		t.Errorf("IssueNumber = %d, want %d (fix issue, not origin issue %d)", state.IssueNumber, fixIssue, originIssue)
+	}
+	if state.BranchName != "pilot/GH-10" {
+		t.Errorf("BranchName = %q, want %q (borrowed origin branch preserved unchanged)", state.BranchName, "pilot/GH-10")
+	}
+}
+
+// TestGithubRetryOnPRCreated_NoFromPR_MismatchedBranchIsBlocked is the
+// GH-5413 regression companion: a retried task WITHOUT the borrowed-branch
+// signal (fromPR == 0) whose branch still doesn't match issueNumber must
+// still hit the GH-5409 guard inside plain OnPRCreated and register nothing —
+// githubRetryOnPRCreated must not itself become a bypass for the mis-paired-
+// event case the guard was written to block.
+func TestGithubRetryOnPRCreated_NoFromPR_MismatchedBranchIsBlocked(t *testing.T) {
+	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
+	cfg := autopilot.DefaultConfig()
+	ctrl := autopilot.NewController(cfg, ghClient, nil, "owner", "repo")
+
+	result := &sdkcore.IssueResult{
+		Success:    true,
+		PRNumber:   99,
+		PRURL:      "https://github.com/owner/repo/pull/99",
+		HeadSHA:    "deadbeef",
+		BranchName: "pilot/GH-10",
+	}
+
+	// fromPR = 0: no borrowed-branch signal, but issueNumber (99) still
+	// mismatches the branch-encoded issue (10).
+	githubRetryOnPRCreated(ctrl, result, 99, "", 0)
+
+	prs := ctrl.GetActivePRs()
+	if len(prs) != 0 {
+		t.Fatalf("expected 0 PRs registered for a mismatched branch without the borrowed-branch signal, got %d", len(prs))
+	}
+	if _, ok := ctrl.GetPRState(99); ok {
+		t.Error("PR 99 should not be registered when branch/issueNumber mismatch and fromPR == 0")
+	}
+}
+
+// TestGithubRetryOnPRCreated_NilResult_NoOp guards the nil-safety of the
+// extracted routing function against the common "no PR yet" retry result
+// (e.g. Skipped, or execution failed before pushing a branch).
+func TestGithubRetryOnPRCreated_NilResult_NoOp(t *testing.T) {
+	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
+	cfg := autopilot.DefaultConfig()
+	ctrl := autopilot.NewController(cfg, ghClient, nil, "owner", "repo")
+
+	githubRetryOnPRCreated(ctrl, nil, 20, "", 10)
+	githubRetryOnPRCreated(ctrl, &sdkcore.IssueResult{Success: true}, 20, "", 10)
+
+	if prs := ctrl.GetActivePRs(); len(prs) != 0 {
+		t.Fatalf("expected 0 PRs registered for a nil/PR-less result, got %d", len(prs))
+	}
+}

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -79,6 +79,85 @@ func githubOnPRCreatedHandler(ctrl *autopilot.Controller) func(sdkcore.PRCreated
 	}
 }
 
+// githubRetryCallback builds the rate-limit-retry callback for the GitHub SDK
+// poller: it re-fetches the issue and re-enters the SDK handler path, then
+// forwards any resulting PR to autopilot the same way the primary path does
+// (GH-797). Extracted to its own function (GH-4211: test the handler
+// production wires up, not a lower-level method called directly) so a test
+// can drive this exact callback the scheduler invokes.
+//
+// GH-5413: pendingTask.Task.FromPR > 0 means this task was dispatched by
+// resolveAutopilotFixBranch onto its origin PR's branch — the branch is named
+// after the ORIGIN issue, not the fix issue in pendingTask.Task.ID/issue.Number.
+// Controller.OnPRCreated's branch/issue guard (GH-5409) would silently drop
+// registration in that case, so route through OnPRCreatedForFixIssue instead,
+// which records the PR under the fix issue while preserving the (borrowed)
+// branch name.
+func githubRetryCallback(deps *PollerDeps, target githubSDKPollerTarget, sdkClient *githubSDK.Client, repoOwner, repoName string, controller *autopilot.Controller) func(context.Context, *executor.PendingTask) error {
+	return func(retryCtx context.Context, pendingTask *executor.PendingTask) error {
+		var issueNum int
+		if _, err := fmt.Sscanf(pendingTask.Task.ID, "GH-%d", &issueNum); err != nil {
+			return fmt.Errorf("invalid task ID format: %s", pendingTask.Task.ID)
+		}
+
+		issue, err := sdkClient.GetIssue(retryCtx, repoOwner, repoName, issueNum)
+		if err != nil {
+			return fmt.Errorf("failed to fetch issue for retry: %w", err)
+		}
+
+		logging.WithComponent("scheduler").Info("Retrying rate-limited issue (SDK path)",
+			slog.Int("issue", issueNum),
+			slog.Int("attempt", pendingTask.Attempts),
+			slog.String("repo", target.repoFullName),
+		)
+
+		labelNames := make([]string, 0, len(issue.Labels))
+		for _, l := range issue.Labels {
+			labelNames = append(labelNames, l.Name)
+		}
+		ev := sdkcore.IssueEvent{
+			Action:     "created",
+			IssueID:    strconv.Itoa(issue.Number),
+			SequenceID: pendingTask.Task.ID,
+			Title:      issue.Title,
+			Body:       issue.Body,
+			Labels:     labelNames,
+			ProjectID:  repoName,
+		}
+
+		result, err := handleGithubIssueEventSDK(retryCtx, deps.Cfg, ev, target.projectPath, target.repoFullName, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer, resolveRepoMetrics(deps, target.repoFullName))
+
+		// GH-797: surface retried-issue PRs to autopilot so their merge gates run.
+		githubRetryOnPRCreated(controller, result, issue.Number, issue.NodeID, pendingTask.Task.FromPR)
+
+		return err
+	}
+}
+
+// githubRetryOnPRCreated routes a retried issue's resulting PR (if any) to the
+// autopilot controller, extracted out of githubRetryCallback (GH-4211: test
+// the handler production wires up) so this decision can be driven directly
+// without also having to fetch a real issue and run the full executor
+// pipeline through handleGithubIssueEventSDK.
+//
+// GH-5413: fromPR > 0 means this task was dispatched by
+// resolveAutopilotFixBranch onto its origin PR's branch — that branch is
+// named after the ORIGIN issue, not issueNumber (the fix issue). Plain
+// Controller.OnPRCreated's branch/issue guard (GH-5409) would silently drop
+// registration in that case, so route through OnPRCreatedForFixIssue instead,
+// which records the PR under the fix issue while preserving the (borrowed)
+// branch name unchanged.
+func githubRetryOnPRCreated(controller *autopilot.Controller, result *sdkcore.IssueResult, issueNumber int, issueNodeID string, fromPR int) {
+	if result == nil || result.PRNumber <= 0 || controller == nil {
+		return
+	}
+	if fromPR > 0 {
+		controller.OnPRCreatedForFixIssue(result.PRNumber, result.PRURL, issueNumber, fromPR, result.HeadSHA, result.BranchName, issueNodeID)
+	} else {
+		controller.OnPRCreated(result.PRNumber, result.PRURL, issueNumber, result.HeadSHA, result.BranchName, issueNodeID)
+	}
+}
+
 // sdkPollerVerifyTimeout bounds the one-off authenticated call made before
 // the SDK poller starts (GH-3917), matching preflightVerifyTimeout's budget
 // for the equivalent in-tree adapter checks (adapter_preflight.go).
@@ -227,10 +306,18 @@ func (s sdkRateLimitScheduler) QueueRetryIfRateLimited(taskID, title, body, errT
 	if !ok {
 		return false
 	}
+	// GH-5413: a fix/revision issue runs on its origin PR's (borrowed) branch —
+	// resolveAutopilotFixBranch recovers that from the autopilot-meta footer in
+	// body alone (labels only affect its logged source string). Without FromPR
+	// set here, the retry callback below has no way to tell a borrowed-branch
+	// dispatch from a mis-paired PR event once the rate-limited task is
+	// re-queued and replayed.
+	_, fromPR, _, _, _ := resolveAutopilotFixBranch(nil, body)
 	s.scheduler.QueueTask(&executor.Task{
 		ID:          taskID,
 		Title:       title,
 		Description: body,
+		FromPR:      fromPR,
 	}, rlInfo)
 	return true
 }
@@ -628,46 +715,7 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 	// in by the caller (one client per fan-out, not per repo).
 	sdkClient := client
 	rateLimitScheduler := executor.NewScheduler(executor.DefaultSchedulerConfig(), nil)
-	rateLimitScheduler.SetRetryCallback(func(retryCtx context.Context, pendingTask *executor.PendingTask) error {
-		var issueNum int
-		if _, err := fmt.Sscanf(pendingTask.Task.ID, "GH-%d", &issueNum); err != nil {
-			return fmt.Errorf("invalid task ID format: %s", pendingTask.Task.ID)
-		}
-
-		issue, err := sdkClient.GetIssue(retryCtx, repoOwner, repoName, issueNum)
-		if err != nil {
-			return fmt.Errorf("failed to fetch issue for retry: %w", err)
-		}
-
-		logging.WithComponent("scheduler").Info("Retrying rate-limited issue (SDK path)",
-			slog.Int("issue", issueNum),
-			slog.Int("attempt", pendingTask.Attempts),
-			slog.String("repo", target.repoFullName),
-		)
-
-		labelNames := make([]string, 0, len(issue.Labels))
-		for _, l := range issue.Labels {
-			labelNames = append(labelNames, l.Name)
-		}
-		ev := sdkcore.IssueEvent{
-			Action:     "created",
-			IssueID:    strconv.Itoa(issue.Number),
-			SequenceID: pendingTask.Task.ID,
-			Title:      issue.Title,
-			Body:       issue.Body,
-			Labels:     labelNames,
-			ProjectID:  repoName,
-		}
-
-		result, err := handleGithubIssueEventSDK(retryCtx, deps.Cfg, ev, target.projectPath, target.repoFullName, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer, resolveRepoMetrics(deps, target.repoFullName))
-
-		// GH-797: surface retried-issue PRs to autopilot so their merge gates run.
-		if result != nil && result.PRNumber > 0 && controller != nil {
-			controller.OnPRCreated(result.PRNumber, result.PRURL, issue.Number, result.HeadSHA, result.BranchName, issue.NodeID)
-		}
-
-		return err
-	})
+	rateLimitScheduler.SetRetryCallback(githubRetryCallback(deps, target, sdkClient, repoOwner, repoName, controller))
 	rateLimitScheduler.SetExpiredCallback(func(expiredCtx context.Context, pendingTask *executor.PendingTask) {
 		logging.WithComponent("scheduler").Error("Task exceeded max retry attempts",
 			slog.String("task_id", pendingTask.Task.ID),

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2587,6 +2587,14 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 	// prState.IssueNumber, which is set from this parameter — refuse to
 	// register a confirmed mismatch rather than let autopilot act on the
 	// wrong issue when this PR later merges.
+	//
+	// GH-5413: this guard assumes the branch always encodes the SAME issue as
+	// the caller's issueNumber. Fix/revision issues break that assumption by
+	// design — resolveAutopilotFixBranch (cmd/pilot/handlers.go) makes a fix
+	// issue F run on its origin PR's branch, which is named after the ORIGIN
+	// issue O. A caller that has independently verified this is a legitimate
+	// borrowed-branch dispatch (not a mis-paired event) must call
+	// OnPRCreatedForFixIssue instead, which bypasses this check on purpose.
 	if issueNumber != 0 {
 		if branchIssue, ok := parsePilotGHBranch(branchName); ok && branchIssue != issueNumber {
 			c.log.Warn("OnPRCreated: branch encodes a different issue than the caller claims — skipping registration",
@@ -2599,6 +2607,35 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 		}
 	}
 
+	c.registerPR(prNumber, prURL, issueNumber, headSHA, branchName, issueNodeID)
+}
+
+// OnPRCreatedForFixIssue registers prNumber under fixIssue even though
+// branchName encodes originIssue's number, not fixIssue's — GH-5413 (PR
+// #5412 follow-up). resolveAutopilotFixBranch (cmd/pilot/handlers.go) makes a
+// fix/revision issue continue its origin PR's branch on purpose (the
+// autopilot-meta footer flow, decision memory "Pilot never reads GH
+// comments", precedent #5261), so a branch/issue mismatch here is expected,
+// not evidence of a mis-paired event the way it is for OnPRCreated's guard
+// (GH-5409). Callers must only use this entry point when they have
+// independently verified the borrowed-branch dispatch (e.g. the dispatched
+// task carried FromPR > 0) — it intentionally skips OnPRCreated's mismatch
+// check. originIssue is accepted purely for logging/traceability; the PR is
+// always tracked under fixIssue, with branchName recorded unchanged.
+func (c *Controller) OnPRCreatedForFixIssue(prNumber int, prURL string, fixIssue int, originIssue int, headSHA string, branchName string, issueNodeID string) {
+	c.log.Info("OnPRCreatedForFixIssue: registering PR under fix issue on a borrowed origin branch",
+		"pr", prNumber,
+		"fix_issue", fixIssue,
+		"origin_issue", originIssue,
+		"branch", branchName,
+	)
+	c.registerPR(prNumber, prURL, fixIssue, headSHA, branchName, issueNodeID)
+}
+
+// registerPR holds the shared registration body for OnPRCreated and
+// OnPRCreatedForFixIssue (GH-5413) — every check below applies identically
+// regardless of which caller verified issueNumber is correct for this PR.
+func (c *Controller) registerPR(prNumber int, prURL string, issueNumber int, headSHA string, branchName string, issueNodeID string) {
 	c.mu.Lock()
 	if _, exists := c.activePRs[prNumber]; exists {
 		c.mu.Unlock()
@@ -8533,6 +8570,34 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 			"branch", pr.Head.Ref,
 			"issue", issueNum,
 		)
+
+		// GH-5413: issueNum above is derived purely from the branch name, but a
+		// fix/revision issue intentionally runs on its ORIGIN issue's branch
+		// (resolveAutopilotFixBranch), so an orphaned PR here can actually
+		// belong to a fix issue F even though the branch encodes origin issue
+		// O. Prefer F when the durable spawned-fix claim (recorded
+		// synchronously by CreateFailureIssue/CreateReviewIssue, so it
+		// survives the restarts that create these orphans in the first
+		// place) names a different issue than the branch does — otherwise a
+		// merge here would close O instead of F. If the lookup itself fails,
+		// fall back to the branch-derived issue rather than blocking the
+		// sweep, but say so.
+		if c.stateStore != nil {
+			if fixIssue, err := c.stateStore.HasSpawnedFixForPR(c.repoKey(), pr.Number); err != nil {
+				c.log.Warn("reconciler: spawned-fix lookup failed, registering under branch-derived issue",
+					"pr", pr.Number, "branch", pr.Head.Ref, "branch_issue", issueNum, "error", err)
+			} else if fixIssue > 0 && fixIssue != issueNum {
+				c.log.Info("reconciler: orphan PR belongs to a fix issue on a borrowed origin branch — registering under the fix issue",
+					"pr", pr.Number, "branch", pr.Head.Ref, "origin_issue", issueNum, "fix_issue", fixIssue,
+				)
+				c.OnPRCreatedForFixIssue(pr.Number, pr.HTMLURL, fixIssue, issueNum, pr.Head.SHA, pr.Head.Ref, "")
+				if updatedAt, err := time.Parse(time.RFC3339, pr.UpdatedAt); err == nil {
+					c.seedAdoptedCIWaitClock(pr.Number, updatedAt)
+				}
+				c.metrics.RecordOrphanPRRegistered("reconciler")
+				continue
+			}
+		}
 		c.OnPRCreated(pr.Number, pr.HTMLURL, issueNum, pr.Head.SHA, pr.Head.Ref, "")
 		if updatedAt, err := time.Parse(time.RFC3339, pr.UpdatedAt); err == nil {
 			c.seedAdoptedCIWaitClock(pr.Number, updatedAt)

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -399,6 +399,40 @@ func TestController_OnPRCreated_UnverifiableBranchStillRegisters(t *testing.T) {
 	}
 }
 
+// TestController_OnPRCreatedForFixIssue_RegistersUnderFixIssue covers GH-5413
+// (PR #5412 follow-up): a fix issue F dispatched via resolveAutopilotFixBranch
+// runs on its origin PR's branch, which encodes the ORIGIN issue O, not F. A
+// caller that has independently confirmed this is a legitimate
+// borrowed-branch dispatch calls OnPRCreatedForFixIssue, which must register
+// the PR under F (so merging closes F, not O) while preserving the O-encoded
+// branch name unchanged.
+func TestController_OnPRCreatedForFixIssue_RegistersUnderFixIssue(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	const originIssue = 10
+	const fixIssue = 20
+	c.OnPRCreatedForFixIssue(42, "https://github.com/owner/repo/pull/42", fixIssue, originIssue, "abc123", "pilot/GH-10", "")
+
+	prs := c.GetActivePRs()
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 PR registered under the fix issue, got %d", len(prs))
+	}
+
+	state, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("PR 42 should be registered")
+	}
+	if state.IssueNumber != fixIssue {
+		t.Errorf("IssueNumber = %d, want %d (fix issue, not origin issue %d)", state.IssueNumber, fixIssue, originIssue)
+	}
+	if state.BranchName != "pilot/GH-10" {
+		t.Errorf("BranchName = %q, want %q (borrowed origin branch preserved unchanged)", state.BranchName, "pilot/GH-10")
+	}
+}
+
 func TestController_GetPRState(t *testing.T) {
 	ghClient := github.NewClient(testutil.FakeGitHubToken)
 	cfg := DefaultConfig()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5413.

Closes #5413

## Changes

GitHub Issue GH-5413: fix(autopilot): OnPRCreated branch/issue guard skips fix-issue PRs on a borrowed origin branch (PR #5412 follow-up)

## Problem

PR #5412 (GH-5409) added a defence-in-depth guard at the top of `OnPRCreated` in `internal/autopilot/controller.go`: if `parsePilotGHBranch(branchName)` yields an issue number different from the caller's `issueNumber`, registration is skipped with a warning. The guard assumes the branch always encodes the same issue as the task. Fix and revision issues break that assumption by design:

- `resolveAutopilotFixBranch` in `cmd/pilot/handlers.go` makes a fix issue F run on the origin PR's branch, which is named after the ORIGIN issue O (the autopilot-meta footer flow, decision memory "Pilot never reads GH comments", precedent #5261).
- `CreatePR` in `internal/executor/git.go` returns the existing PR's URL when the branch already has an open PR ("already exists" branch), and `adoptOpenBranchPR` in `internal/executor/runner.go` deliberately does not adopt the origin PR either, so the run's result carries PR = origin PR P (or a brand-new PR N when P was already closed) with branch = the origin branch.
- `cmd/pilot/poller_github.go` line 666 then calls OnPRCreated with PR = P or N, issue = F, branch = the origin branch. The guard sees O != F and returns.

While P is still in `activePRs` this changes nothing (the duplicate check right below already skipped the call). It bites exactly when P is NOT tracked: autopilot abandoned it at a failed stage (PR #5356 on 09-08, the case #5378 was filed for), the daemon restarted, or P was closed and the fix run opened a new PR N. Before #5412 those calls registered the PR under F. Now the PR is picked up only by `reconcileOrphanPRs` (same file, around lines 8454 and 8536), which derives the issue from the branch name, so it is registered under O. Consequences: F is never closed on merge and stays `pilot-in-progress`; the GH-1566 iteration check reads O's body instead of F's; O, already closed, gets the merge comment.

Not yet on the box: #5412 merged after the 14:16Z v2.274.0 train. This fix should land before the next train.

## Fix

Keep the guard for the case it was written for (a mis-paired PR event) but let a caller that KNOWS the branch is borrowed say so. Preferred shape:

1. Plumb "this task ran on a borrowed branch" from the runner result to the poller. The runner already knows it: `FromPR > 0` on the task (set by `resolveAutopilotFixBranch`). Expose it on the handler result that `cmd/pilot/handlers.go` builds (the struct that carries `BranchName` and `PRNumber`) and on the SDK-facing result at `cmd/pilot/poller_github.go` line 666.
2. Add an explicit entry point on the controller, for example `OnPRCreatedForFixIssue(prNumber, prURL, fixIssue, originIssue, headSHA, branchName, issueNodeID)` or an options struct, that bypasses the branch/issue mismatch check but still records `BranchName` unchanged and sets `IssueNumber = fixIssue`. The plain `OnPRCreated` keeps the guard.
3. Call the new entry point from the poller when the result says the branch was borrowed; otherwise call `OnPRCreated` as today.
4. `reconcileOrphanPRs` should not silently re-home a fix issue's PR under the origin issue: when the branch's issue is closed and an open `pilot`-labeled issue carries an autopilot-meta footer naming that branch, prefer the fix issue. If that lookup is too expensive for the 60s ticker, log a warning naming both candidates instead of registering under O.

## Tests

- `internal/autopilot/controller_test.go`: the guard still rejects the mismatch case (`TestController_OnPRCreated_ForeignIssueNumberIgnored` unchanged); a new test registers a PR under fix issue F via the new entry point with branch encoding O, and asserts `IssueNumber == F` and `BranchName` preserved.
- `cmd/pilot`: a poller-level test drives the real wiring at `cmd/pilot/poller_github.go` line 666 with a result whose task had `FromPR > 0` and asserts the controller tracks the PR under F (the GH-4211 lesson: test the handler production wires, not the controller method directly).
- Regression: a result WITHOUT the borrowed flag and a mismatching branch still produces zero registrations.

## Acceptance

- A fix issue whose run pushes to an untracked origin branch ends up tracked under the fix issue, and merging closes the fix issue.
- The mis-paired-event case from GH-5409 remains blocked.
- Test command, must be green:

```
go test ./internal/autopilot/ ./cmd/pilot/
```