### PR TITLE
GH-5414: fix(dispatch): needs_human rows have no re-arm path — clearing pilot-needs-human no longer re-admits the task (PR #5402 regression)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -4345,9 +4345,10 @@ type terminalCompletionChecker struct {
 // HasCompletedExecutionReason implements sdkCore.ExecutionCheckerV2
 // (studio-sdk v0.38.2+): same skip verdict as HasCompletedExecution, plus a
 // reason string classified at the point of decision so the poller's skip
-// log line names the real cause (repick-backoff cooldown, a stalled task
-// still awaiting GH-5139/GH-5249 re-arm evidence, or a genuinely completed
-// execution) instead of a single generic message.
+// log line names the real cause (repick-backoff cooldown, a canceled/
+// superseded task still awaiting GH-5139/GH-5249 re-arm evidence, a
+// needs_human task still awaiting GH-5414 re-arm evidence, or a genuinely
+// completed execution) instead of a single generic message.
 func (c terminalCompletionChecker) HasCompletedExecutionReason(taskID, projectPath string) (bool, string, error) {
 	key := repickBackoffKey(projectPath, taskID)
 	if gated, shouldLog := repickBackoff.gateStatus(key); gated {
@@ -4384,13 +4385,15 @@ func (c terminalCompletionChecker) HasCompletedExecutionReason(taskID, projectPa
 		return done, "", err
 	}
 
-	// GH-5139/GH-5249: `done` may be a genuine completed/no_op row (never
-	// re-arm — no GitHub probe, no throttling change), an operator cancel, or
-	// a hand-off supersede — the latter two alone among the terminal reasons
-	// are documented as re-armable via GitHub reopen/relabel.
-	// tryRearmCanceled/tryRearmSuperseded each tell their case apart
-	// internally (via LatestCanceledExecution/LatestSupersededExecution) and
-	// only spend an API call when their own row type is present.
+	// GH-5139/GH-5249/GH-5414: `done` may be a genuine completed/no_op row
+	// (never re-arm — no GitHub probe, no throttling change), an operator
+	// cancel, a hand-off supersede, or a needs_human hold — the latter three
+	// alone among the terminal reasons are documented as re-armable via
+	// GitHub reopen/relabel(/label-clear). tryRearmCanceled/tryRearmSuperseded/
+	// tryRearmNeedsHuman each tell their case apart internally (via
+	// LatestCanceledExecution/LatestSupersededExecution/
+	// LatestNeedsHumanExecution) and only spend an API call when their own
+	// row type is present.
 	if c.ghClient == nil {
 		return true, "completed execution exists", nil
 	}
@@ -4411,17 +4414,34 @@ func (c terminalCompletionChecker) HasCompletedExecutionReason(taskID, projectPa
 		repickBackoff.recordClaimLostDrop(key)
 		return true, "completed execution exists", nil
 	}
-	if !rearmed {
-		// Neither probe found a matching row + fresh re-arm evidence — a
-		// canceled/superseded task sitting open+labeled (or not yet
-		// relabeled at all) without a qualifying reopen/relabel event since
-		// its terminal transition. Throttle via the same repick-backoff
-		// window GH-4469 already built, so this doesn't pay for a
-		// GetIssue+ListIssueEvents call on every ~30s poll tick.
-		repickBackoff.recordClaimLostDrop(key)
-		return true, "stalled: awaiting re-arm evidence", nil
+	if rearmed {
+		return false, "", nil
 	}
-	return false, "", nil
+	rearmed, probeErr = c.tryRearmNeedsHuman(taskID, projectPath, key)
+	if probeErr != nil {
+		logging.WithComponent("dispatch").Warn("GH-5414 re-arm probe failed — treating needs_human task as still terminal",
+			slog.String("task_id", taskID), slog.Any("error", probeErr))
+		repickBackoff.recordClaimLostDrop(key)
+		return true, "completed execution exists", nil
+	}
+	if rearmed {
+		return false, "", nil
+	}
+
+	// None of the three probes found a matching row + fresh re-arm evidence
+	// — a canceled/superseded/needs_human task sitting open+labeled (or not
+	// yet relabeled/uncleared at all) without a qualifying event since its
+	// terminal transition. Throttle via the same repick-backoff window
+	// GH-4469 already built, so this doesn't pay for up to three
+	// GetIssue+ListIssueEvents call pairs on every ~30s poll tick.
+	repickBackoff.recordClaimLostDrop(key)
+	if _, found, lookupErr := c.store.LatestNeedsHumanExecution(taskID, projectPath); lookupErr == nil && found {
+		// GH-5414: name the parked state explicitly rather than the generic
+		// stalled text below, so the poller's skip log line tells the
+		// operator what to do — clear pilot-needs-human.
+		return true, reasonNeedsHumanAwaitingRearm, nil
+	}
+	return true, "stalled: awaiting re-arm evidence", nil
 }
 
 // HasCompletedExecution implements sdkCore.ExecutionChecker. Delegates to

--- a/cmd/pilot/rearm_needs_human.go
+++ b/cmd/pilot/rearm_needs_human.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/logging"
+)
+
+// reasonNeedsHumanAwaitingRearm is HasCompletedExecutionReason's skip reason
+// for a needs_human row that has not (yet) seen re-arm evidence — GH-5414
+// names the parked state explicitly instead of falling through to the
+// generic "stalled: awaiting re-arm evidence" text canceled/superseded share,
+// so the poller's skip log line tells the operator what to do: clear
+// pilot-needs-human.
+const reasonNeedsHumanAwaitingRearm = "needs_human: awaiting operator to clear pilot-needs-human"
+
+// tryRearmNeedsHuman is GH-5414's re-arm probe for holdPushedBranch's
+// needs_human hand-off (GH-5399/PR#5402). Counting 'needs_human' as terminal
+// in Store.HasTerminalCompletion fixed a false-retry bug, but it also removed
+// the only re-admission path a parked task had: unlike 'canceled' (GH-5139)
+// and 'superseded' (GH-5249), needs_human had no re-arm probe at all, so the
+// hold comment (internal/executor/runner.go, "clear pilot-needs-human to
+// resume") and the pre-PR#5402 operator recipe that worked live on #5375
+// until 09-08 both promised something the poller could no longer deliver —
+// clearing the label just left the task falling through to
+// HasCompletedExecutionReason's generic "stalled: awaiting re-arm evidence"
+// branch forever. This is what makes the promise true again, for
+// GitHub-backed tasks only.
+//
+// Mirrors tryRearmCanceled (cmd/pilot/rearm_canceled.go) almost exactly —
+// same store-pair shape, same rearmProbeTimeout, same backoff wiring — with
+// two differences: the issue must ALSO have actually dropped
+// pilot-needs-human (a needs_human hold is only resumable once the label
+// that caused it is gone, not just because the trigger label is still
+// present), and the re-arm evidence additionally accepts an "unlabeled"
+// event for pilot-needs-human itself, via latestNeedsHumanRearmEvent below —
+// removing that label IS the documented gesture.
+//
+// backoffKey is threaded through so a successful re-arm can clear the
+// repick-backoff window immediately (recordSuccess) rather than waiting out
+// whatever cooldown the last "not yet re-armed" probe set.
+//
+// Returns rearmed=false, err=nil for the ordinary "nothing to do" cases: no
+// needs_human row (the terminal evidence was a genuine completed/no_op/
+// canceled/superseded row instead), a non-GitHub task_id, the issue still
+// carrying pilot-needs-human, a closed issue, or an open+labeled+cleared
+// issue with no qualifying event timestamped after the hold. Returns
+// err != nil only on an actual GitHub API failure, so the caller can
+// distinguish "confirmed not re-armed" from "couldn't tell" (see
+// HasCompletedExecutionReason's error-handling comment for why that
+// distinction matters for backoff).
+func (c terminalCompletionChecker) tryRearmNeedsHuman(taskID, projectPath, backoffKey string) (bool, error) {
+	exec, found, err := c.store.LatestNeedsHumanExecution(taskID, projectPath)
+	if err != nil {
+		return false, fmt.Errorf("looking up needs_human execution: %w", err)
+	}
+	if !found || exec.CompletedAt == nil {
+		// No needs_human row (terminal evidence was completed/no_op/canceled/
+		// superseded instead) or a needs_human row somehow missing its hold
+		// timestamp — either way, nothing GH-5414 can evaluate re-arm
+		// evidence against.
+		return false, nil
+	}
+
+	var issueNum int
+	if _, scanErr := fmt.Sscanf(taskID, "GH-%d", &issueNum); scanErr != nil || issueNum <= 0 {
+		// Not a GitHub-issue-shaped task_id — this checker is only wired for
+		// the GitHub SDK poller, but stay defensive rather than assume.
+		return false, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rearmProbeTimeout)
+	defer cancel()
+
+	issue, err := c.ghClient.GetIssue(ctx, c.repoOwner, c.repoName, issueNum)
+	if err != nil {
+		return false, fmt.Errorf("fetching issue #%d: %w", issueNum, err)
+	}
+	if issue.State != "open" || !github.HasLabel(issue, c.triggerLabel) || github.HasLabel(issue, labelPilotNeedsHumanSDK) {
+		// Re-arm requires open + trigger-labeled + pilot-needs-human actually
+		// gone right now — an operator who relabels a still-closed issue,
+		// reopens without the trigger label, or hasn't removed
+		// pilot-needs-human yet hasn't finished the deliberate re-arm
+		// gesture.
+		return false, nil
+	}
+
+	events, err := c.ghClient.ListIssueEvents(ctx, c.repoOwner, c.repoName, issueNum)
+	if err != nil {
+		return false, fmt.Errorf("listing issue #%d events: %w", issueNum, err)
+	}
+	rearmEvent := latestNeedsHumanRearmEvent(events, *exec.CompletedAt, c.triggerLabel, labelPilotNeedsHumanSDK)
+	if rearmEvent == nil {
+		// Open + labeled + needs-human cleared right now, but nothing in the
+		// timeline shows that state was reached AFTER the hold — e.g. the
+		// label was removed before the hold and somehow never re-applied.
+		// Not a deliberate re-arm gesture.
+		return false, nil
+	}
+
+	reason := fmt.Sprintf("GH-5414: re-armed by issue #%d %s event at %s (needs_human at %s)",
+		issueNum, rearmEvent.Event, rearmEvent.CreatedAt.Format(time.RFC3339), exec.CompletedAt.Format(time.RFC3339))
+	if err := c.store.ReclassifyNeedsHumanForRearm(taskID, projectPath, reason); err != nil {
+		return false, fmt.Errorf("reclassifying needs_human row: %w", err)
+	}
+	repickBackoff.recordSuccess(backoffKey)
+	logging.WithComponent("dispatch").Info("GH-5414: needs_human task re-armed via GitHub label-clear/relabel/reopen",
+		slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.String("event", rearmEvent.Event))
+	return true, nil
+}
+
+// latestNeedsHumanRearmEvent extends latestRearmEvent (cmd/pilot/rearm_canceled.go)
+// for GH-5414: on top of the shared reopened/renamed/labeled(triggerLabel)
+// evidence every other re-arm probe accepts, an "unlabeled" event for
+// needsHumanLabel is itself sufficient re-arm evidence — removing
+// pilot-needs-human IS the documented gesture (the hold comment posted by
+// internal/executor/runner.go and the operator recipe that worked live on
+// #5375 until 09-08 both say "clear pilot-needs-human to resume"), unlike
+// labeled/unlabeled events on any other label family that other probes
+// accept.
+func latestNeedsHumanRearmEvent(events []*github.IssueEvent, since time.Time, triggerLabel, needsHumanLabel string) *github.IssueEvent {
+	latest := latestRearmEvent(events, since, triggerLabel)
+	for _, ev := range events {
+		if ev == nil || !ev.CreatedAt.After(since) {
+			continue
+		}
+		if ev.Event != "unlabeled" || ev.Label == nil || !strings.EqualFold(ev.Label.Name, needsHumanLabel) {
+			continue
+		}
+		if latest == nil || ev.CreatedAt.After(latest.CreatedAt) {
+			latest = ev
+		}
+	}
+	return latest
+}

--- a/cmd/pilot/rearm_needs_human_test.go
+++ b/cmd/pilot/rearm_needs_human_test.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// newRearmNeedsHumanTestServer mirrors newRearmTestServer (rearm_canceled_test.go)
+// but serves issue #5414 — a distinct number from the canceled/superseded
+// tests' fixed #5139/#5249 fixtures, since all three test files share the
+// terminalCompletionChecker struct and could otherwise collide if ever
+// exercised against the same httptest.Server. tryRearmNeedsHuman never
+// removes labels itself (that's the operator's own re-arm gesture), so
+// unlike newRearmSupersededTestServer this fixture has no DELETE route.
+func newRearmNeedsHumanTestServer(t *testing.T, issue *github.Issue, events []*github.IssueEvent) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/5414" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(issue)
+		case r.URL.Path == "/repos/owner/repo/issues/5414/events" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(events)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func seedNeedsHumanRow(t *testing.T, store *memory.Store, id, taskID, projectPath string, completedAt time.Time) {
+	t.Helper()
+	if err := store.SaveExecution(&memory.Execution{
+		ID: id, TaskID: taskID, ProjectPath: projectPath,
+		Status: "needs_human", Error: "GH-5399: salvaged work pushed, awaiting manual review", CompletedAt: &completedAt,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+}
+
+// TestTryRearmNeedsHuman_NoNeedsHumanRow_NoGitHubCallMade proves the probe is
+// scoped strictly to needs_human rows: a task with no needs_human row (e.g.
+// its terminal evidence was a genuine completed/canceled/superseded row
+// instead) must never trigger a GitHub API call.
+func TestTryRearmNeedsHuman_NoNeedsHumanRow_NoGitHubCallMade(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	srv := failIfCalledServer(t)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	rearmed, err := checker.tryRearmNeedsHuman("GH-5414-NOROW", "/project-no-row", "backoff-key-no-row")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rearmed {
+		t.Fatal("expected rearmed=false with no needs_human row present")
+	}
+}
+
+// TestTryRearmNeedsHuman_LabelStillPresent_NotRearmed covers the "operator
+// hasn't (yet) cleared pilot-needs-human" case: the issue is open and
+// trigger-labeled, but still carries pilot-needs-human — the re-arm gesture
+// is not complete yet, regardless of any other timeline evidence.
+func TestTryRearmNeedsHuman_LabelStillPresent_NotRearmed(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	holdTime := time.Now().Add(-time.Hour)
+
+	srv := newRearmNeedsHumanTestServer(t,
+		&github.Issue{Number: 5414, State: "open", Labels: []github.Label{{Name: "pilot"}, {Name: labelPilotNeedsHumanSDK}}},
+		nil,
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5414", "/project-label-present"
+	seedNeedsHumanRow(t, store, "exec-label-present", taskID, projectPath, holdTime)
+
+	rearmed, err := checker.tryRearmNeedsHuman(taskID, projectPath, "backoff-key-label-present")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rearmed {
+		t.Fatal("expected rearmed=false — pilot-needs-human is still on the issue")
+	}
+
+	exec, err := store.GetExecution("exec-label-present")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "needs_human" {
+		t.Errorf("expected the row to remain status=needs_human (not reclassified), got %q", exec.Status)
+	}
+}
+
+// TestTryRearmNeedsHuman_UnlabeledAfterHold_Rearms is the AC1 regression
+// test: an operator removing pilot-needs-human from an open, pilot-labeled
+// issue AFTER the hold must re-admit the task_id — reclassifying the
+// needs_human row to 'failed' so it flows through the ordinary
+// retry/backoff/hard-cap path.
+func TestTryRearmNeedsHuman_UnlabeledAfterHold_Rearms(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	holdTime := time.Now().Add(-time.Hour)
+	clearTime := holdTime.Add(30 * time.Minute)
+
+	srv := newRearmNeedsHumanTestServer(t,
+		&github.Issue{Number: 5414, State: "open", Labels: []github.Label{{Name: "pilot"}}},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: holdTime.Add(-24 * time.Hour), Label: &github.Label{Name: labelPilotNeedsHumanSDK}},
+			{Event: "unlabeled", CreatedAt: clearTime, Label: &github.Label{Name: labelPilotNeedsHumanSDK}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5414", "/project-rearmed"
+	seedNeedsHumanRow(t, store, "exec-rearmed", taskID, projectPath, holdTime)
+	key := repickBackoffKey(projectPath, taskID)
+	repickBackoff.recordDrop(key) // arm the backoff so we can prove recordSuccess clears it
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	rearmed, err := checker.tryRearmNeedsHuman(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rearmed {
+		t.Fatal("expected rearmed=true — pilot-needs-human was removed after the hold on an open, pilot-labeled issue")
+	}
+
+	exec, err := store.GetExecution("exec-rearmed")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected the needs_human row to be reclassified to status=failed (demote-don't-delete), got %q", exec.Status)
+	}
+
+	if gated, _ := repickBackoff.gateStatus(key); gated {
+		t.Error("expected repick backoff to be cleared on a successful re-arm, not left gated")
+	}
+
+	stillDone, err := store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion: %v", err)
+	}
+	if stillDone {
+		t.Fatal("expected HasTerminalCompletion to report false after re-arm, so nextRetryGeneration can grant the next generation normally")
+	}
+}
+
+// TestTryRearmNeedsHuman_RelabelTriggerAfterHold_Rearms covers the
+// alternative re-arm gesture: re-adding the base trigger label after the
+// hold (with pilot-needs-human already absent) is itself sufficient
+// evidence, same as tryRearmCanceled accepts for its own row type.
+func TestTryRearmNeedsHuman_RelabelTriggerAfterHold_Rearms(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	holdTime := time.Now().Add(-time.Hour)
+	relabelTime := holdTime.Add(30 * time.Minute)
+
+	srv := newRearmNeedsHumanTestServer(t,
+		&github.Issue{Number: 5414, State: "open", Labels: []github.Label{{Name: "pilot"}}},
+		[]*github.IssueEvent{
+			{Event: "unlabeled", CreatedAt: holdTime.Add(-time.Minute), Label: &github.Label{Name: "pilot"}},
+			{Event: "labeled", CreatedAt: relabelTime, Label: &github.Label{Name: "pilot"}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5414", "/project-relabel-rearmed"
+	seedNeedsHumanRow(t, store, "exec-relabel-rearmed", taskID, projectPath, holdTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	rearmed, err := checker.tryRearmNeedsHuman(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rearmed {
+		t.Fatal("expected rearmed=true — the trigger label was re-added after the hold on an open, pilot-needs-human-free issue")
+	}
+}
+
+// TestTryRearmNeedsHuman_UnlabeledBeforeHold_NotRearmed covers the ordering
+// half of the check: an unlabeled(pilot-needs-human) event timestamped
+// BEFORE the hold must not count as re-arm evidence — e.g. the label was
+// removed and then re-applied (triggering the hold again) without any
+// post-hold gesture.
+func TestTryRearmNeedsHuman_UnlabeledBeforeHold_NotRearmed(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	holdTime := time.Now().Add(-time.Hour)
+
+	srv := newRearmNeedsHumanTestServer(t,
+		&github.Issue{Number: 5414, State: "open", Labels: []github.Label{{Name: "pilot"}}},
+		[]*github.IssueEvent{
+			{Event: "unlabeled", CreatedAt: holdTime.Add(-time.Minute), Label: &github.Label{Name: labelPilotNeedsHumanSDK}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5414", "/project-stale-unlabel"
+	seedNeedsHumanRow(t, store, "exec-stale-unlabel", taskID, projectPath, holdTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	rearmed, err := checker.tryRearmNeedsHuman(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rearmed {
+		t.Fatal("expected rearmed=false — the unlabeled event predates the hold timestamp")
+	}
+
+	exec, err := store.GetExecution("exec-stale-unlabel")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "needs_human" {
+		t.Errorf("expected the row to remain status=needs_human (not reclassified), got %q", exec.Status)
+	}
+}
+
+// TestTryRearmNeedsHuman_ClosedIssue_NotRearmed covers the "reopen didn't
+// happen" half of the AND: even with a qualifying unlabeled event after the
+// hold, a currently-CLOSED issue must not re-arm.
+func TestTryRearmNeedsHuman_ClosedIssue_NotRearmed(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	holdTime := time.Now().Add(-time.Hour)
+
+	srv := newRearmNeedsHumanTestServer(t,
+		&github.Issue{Number: 5414, State: "closed", Labels: []github.Label{{Name: "pilot"}}},
+		[]*github.IssueEvent{
+			{Event: "unlabeled", CreatedAt: holdTime.Add(time.Minute), Label: &github.Label{Name: labelPilotNeedsHumanSDK}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5414", "/project-closed"
+	seedNeedsHumanRow(t, store, "exec-closed", taskID, projectPath, holdTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	rearmed, err := checker.tryRearmNeedsHuman(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rearmed {
+		t.Fatal("expected no re-arm — the issue is currently closed, regardless of a post-hold unlabeled event")
+	}
+}
+
+// TestTryRearmNeedsHuman_GitHubError_ReturnsError proves a genuine GitHub API
+// failure (as opposed to "no evidence found") is surfaced as an error rather
+// than silently treated as "not re-armed" — the caller (HasCompletedExecutionReason)
+// needs the distinction to decide whether to trust the still-terminal verdict.
+func TestTryRearmNeedsHuman_GitHubError_ReturnsError(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	holdTime := time.Now().Add(-time.Hour)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5414", "/project-gh-error"
+	seedNeedsHumanRow(t, store, "exec-gh-error", taskID, projectPath, holdTime)
+
+	rearmed, err := checker.tryRearmNeedsHuman(taskID, projectPath, "backoff-key-gh-error")
+	if err == nil {
+		t.Fatal("expected an error from a failing GitHub API call")
+	}
+	if rearmed {
+		t.Fatal("expected rearmed=false alongside the error")
+	}
+}

--- a/cmd/pilot/terminal_completion_checker_test.go
+++ b/cmd/pilot/terminal_completion_checker_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
 )
 
 // newTerminalCompletionCheckerTestStore creates a real on-disk store (no
@@ -188,5 +190,80 @@ func TestTerminalCompletionChecker_HasCompletedExecutionReason_GenuineCompletion
 	}
 	if reason != "completed execution exists" {
 		t.Fatalf("expected reason %q, got %q", "completed execution exists", reason)
+	}
+}
+
+// TestTerminalCompletionChecker_HasCompletedExecutionReason_NeedsHumanAwaitingRearm
+// is GH-5414's regression test: a needs_human row whose issue still carries
+// pilot-needs-human must report skip=true with the distinct
+// reasonNeedsHumanAwaitingRearm text — not the generic "stalled: awaiting
+// re-arm evidence" canceled/superseded fall through to — so the poller's
+// skip log line names the parked state and tells the operator what to do.
+func TestTerminalCompletionChecker_HasCompletedExecutionReason_NeedsHumanAwaitingRearm(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	holdTime := time.Now().Add(-time.Hour)
+
+	srv := newRearmNeedsHumanTestServer(t,
+		&github.Issue{Number: 5414, State: "open", Labels: []github.Label{{Name: "pilot"}, {Name: labelPilotNeedsHumanSDK}}},
+		nil,
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5414", "/project-needs-human-reason"
+	seedNeedsHumanRow(t, store, "exec-needs-human-reason", taskID, projectPath, holdTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	skip, reason, err := checker.HasCompletedExecutionReason(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !skip {
+		t.Fatal("expected skip=true — pilot-needs-human is still on the issue")
+	}
+	if reason != reasonNeedsHumanAwaitingRearm {
+		t.Fatalf("expected reason %q, got %q", reasonNeedsHumanAwaitingRearm, reason)
+	}
+}
+
+// TestTerminalCompletionChecker_HasCompletedExecutionReason_NeedsHumanRearmed
+// is the AC1 integration-style regression test through the full
+// HasCompletedExecutionReason chain: clearing pilot-needs-human on an open,
+// pilot-labeled issue after the hold must report skip=false (i.e. re-admit
+// the task_id) on the very next poll tick.
+func TestTerminalCompletionChecker_HasCompletedExecutionReason_NeedsHumanRearmed(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	holdTime := time.Now().Add(-time.Hour)
+	clearTime := holdTime.Add(30 * time.Minute)
+
+	srv := newRearmNeedsHumanTestServer(t,
+		&github.Issue{Number: 5414, State: "open", Labels: []github.Label{{Name: "pilot"}}},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: holdTime.Add(-24 * time.Hour), Label: &github.Label{Name: labelPilotNeedsHumanSDK}},
+			{Event: "unlabeled", CreatedAt: clearTime, Label: &github.Label{Name: labelPilotNeedsHumanSDK}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5414", "/project-needs-human-full-rearm"
+	seedNeedsHumanRow(t, store, "exec-needs-human-full-rearm", taskID, projectPath, holdTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	skip, reason, err := checker.HasCompletedExecutionReason(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if skip {
+		t.Fatal("expected skip=false — the task was re-armed by clearing pilot-needs-human after the hold")
+	}
+	if reason != "" {
+		t.Fatalf("expected an empty reason on re-arm, got %q", reason)
 	}
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1330,6 +1330,17 @@ func (s *Store) HasCompletedExecution(taskID, projectPath string) (bool, error) 
 // Without this, a needs_human row (which TerminalStatus/terminalExecutionStatuses
 // now also treat as terminal) would still look "not done" here and could be
 // handed a brand new generation on top of the held branch.
+//
+// GH-5414: like 'canceled'/'superseded' above, 'needs_human' here is a
+// default, not an unconditional forever — cmd/pilot's terminalCompletionChecker
+// independently probes for genuine re-arm evidence (issue open + trigger
+// label present + pilot-needs-human label removed + a qualifying event after
+// the hold) and, when found, calls ReclassifyNeedsHumanForRearm to demote the
+// row to 'failed' BEFORE this ever runs again — restoring the re-admission
+// path that counting needs_human as terminal here removed. This function
+// itself never consults GitHub state and keeps treating a still-held row as
+// done, which is the correct default for every caller with no re-arm
+// evidence of its own.
 func (s *Store) HasTerminalCompletion(taskID, projectPath string) (bool, error) {
 	completed, err := s.HasCompletedExecution(taskID, projectPath)
 	if err != nil {
@@ -1534,6 +1545,67 @@ func (s *Store) ReclassifySupersededForRearm(taskID, projectPath, reason string)
 			UPDATE executions
 			SET status = 'failed', error = ?, completed_at = CURRENT_TIMESTAMP
 			WHERE task_id = ? AND project_path = ? AND status = 'superseded'
+		`, reason, taskID, projectPath)
+		return err
+	})
+}
+
+// LatestNeedsHumanExecution returns the most recent status='needs_human' row
+// for taskID/projectPath — GH-5414's counterpart to LatestCanceledExecution,
+// extending the GH-5139 re-arm pattern to holdPushedBranch's hand-off status
+// (GH-5399/PR#5402). Exact task_id + status match, same as
+// LatestCanceledExecution: filtering on the literal status='needs_human'
+// column is what keeps this safe against the GH-4347 ordering trap (a fresh
+// 'queued' row for the same task_id sitting alongside the old needs_human
+// one). found=false when no needs_human row exists.
+//
+// completed_at on the returned row is the hold timestamp
+// (UpdateExecutionStatusIfNotTerminal stamps it CURRENT_TIMESTAMP on every
+// terminal transition, needs_human included) — the reference point GH-5414's
+// re-arm probe compares GitHub issue-event timestamps against to decide
+// whether a label-clear/relabel/reopen happened AFTER the hold, not before
+// it.
+func (s *Store) LatestNeedsHumanExecution(taskID, projectPath string) (exec *Execution, found bool, err error) {
+	row := s.db.QueryRow(`
+		SELECT `+executionDetailColumns+`
+		FROM executions
+		WHERE task_id = ? AND project_path = ? AND status = 'needs_human'
+		ORDER BY completed_at DESC, rowid DESC
+		LIMIT 1
+	`, taskID, projectPath)
+	exec, err = scanExecutionDetail(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return exec, true, nil
+}
+
+// ReclassifyNeedsHumanForRearm demotes every status='needs_human' row for
+// taskID/projectPath to 'failed' with reason recorded — GH-5414's
+// counterpart to ReclassifyCanceledForRearm, same "demote, don't delete"
+// idiom: the row (and its history) stays visible to `pilot trace`, but a
+// 'failed' row is not terminal per HasTerminalCompletion, so the ordinary
+// nextRetryGeneration retry-with-backoff/hard-cap path
+// (internal/executor/dispatcher.go) grants the next generation exactly the
+// way it would for any other post-failure retry — no bespoke bypass of those
+// invariants. The UPDATE's own `status = 'needs_human'` filter is what
+// protects against the GH-4347 ordering trap (see LatestNeedsHumanExecution):
+// a fresh 'queued' row for the same task_id is never touched by this call.
+//
+// Callers must independently confirm GitHub-side re-arm evidence (issue open
+// + carries the trigger label + does NOT carry pilot-needs-human + a
+// labeled/reopened/unlabeled(pilot-needs-human) event after the hold
+// timestamp LatestNeedsHumanExecution returned) before calling this — it
+// does not itself decide re-arm eligibility.
+func (s *Store) ReclassifyNeedsHumanForRearm(taskID, projectPath, reason string) error {
+	return s.withRetry("ReclassifyNeedsHumanForRearm", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET status = 'failed', error = ?, completed_at = CURRENT_TIMESTAMP
+			WHERE task_id = ? AND project_path = ? AND status = 'needs_human'
 		`, reason, taskID, projectPath)
 		return err
 	})


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5414.

Closes #5414

## Changes

GitHub Issue GH-5414: fix(dispatch): needs_human rows have no re-arm path — clearing pilot-needs-human no longer re-admits the task (PR #5402 regression)

## Problem

Since PR #5402 (GH-5399, on the box in v2.274.0), `HasTerminalCompletion` in `internal/memory/store.go` counts a `needs_human` row as terminal completion. That was correct for the false-retry it fixed, but it removed the only re-admission path a parked task had:

- The SDK poller asks `HasCompletedExecutionReason` in `cmd/pilot/main.go` before dispatch. With a `needs_human` row present it now returns skip=true. The re-arm probes that exist for the other operator-recoverable terminal rows (`cmd/pilot/rearm_canceled.go` for GH-5139, `cmd/pilot/rearm_superseded.go` for GH-5249) have no `needs_human` counterpart, so the call falls through to the "stalled: awaiting re-arm evidence" branch forever.
- `nextRetryGeneration` in `internal/executor/dispatcher.go` refuses generation+1 for the same reason.
- The hold comment Pilot posts (`internal/executor/runner.go` around line 2690, "before clearing this label") and the operator recipe that worked until 09-08 (strip `pilot-needs-human`, fix the body, task re-admits within one poll; used live on #5375) both still promise that clearing the label resumes the task. It no longer does. The only recovery today is close + refile, which loses the branch and the ledger.

PR #5411 (GH-5408) extended the same terminality into the store's CAS guard and the cleanup mirror, which is consistent, so the fix belongs in the re-arm layer, not in reverting terminality.

## Fix

Add a `needs_human` re-arm probe mirroring the GH-5139 idiom in `cmd/pilot/rearm_canceled.go`:

1. Store: a `LatestNeedsHumanExecution(taskID, projectPath)` lookup (exact match, like `LatestCanceledExecution`) and a `ReclassifyNeedsHumanForRearm(taskID, projectPath, reason)` mutation that moves the row out of the terminal set the same way `ReclassifyCanceledForRearm` does, so `HasTerminalCompletion` stops counting it and the poller dispatches a fresh generation.
2. Checker: a `tryRearmNeedsHuman` method on `terminalCompletionChecker` in `cmd/pilot/main.go`, called from `HasCompletedExecutionReason` alongside the canceled and superseded probes. Re-arm evidence is: issue open AND currently carries the trigger label AND does NOT carry `pilot-needs-human` AND the timeline has an `unlabeled` event for `pilot-needs-human`, or a `labeled` event for the trigger label, or `reopened`, timestamped strictly after the row's `completed_at`. `latestRearmEvent` currently accepts only labeled/reopened/renamed; extend it (or add a sibling) to accept the `unlabeled` event for the needs-human label, since removing that label IS the documented gesture.
3. Reason string: return a distinct reason (for example "needs_human: awaiting operator to clear pilot-needs-human") instead of the generic stalled text, so the poller log tells the operator what to do.
4. Backoff: on successful re-arm call `recordSuccess` on the repick-backoff key, as the canceled probe does; on "not yet" record a claim-lost drop so this does not cost two GitHub calls per 30s tick.

Do not touch `internal/executor/dispatcher.go` terminal sets or `TestTerminalExecutionStatusSets_Match`; `needs_human` stays terminal for every other consumer.

## Tests

- New test file next to `cmd/pilot/rearm_canceled_test.go` covering: no needs_human row → no-op; row present, label still on issue → skip with the new reason; label removed after completed_at → reclassified, skip=false, backoff cleared; unlabeled event BEFORE completed_at → not re-armed; GitHub error → err returned, still skip.
- Assert the reason string in the checker test (`cmd/pilot/terminal_completion_checker_test.go`).
- Existing `HasTerminalCompletion` tests in `internal/memory/store_test.go` must still pass unchanged.

## Acceptance

- A task whose latest row is `needs_human` re-dispatches within one poll tick after an operator removes `pilot-needs-human` from an open, `pilot`-labeled issue, with no close/refile.
- The poller log line for a still-parked task names the needs-human state, not "completed execution exists" or the generic stalled text.
- Test command, must be green:

```
go test ./cmd/pilot/ ./internal/memory/ ./internal/executor/
```