### PR TITLE
GH-5415: fix(executor): declinedCancel reason leaks past a clean backend exit and misclassifies the next failure as declined (PR #5412 follow-up)

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -6850,9 +6850,22 @@ func (r *Runner) registerExecCancel(taskID string, cancel context.CancelFunc) {
 // once its executeWithOptions call returns. GH-5400/GH-5409: only the top of
 // the stack is removed, so a still-in-flight OUTER call's entry survives a
 // nested inner call with the same task ID (see the execCancel field doc).
+//
+// GH-5415: this is also the safety net for declinedCancel. CancelDeclined
+// stashes a reason for executeWithOptions's error path to consume via
+// takeDeclinedCancelReason, but that consumption only happens on the
+// err != nil branch — if the backend races the cancel and returns err == nil
+// (subprocess finished cleanly just before the cancel landed, or the backend
+// swallows the ctx cancellation), the reason is never taken and would
+// otherwise survive in the map. The NEXT genuine failure of the same task ID
+// (a retry generation, a re-pick, a decomposed subtask sharing the parent
+// ID) would then be misclassified as "declined" instead of "failed". Clear
+// it unconditionally here — once this execution's defer runs, no later,
+// unrelated run of the same task ID may inherit its decline reason.
 func (r *Runner) unregisterExecCancel(taskID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	delete(r.declinedCancel, taskID)
 	stack := r.execCancel[taskID]
 	if len(stack) <= 1 {
 		delete(r.execCancel, taskID)

--- a/internal/executor/runner_gh5409_test.go
+++ b/internal/executor/runner_gh5409_test.go
@@ -143,3 +143,40 @@ func TestRunner_FinishDeclined_TerminalStatusIsDeclinedNotFailed(t *testing.T) {
 		t.Errorf("TerminalStatus() = %q, want %q", got, "declined")
 	}
 }
+
+// TestRunner_UnregisterExecCancel_ClearsStaleDeclinedReason is the GH-5415
+// regression test: CancelDeclined stashes a decline reason for the failure
+// path to consume via takeDeclinedCancelReason, but that consumption only
+// happens on the err != nil branch. If the backend races the cancel and
+// returns success (subprocess finished cleanly just before the cancel
+// landed, or the backend swallows the ctx cancellation), the reason is never
+// taken by that execution. Before this fix, it survived in the runner's
+// declinedCancel map and the NEXT execution of the same task ID — even one
+// that fails for a completely ordinary reason — would be misclassified as
+// "declined" instead of "failed". unregisterExecCancel must clear the entry
+// unconditionally so no reason outlives the execution it was raised against.
+func TestRunner_UnregisterExecCancel_ClearsStaleDeclinedReason(t *testing.T) {
+	r := newSilentRunnerTask359()
+	const taskID = "GH-104"
+
+	// First execution: CancelDeclined is invoked (races a backend that is
+	// about to finish cleanly), but the mock backend "returns success" —
+	// i.e. the error path (and its takeDeclinedCancelReason call) never
+	// runs, so the reason is left sitting in the map.
+	r.registerExecCancel(taskID, func() {})
+	if err := r.CancelDeclined(taskID, "spec-guard: scope changed after dispatch"); err != nil {
+		t.Fatalf("CancelDeclined returned error: %v", err)
+	}
+	// Simulate the backend returning err == nil: the success path does not
+	// call takeDeclinedCancelReason. executeWithOptions's defer still runs.
+	r.unregisterExecCancel(taskID)
+
+	// Second, unrelated execution of the same task ID fails for an ordinary
+	// reason. Its error path calls takeDeclinedCancelReason to decide
+	// declined vs. failed — it must find nothing.
+	r.registerExecCancel(taskID, func() {})
+	if reason, declined := r.takeDeclinedCancelReason(taskID); declined {
+		t.Errorf("expected no stale declinedCancel reason to survive into the next execution, got %q", reason)
+	}
+	r.unregisterExecCancel(taskID)
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5415.

Closes #5415

## Changes

GitHub Issue GH-5415: fix(executor): declinedCancel reason leaks past a clean backend exit and misclassifies the next failure as declined (PR #5412 follow-up)

## Problem

PR #5412 (GH-5409) added `CancelDeclined` on the runner in `internal/executor/runner.go`: it stores a decline reason per task ID, cancels the running backend, and the failure path consumes the reason via `takeDeclinedCancelReason` (around line 6935) so the terminal status becomes `declined` instead of `failed`.

The reason is consumed only on the `err != nil` path. If `CancelDeclined` races a backend that returns `err == nil` (the subprocess finished cleanly a moment before the cancel landed, or the backend swallows the context cancellation), the stored reason is never taken. It survives in the runner's map, and the NEXT genuine failure of the same task ID (a retry generation, a re-pick, a subtask sharing the parent ID prefix) is misclassified as `declined`, which routes it away from the retry and alerting paths that a real failure should take.

## Fix

- Clear the task's `declinedCancel` entry in the `unregisterExecCancel` defer (same lifecycle as the per-task cancel stack introduced in the same PR), so a reason can never outlive the execution it was raised against.
- Keep `takeDeclinedCancelReason` as the read on the failure path; the defer is the safety net, not a replacement.

## Tests

- `internal/executor/runner_gh5409_test.go`: a test where the mock backend returns success after `CancelDeclined` was called, then a second execution of the same task ID fails for an ordinary reason, asserting the second run's terminal status is `failed`, not `declined`.
- The existing `TestRunner_FinishDeclined_TerminalStatusIsDeclinedNotFailed` remains green.

## Acceptance

- No decline reason survives past its execution's `unregisterExecCancel`.
- Test command, must be green:

```
go test ./internal/executor/ -run 'Declin|5409'
```