### PR TITLE
GH-5421: fix(poller): borrowed-branch fix-issue PRs still dropped on the primary SDK OnPRCreated path; reconciler re-homes new PR under closed origin issue (PR #5416 follow-up)

### DIFF
--- a/.agent/tasks/gh-5421.md
+++ b/.agent/tasks/gh-5421.md
@@ -1,0 +1,42 @@
+# GH-5421
+
+**Created:** 2026-09-10
+
+## Problem
+
+GitHub Issue GH-5421: fix(poller): borrowed-branch fix-issue PRs still dropped on the primary SDK OnPRCreated path; reconciler re-homes new PR under closed origin issue (PR #5416 follow-up)
+
+## Problem
+
+PR #5416 (GH-5413) added `OnPRCreatedForFixIssue` on the autopilot controller and routed borrowed-branch PRs to it, but only on the rate-limit retry path in `cmd/pilot/poller_github.go` (the `QueueRetryIfRateLimited` / `githubRetryCallback` pair). The primary path is untouched: the SDK poller calls its `OnPRCreated` hook after every handled issue, that hook is `githubOnPRCreatedHandler` in `cmd/pilot/poller_github.go` (around line 75), and it calls the plain guarded `OnPRCreated` in `internal/autopilot/controller.go`. The SDK's PRCreatedEvent struct carries only PR number, URL, issue id, head SHA, branch name and node id; there is no borrowed marker, and `FromPR` is not persisted anywhere the handler could read.
+
+So for a fix or revision issue F whose task runs on the origin branch named after issue O (set by `resolveAutopilotFixBranch` in `cmd/pilot/handlers.go`), the branch/issue guard still drops the registration on every non-rate-limited run. GH-5413's acceptance criterion is not met on the path that fires in production. The earlier issue pointed at the retry callback line by mistake; this issue corrects the target.
+
+Second gap: `reconcileOrphanPRs` in `internal/autopilot/controller.go` (around lines 8585-8600) asks `HasSpawnedFixForPR` keyed by the ORIGIN PR number. The normal CI-fix spawn closes the origin PR P, so the fix run opens a new PR N on the borrowed branch. The lookup for N finds nothing and N is registered under O. Live scenario: P on branch for #100 fails CI → fix #200 spawned, P closed → run opens N on that branch → SDK path drops it → reconciler registers N under #100 → N merges, closed #100 gets the merge comment, #200 stays `pilot-in-progress`.
+
+## Fix (network-free, no SDK bump)
+
+1. **Record the borrowed branch at dispatch.** In `cmd/pilot/handlers.go` where the Task is built (the block that sets `FromPR` and `FixFromSHA`, around line 1117): when `FromPR > 0` and the resolved branch does not equal the task's own default branch name, record (task id → branch, fromPR) in a small process-local registry. Put the registry on the Runner in `internal/executor/runner.go` next to the per-task cancel stack (same mutex), with `RecordBorrowedBranch(taskID, branch string, fromPR int)` and `BorrowedBranch(taskID string) (branch string, fromPR int, ok bool)`. Clear the entry when the execution unregisters, the same way `declinedCancel` is cleared in `unregisterExecCancel` (PR #5418), but only AFTER the poller has had its chance to read it: simplest is to keep the entry until the next execution of the same task id overwrites it, or expire on a short TTL. State the choice in the PR.
+2. **Consult it in the primary hook.** `githubOnPRCreatedHandler` gets the Runner (or a narrow interface with just `BorrowedBranch`). If the event's issue id maps to a task with a recorded borrowed branch equal to the event's branch name, call `OnPRCreatedForFixIssue` with fixIssue = event issue, originIssue = parsed from the branch; otherwise call `OnPRCreated` as today. Keep `githubRetryCallback` working; it can use the same registry instead of the `FromPR` it currently threads through, or keep both.
+3. **Reconciler.** In `reconcileOrphanPRs`, before registering an untracked `pilot/GH-<O>` PR under O: if the registry (or the state store) shows an open pilot issue F that ran on this branch, register under F via `OnPRCreatedForFixIssue`. If no such record exists AND issue O is closed, log a warning naming O and the PR and skip registration rather than registering under a closed issue. The existing `HasSpawnedFixForPR` check can stay as a first attempt.
+4. Persisting across daemon restarts is out of scope for this issue; note it in the PR if the registry is in-memory only.
+
+## Tests
+
+- `cmd/pilot`: a test that builds the real `githubOnPRCreatedHandler` with a Runner that has a borrowed-branch record for task GH-200 on branch pilot/GH-100, feeds a PRCreatedEvent with IssueID "200" and that branch, and asserts the controller tracks the PR with IssueNumber 200 and the branch preserved (the GH-4211 lesson: drive the production hook, not the controller method).
+- Negative: same event without a registry record → zero registrations (guard still holds).
+- `internal/autopilot`: reconciler test where the origin issue is closed and no fix record exists → warning, no registration; and where a fix record exists → registered under the fix issue.
+- Removing the `FromPR` assignment in `cmd/pilot/handlers.go` must fail at least one test.
+
+## Acceptance
+
+- A fix issue whose run pushes to a borrowed origin branch is tracked under the fix issue on the normal poll path, and merging closes the fix issue.
+- An untracked PR on a branch whose origin issue is closed is never silently registered under that closed issue.
+- Test command, must be green:
+
+```
+go test ./cmd/pilot/ ./internal/autopilot/
+```
+
+## Acceptance Criteria
+

--- a/cmd/pilot/gh5421_borrowed_branch_dispatch_test.go
+++ b/cmd/pilot/gh5421_borrowed_branch_dispatch_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestHandleGithubIssueEventSDK_BorrowedBranch_RecordsRegistryEntry is the
+// GH-5421 regression test for dispatch-time recording: when
+// resolveAutopilotFixBranch resolves a fix issue's branch to its origin PR's
+// branch (the autopilot-meta footer flow), handleGithubIssueEventSDK must
+// call runner.RecordBorrowedBranch so the primary SDK OnPRCreated hook
+// (githubOnPRCreatedHandler) can later find it. This drives the real
+// production function (mirrors the GH-5072/GH-5056 idiom: a nonexistent
+// projectPath makes the dispatcher fail cheaply at its preflight git_clean
+// check rather than actually running a backend) instead of asserting on a
+// re-implementation, so a future edit that stops wiring the call is caught
+// here, not just by a source-level grep.
+func TestHandleGithubIssueEventSDK_BorrowedBranch_RecordsRegistryEntry(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-test-gh5421-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	runner := executor.NewRunner()
+	dispatcher := executor.NewDispatcher(store, runner, nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("dispatcher.Start: %v", err)
+	}
+	t.Cleanup(dispatcher.Stop)
+
+	const taskID = "GH-54210"
+	const projectPath = "/nonexistent-gh5421-project"
+
+	ev := sdkcore.IssueEvent{
+		SequenceID: taskID,
+		IssueID:    "54210",
+		Title:      "Fix the failing check",
+		// GH-5379 autopilot-meta footer: resolveAutopilotFixBranch resolves
+		// this to branch=pilot/GH-54209 (the ORIGIN issue), fromPR=9001 — a
+		// borrowed branch, distinct from this task's own default
+		// "pilot/GH-54210" branch.
+		Body:   "Please fix the failing check.\n\n<!-- autopilot-meta branch:pilot/GH-54209 pr:9001 -->",
+		Labels: []string{"pilot"},
+	}
+
+	// Dispatch genuinely proceeds past admission (no needs-human label) and
+	// fails only once the dispatcher's own preflight can't find projectPath
+	// on disk — by then RecordBorrowedBranch has already run, since it sits
+	// before task construction/dispatch in handleGithubIssueEventSDK.
+	_, _ = handleGithubIssueEventSDK(context.Background(), &config.Config{}, ev, projectPath, "", dispatcher, runner, nil, nil, nil, nil, nil)
+
+	branch, fromPR, ok := runner.BorrowedBranch(taskID)
+	if !ok {
+		t.Fatalf("runner.BorrowedBranch(%q) recorded no entry, want the autopilot-meta footer's borrowed branch", taskID)
+	}
+	if branch != "pilot/GH-54209" {
+		t.Errorf("BorrowedBranch branch = %q, want %q", branch, "pilot/GH-54209")
+	}
+	if fromPR != 9001 {
+		t.Errorf("BorrowedBranch fromPR = %d, want 9001", fromPR)
+	}
+}
+
+// TestHandleGithubIssueEventSDK_OwnBranch_NoRegistryEntry is the negative
+// control: an issue with no autopilot-meta footer (the common case) resolves
+// to its own default "pilot/<taskID>" branch and must NOT record a
+// borrowed-branch entry — RecordBorrowedBranch is dispatch-time noise
+// otherwise, and would make FixIssueForBranch/BorrowedBranch's "found" case
+// meaningless for ordinary issues.
+func TestHandleGithubIssueEventSDK_OwnBranch_NoRegistryEntry(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-test-gh5421-b-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	runner := executor.NewRunner()
+	dispatcher := executor.NewDispatcher(store, runner, nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("dispatcher.Start: %v", err)
+	}
+	t.Cleanup(dispatcher.Stop)
+
+	const taskID = "GH-54211"
+	const projectPath = "/nonexistent-gh5421-project-b"
+
+	ev := sdkcore.IssueEvent{
+		SequenceID: taskID,
+		IssueID:    "54211",
+		Title:      "Implement a normal feature",
+		Body:       "Please implement this feature.",
+		Labels:     []string{"pilot"},
+	}
+
+	_, _ = handleGithubIssueEventSDK(context.Background(), &config.Config{}, ev, projectPath, "", dispatcher, runner, nil, nil, nil, nil, nil)
+
+	if branch, fromPR, ok := runner.BorrowedBranch(taskID); ok {
+		t.Errorf("runner.BorrowedBranch(%q) = (%q, %d, true), want ok=false for an issue with no autopilot-meta footer", taskID, branch, fromPR)
+	}
+}
+
+// TestGithubHandlerSDK_RecordBorrowedBranchWired is a source-level regression
+// guard (mirrors TestGithubHandlerSDK_FieldsWired in
+// github_sdk_task_fields_test.go), scoped to handleGithubIssueEventSDK's own
+// body: the RecordBorrowedBranch call must exist inside this function, not
+// merely somewhere unreferenced in the package.
+func TestGithubHandlerSDK_RecordBorrowedBranchWired(t *testing.T) {
+	body := githubFuncBody(t, "handlers.go", "func handleGithubIssueEventSDK(")
+
+	for _, want := range []string{
+		"RecordBorrowedBranch(",
+		"fromPR > 0",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("handleGithubIssueEventSDK body must contain %q (GH-5421: borrowed-branch registry must be populated at dispatch time)", want)
+		}
+	}
+}

--- a/cmd/pilot/gh5421_borrowed_branch_primary_test.go
+++ b/cmd/pilot/gh5421_borrowed_branch_primary_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/autopilot"
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/testutil"
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestGithubOnPRCreatedHandler_BorrowedBranch_RegistersUnderFixIssue is the
+// GH-5421 regression test for the PRIMARY SDK OnPRCreated path (as opposed to
+// the rate-limit retry path GH-5413/PR#5416 already fixed). Mirrors the
+// GH-4211 lesson (poller_github_gh4211_test.go): drive the exact function
+// production wires into pollerDeps.OnPRCreated, not a lower-level controller
+// method called directly.
+//
+// A fix issue (task GH-200) dispatched onto its origin PR's branch
+// (resolveAutopilotFixBranch, cmd/pilot/handlers.go) records that borrowed
+// branch via RecordBorrowedBranch. When the SDK poller later fires
+// OnPRCreated for the resulting PR — with IssueID "200" (the fix issue) and
+// BranchName "pilot/GH-100" (the borrowed origin branch) — the handler must
+// route through OnPRCreatedForFixIssue so the PR is tracked under the fix
+// issue with the borrowed branch name preserved, instead of being silently
+// dropped by Controller.OnPRCreated's branch/issue guard (GH-5409).
+func TestGithubOnPRCreatedHandler_BorrowedBranch_RegistersUnderFixIssue(t *testing.T) {
+	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
+	cfg := autopilot.DefaultConfig()
+	ctrl := autopilot.NewController(cfg, ghClient, nil, "owner", "repo")
+
+	runner := &executor.Runner{}
+	runner.RecordBorrowedBranch("GH-200", "pilot/GH-100", 5361)
+
+	// This is the exact function production wires into pollerDeps.OnPRCreated
+	// (poller_github.go's startGithubSDKPollerForRepo), not a re-implementation.
+	handler := githubOnPRCreatedHandler(ctrl, runner)
+	handler(sdkcore.PRCreatedEvent{
+		PRNumber:   99,
+		PRURL:      "https://github.com/owner/repo/pull/99",
+		IssueID:    "200",
+		HeadSHA:    "deadbeef",
+		BranchName: "pilot/GH-100",
+	})
+
+	state, ok := ctrl.GetPRState(99)
+	if !ok {
+		t.Fatal("PR 99 should be registered")
+	}
+	if state.IssueNumber != 200 {
+		t.Errorf("IssueNumber = %d, want 200 (fix issue, not the branch-derived origin issue 100)", state.IssueNumber)
+	}
+	if state.BranchName != "pilot/GH-100" {
+		t.Errorf("BranchName = %q, want %q (borrowed origin branch preserved unchanged)", state.BranchName, "pilot/GH-100")
+	}
+}
+
+// TestGithubOnPRCreatedHandler_NoBorrowedRecord_GuardStillHolds is the
+// negative control: without a matching RecordBorrowedBranch entry (the
+// common case — most issues aren't fix/revision issues on a borrowed
+// branch), a branch/issue mismatch must still hit Controller.OnPRCreated's
+// GH-5409 guard and register nothing. This pins that adding the borrowed-
+// branch lookup does not turn into a blanket bypass of that guard.
+func TestGithubOnPRCreatedHandler_NoBorrowedRecord_GuardStillHolds(t *testing.T) {
+	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
+	cfg := autopilot.DefaultConfig()
+	ctrl := autopilot.NewController(cfg, ghClient, nil, "owner", "repo")
+
+	runner := &executor.Runner{} // no RecordBorrowedBranch call
+
+	handler := githubOnPRCreatedHandler(ctrl, runner)
+	handler(sdkcore.PRCreatedEvent{
+		PRNumber:   99,
+		PRURL:      "https://github.com/owner/repo/pull/99",
+		IssueID:    "200",
+		HeadSHA:    "deadbeef",
+		BranchName: "pilot/GH-100", // mismatches issue 200, no borrowed record to justify it
+	})
+
+	if prs := ctrl.GetActivePRs(); len(prs) != 0 {
+		t.Fatalf("expected 0 PRs registered without a borrowed-branch record, got %d", len(prs))
+	}
+	if _, ok := ctrl.GetPRState(99); ok {
+		t.Error("PR 99 should not be registered when branch/issue mismatch and no borrowed-branch record exists")
+	}
+}
+
+// TestGithubOnPRCreatedHandler_NilBorrowedReader_FallsBackToPlainOnPRCreated
+// guards the nil-safety of the borrowed reader parameter — production code
+// that hasn't wired a Runner (or an older test) must keep working exactly as
+// before GH-5421.
+func TestGithubOnPRCreatedHandler_NilBorrowedReader_FallsBackToPlainOnPRCreated(t *testing.T) {
+	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
+	cfg := autopilot.DefaultConfig()
+	ctrl := autopilot.NewController(cfg, ghClient, nil, "owner", "repo")
+
+	handler := githubOnPRCreatedHandler(ctrl, nil)
+	handler(sdkcore.PRCreatedEvent{
+		PRNumber:   4212,
+		PRURL:      "https://github.com/owner/repo/pull/4212",
+		IssueID:    "4211",
+		HeadSHA:    "abc1234",
+		BranchName: "pilot/GH-4211",
+	})
+
+	state, ok := ctrl.GetPRState(4212)
+	if !ok {
+		t.Fatal("PR 4212 should be registered via the plain OnPRCreated fallback")
+	}
+	if state.IssueNumber != 4211 {
+		t.Errorf("IssueNumber = %d, want 4211", state.IssueNumber)
+	}
+}

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -966,6 +966,19 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 			slog.String("source", source),
 		)
 	}
+	// GH-5421: record the borrowed branch/origin-PR before dispatch so the
+	// primary SDK OnPRCreated hook (githubOnPRCreatedHandler in
+	// poller_github.go) can route this task's resulting PR to
+	// OnPRCreatedForFixIssue instead of losing it to
+	// Controller.OnPRCreated's branch/issue guard (GH-5409) — GH-5413 only
+	// wired that routing into the rate-limit retry path, not this primary
+	// one, which is the gap this issue closes. Only recorded when the
+	// resolved branch actually differs from this task's own default branch
+	// (fromPR > 0 alone isn't enough — resolveAutopilotFixBranch's fallback
+	// sources can in principle resolve back to the task's own branch).
+	if fromPR > 0 && branchName != fmt.Sprintf("pilot/%s", taskID) && runner != nil {
+		runner.RecordBorrowedBranch(taskID, branchName, fromPR)
+	}
 
 	// Resolve owner/repo. M7 4d.2c: the per-repo SDK poller passes its repo
 	// explicitly (repoFullName) because resolveGithubRepo matches by repo NAME only

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -66,15 +66,40 @@ func (a githubPollerMetricsAdapter) RecordUnsourcedLabeledIssues(repo string, co
 	a.metrics.SetUnsourcedLabeledIssues(repo, int64(count))
 }
 
+// borrowedBranchReader is the narrow seam githubOnPRCreatedHandler needs to
+// detect a fix issue whose task was dispatched onto a borrowed origin branch
+// (GH-5421) — satisfied by *executor.Runner's BorrowedBranch method. A
+// separate interface (rather than depending on *executor.Runner directly)
+// lets tests supply a minimal fake without constructing a real Runner.
+type borrowedBranchReader interface {
+	BorrowedBranch(taskID string) (branch string, fromPR int, ok bool)
+}
+
 // githubOnPRCreatedHandler builds the callback wired into pollerDeps.OnPRCreated:
 // it forwards the SDK's PRCreatedEvent into Controller.OnPRCreated, the sole live
 // entry point for the GH-4130 throughput-histogram observation. Extracted to its
 // own function (GH-4211) so a regression test can drive the real handler that
 // production wires up, instead of calling ctrl.OnPRCreated directly — the gap
 // that let GH-4130's observation ship false-green in the first place.
-func githubOnPRCreatedHandler(ctrl *autopilot.Controller) func(sdkcore.PRCreatedEvent) {
+//
+// GH-5421: borrowed (may be nil) is consulted first. GH-5413 added
+// OnPRCreatedForFixIssue for a fix/revision issue dispatched onto its origin
+// PR's branch (resolveAutopilotFixBranch, cmd/pilot/handlers.go) but only
+// wired the routing into the rate-limit retry path (githubRetryCallback
+// below) — this primary path, which fires on every non-rate-limited run,
+// kept calling plain OnPRCreated, whose branch/issue guard (GH-5409) then
+// silently dropped the registration. handlers.go's RecordBorrowedBranch call
+// is what populates borrowed for this lookup to find.
+func githubOnPRCreatedHandler(ctrl *autopilot.Controller, borrowed borrowedBranchReader) func(sdkcore.PRCreatedEvent) {
 	return func(prEv sdkcore.PRCreatedEvent) {
 		issueNumber, _ := strconv.Atoi(prEv.IssueID)
+		if borrowed != nil {
+			taskID := fmt.Sprintf("GH-%d", issueNumber)
+			if branch, fromPR, ok := borrowed.BorrowedBranch(taskID); ok && fromPR > 0 && branch == prEv.BranchName {
+				ctrl.OnPRCreatedForFixIssue(prEv.PRNumber, prEv.PRURL, issueNumber, fromPR, prEv.HeadSHA, prEv.BranchName, prEv.IssueNodeID)
+				return
+			}
+		}
 		ctrl.OnPRCreated(prEv.PRNumber, prEv.PRURL, issueNumber, prEv.HeadSHA, prEv.BranchName, prEv.IssueNodeID)
 	}
 }
@@ -616,8 +641,16 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 		ctrl := controller
 		// GitHub's IssueID is the numeric issue number; forwarded (with the node ID)
 		// so the autopilot controller's post-merge gates and board-sync-to-Review work.
-		pollerDeps.OnPRCreated = githubOnPRCreatedHandler(ctrl)
+		pollerDeps.OnPRCreated = githubOnPRCreatedHandler(ctrl, deps.Runner)
 		pollerDeps.IssueMetricsRecorder = ctrl.Metrics()
+		// GH-5421: wire the same in-process registry into the reconciler so
+		// reconcileOrphanPRs's fallback path can find a fix issue driving an
+		// untracked PR's branch, not just the durable-but-differently-keyed
+		// HasSpawnedFixForPR claim (see controller.go's reconcileOrphanPRs
+		// doc for why that lookup alone misses this case).
+		if deps.Runner != nil {
+			ctrl.SetBorrowedBranchLookup(deps.Runner)
+		}
 		// GH-5336: wire poller skip/dispatch counters for the GitHub SDK path
 		// too — unlike the in-tree GitLab/AzureDevOps pollers, this was never
 		// hooked up, so recordSkip calls inside the SDK poller (poller.go:962)

--- a/cmd/pilot/poller_github_gh4211_test.go
+++ b/cmd/pilot/poller_github_gh4211_test.go
@@ -77,7 +77,7 @@ func TestGithubOnPRCreatedHandler_ObservesThroughputHistograms(t *testing.T) {
 
 	// This is the exact function production wires into pollerDeps.OnPRCreated
 	// (poller_github.go), not a re-implementation of it.
-	handler := githubOnPRCreatedHandler(ctrl)
+	handler := githubOnPRCreatedHandler(ctrl, nil)
 	handler(sdkcore.PRCreatedEvent{
 		PRNumber:   4212,
 		PRURL:      "https://github.com/owner/repo/pull/4212",
@@ -124,7 +124,7 @@ func TestGithubOnPRCreatedHandler_MissingStartedAt_SkipsObservation(t *testing.T
 	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
 	ctrl := autopilot.NewController(cfg, ghClient, nil, "owner", "repo", autopilot.WithMemoryStore(store))
 
-	handler := githubOnPRCreatedHandler(ctrl)
+	handler := githubOnPRCreatedHandler(ctrl, nil)
 	handler(sdkcore.PRCreatedEvent{
 		PRNumber:   4213,
 		PRURL:      "https://github.com/owner/repo/pull/4213",

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -537,6 +537,13 @@ type Controller struct {
 	owner string
 	repo  string
 
+	// borrowedBranchLookup is the optional in-process registry
+	// (*executor.Runner, wired via SetBorrowedBranchLookup) reconcileOrphanPRs
+	// consults to find a fix issue driving a borrowed origin branch when the
+	// durable-but-differently-keyed HasSpawnedFixForPR claim doesn't match —
+	// GH-5421. Nil means the reconciler falls back to pre-GH-5421 behavior.
+	borrowedBranchLookup BorrowedBranchLookup
+
 	// projectPath is the absolute filesystem path the executor stored in
 	// executions.project_path. Used to scope self-heal to this project's rows.
 	// Empty = match by task_id only (single-repo / tests). TASK-352.
@@ -1253,6 +1260,26 @@ func (c *Controller) SetDispatcherLiveness(d DispatcherLiveness) {
 // exists — reconcileLaneStarvation is a no-op (skips silently) while nil.
 func (c *Controller) SetLaneQueueStatus(s LaneQueueStatus) {
 	c.laneQueueStatus = s
+}
+
+// BorrowedBranchLookup is the narrow seam reconcileOrphanPRs uses to find out
+// whether an untracked PR's branch is actually driven by a fix issue running
+// on a borrowed origin branch (GH-5421) — satisfied by *executor.Runner's
+// FixIssueForBranch. A local interface (rather than importing
+// internal/executor's concrete type here) keeps this package's dependency
+// surface narrow and matches the pattern of DispatcherLiveness/LaneQueueStatus
+// above.
+type BorrowedBranchLookup interface {
+	FixIssueForBranch(branch string) (fixIssue int, ok bool)
+}
+
+// SetBorrowedBranchLookup wires the in-process borrowed-branch registry
+// (normally *executor.Runner) so reconcileOrphanPRs can find a live fix issue
+// for an untracked PR's branch instead of relying solely on the
+// durable-but-differently-keyed HasSpawnedFixForPR claim — GH-5421. Optional:
+// nil (the default) keeps pre-GH-5421 behavior.
+func (c *Controller) SetBorrowedBranchLookup(lookup BorrowedBranchLookup) {
+	c.borrowedBranchLookup = lookup
 }
 
 // SetStateStore sets the persistent state store for crash recovery.
@@ -8582,22 +8609,59 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 		// merge here would close O instead of F. If the lookup itself fails,
 		// fall back to the branch-derived issue rather than blocking the
 		// sweep, but say so.
+		var fixIssue int
 		if c.stateStore != nil {
-			if fixIssue, err := c.stateStore.HasSpawnedFixForPR(c.repoKey(), pr.Number); err != nil {
-				c.log.Warn("reconciler: spawned-fix lookup failed, registering under branch-derived issue",
+			if fi, err := c.stateStore.HasSpawnedFixForPR(c.repoKey(), pr.Number); err != nil {
+				c.log.Warn("reconciler: spawned-fix lookup failed, will try the borrowed-branch registry",
 					"pr", pr.Number, "branch", pr.Head.Ref, "branch_issue", issueNum, "error", err)
-			} else if fixIssue > 0 && fixIssue != issueNum {
-				c.log.Info("reconciler: orphan PR belongs to a fix issue on a borrowed origin branch — registering under the fix issue",
-					"pr", pr.Number, "branch", pr.Head.Ref, "origin_issue", issueNum, "fix_issue", fixIssue,
-				)
-				c.OnPRCreatedForFixIssue(pr.Number, pr.HTMLURL, fixIssue, issueNum, pr.Head.SHA, pr.Head.Ref, "")
-				if updatedAt, err := time.Parse(time.RFC3339, pr.UpdatedAt); err == nil {
-					c.seedAdoptedCIWaitClock(pr.Number, updatedAt)
-				}
-				c.metrics.RecordOrphanPRRegistered("reconciler")
-				continue
+			} else if fi > 0 && fi != issueNum {
+				fixIssue = fi
 			}
 		}
+		// GH-5421: HasSpawnedFixForPR is keyed by the ORIGIN PR that CI-fix
+		// spawning closed, not by this (new) PR's own number, so it never
+		// matches the normal CI-fix flow (origin PR closed -> fix issue spawned
+		// -> fix run opens a NEW PR on the same branch). Fall back to the
+		// in-process borrowed-branch registry (SetBorrowedBranchLookup), which
+		// is keyed by branch name and populated by the exact same
+		// RecordBorrowedBranch call the primary OnPRCreated path (GH-5421)
+		// reads — catching the case that lookup misses.
+		if fixIssue == 0 && c.borrowedBranchLookup != nil {
+			if fi, ok := c.borrowedBranchLookup.FixIssueForBranch(pr.Head.Ref); ok && fi > 0 && fi != issueNum {
+				fixIssue = fi
+			}
+		}
+		if fixIssue > 0 {
+			c.log.Info("reconciler: orphan PR belongs to a fix issue on a borrowed origin branch — registering under the fix issue",
+				"pr", pr.Number, "branch", pr.Head.Ref, "origin_issue", issueNum, "fix_issue", fixIssue,
+			)
+			c.OnPRCreatedForFixIssue(pr.Number, pr.HTMLURL, fixIssue, issueNum, pr.Head.SHA, pr.Head.Ref, "")
+			if updatedAt, err := time.Parse(time.RFC3339, pr.UpdatedAt); err == nil {
+				c.seedAdoptedCIWaitClock(pr.Number, updatedAt)
+			}
+			c.metrics.RecordOrphanPRRegistered("reconciler")
+			continue
+		}
+
+		// GH-5421: neither lookup found a fix issue for this branch. Before
+		// registering under the branch-derived origin issue O, confirm O is
+		// still open — a closed O with no fix record is exactly the second
+		// gap this issue closes (a daemon restart can lose the in-process
+		// registry between spawn and this sweep, and HasSpawnedFixForPR never
+		// matches this PR's own number). Registering here would attach the
+		// eventual merge comment to a closed, unrelated issue while the real
+		// fix issue (if one exists) stays stuck in-progress — better to skip
+		// and let a human investigate than silently mis-attribute the PR.
+		if issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, issueNum); err != nil {
+			c.log.Warn("reconciler: failed to verify origin issue state, registering under branch-derived issue",
+				"pr", pr.Number, "branch", pr.Head.Ref, "origin_issue", issueNum, "error", err)
+		} else if issue != nil && issue.State == github.StateClosed {
+			c.log.Warn("reconciler: origin issue is closed and no fix-issue record exists — skipping registration rather than attaching this PR to a closed issue",
+				"pr", pr.Number, "branch", pr.Head.Ref, "origin_issue", issueNum,
+			)
+			continue
+		}
+
 		c.OnPRCreated(pr.Number, pr.HTMLURL, issueNum, pr.Head.SHA, pr.Head.Ref, "")
 		if updatedAt, err := time.Parse(time.RFC3339, pr.UpdatedAt); err == nil {
 			c.seedAdoptedCIWaitClock(pr.Number, updatedAt)

--- a/internal/autopilot/gh5421_reconciler_borrowed_branch_test.go
+++ b/internal/autopilot/gh5421_reconciler_borrowed_branch_test.go
@@ -1,0 +1,129 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// fakeBorrowedBranchLookup is a minimal BorrowedBranchLookup fake for
+// reconcileOrphanPRs tests — GH-5421.
+type fakeBorrowedBranchLookup struct {
+	branch   string
+	fixIssue int
+}
+
+func (f *fakeBorrowedBranchLookup) FixIssueForBranch(branch string) (int, bool) {
+	if branch == f.branch && f.fixIssue > 0 {
+		return f.fixIssue, true
+	}
+	return 0, false
+}
+
+// TestController_ReconcileOrphanPRs_ClosedOriginIssueNoFixRecord_SkipsRegistration
+// is the GH-5421 regression test for reconciler fix #3's negative case: an
+// untracked pilot/GH-<O> PR whose origin issue O is closed, with neither the
+// state store (HasSpawnedFixForPR) nor the in-process borrowed-branch
+// registry (SetBorrowedBranchLookup) naming a fix issue, must be skipped
+// rather than silently registered under the closed issue O — attaching a
+// live PR's eventual merge comment to a closed, unrelated issue is exactly
+// the bug this issue closes.
+func TestController_ReconcileOrphanPRs_ClosedOriginIssueNoFixRecord_SkipsRegistration(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls":
+			prs := []*github.PullRequest{
+				{
+					Number:  42,
+					HTMLURL: "https://github.com/owner/repo/pull/42",
+					Head:    github.PRRef{Ref: "pilot/GH-100", SHA: "abc1234"},
+					Base:    github.PRRef{Ref: "main"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		case "/repos/owner/repo/issues/100":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(&github.Issue{Number: 100, State: github.StateClosed})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	// No stateStore, no borrowedBranchLookup wired — neither signal is available.
+
+	c.reconcileOrphanPRs(context.Background())
+
+	if _, ok := c.GetPRState(42); ok {
+		t.Fatal("reconciler must not register an orphan PR under a closed origin issue when no fix-issue record exists")
+	}
+	snap := c.metrics.Snapshot()
+	if snap.OrphanPRsRegistered["reconciler"] != 0 {
+		t.Errorf("OrphanPRsRegistered[reconciler] = %d, want 0", snap.OrphanPRsRegistered["reconciler"])
+	}
+}
+
+// TestController_ReconcileOrphanPRs_BorrowedBranchLookup_RegistersUnderFixIssue
+// is the GH-5421 regression test for reconciler fix #3's positive case:
+// HasSpawnedFixForPR is keyed by the ORIGIN PR number, not this new orphan
+// PR's own number, so it never matches the ordinary CI-fix flow. The
+// in-process borrowed-branch registry (SetBorrowedBranchLookup), keyed by
+// branch name instead, must be consulted as a fallback and — when it names a
+// fix issue — the orphan PR must be registered under that fix issue via
+// OnPRCreatedForFixIssue, with the branch name preserved unchanged.
+func TestController_ReconcileOrphanPRs_BorrowedBranchLookup_RegistersUnderFixIssue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls":
+			prs := []*github.PullRequest{
+				{
+					Number:  42,
+					HTMLURL: "https://github.com/owner/repo/pull/42",
+					Head:    github.PRRef{Ref: "pilot/GH-100", SHA: "abc1234"},
+					Base:    github.PRRef{Ref: "main"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		default:
+			// The fix-issue lookup succeeds via the borrowed-branch registry
+			// before the reconciler ever needs to call GetIssue, so no
+			// /repos/owner/repo/issues/... request should reach here.
+			t.Errorf("unexpected request to %s — GetIssue should not be called when the borrowed-branch registry already found a fix issue", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetBorrowedBranchLookup(&fakeBorrowedBranchLookup{branch: "pilot/GH-100", fixIssue: 200})
+
+	c.reconcileOrphanPRs(context.Background())
+
+	pr, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("reconciler did not register orphan PR 42 under the fix issue named by the borrowed-branch registry")
+	}
+	if pr.IssueNumber != 200 {
+		t.Errorf("IssueNumber = %d, want 200 (fix issue from the borrowed-branch registry)", pr.IssueNumber)
+	}
+	if pr.BranchName != "pilot/GH-100" {
+		t.Errorf("BranchName = %q, want %q (borrowed origin branch preserved unchanged)", pr.BranchName, "pilot/GH-100")
+	}
+
+	snap := c.metrics.Snapshot()
+	if snap.OrphanPRsRegistered["reconciler"] != 1 {
+		t.Errorf("OrphanPRsRegistered[reconciler] = %d, want 1", snap.OrphanPRsRegistered["reconciler"])
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1020,7 +1020,35 @@ type Runner struct {
 	// pilot-failed on top of pilot-needs-clarification). executeWithOptions
 	// consults and clears this via takeDeclinedCancelReason once its own
 	// ctx observes the cancellation. Guarded by mu alongside execCancel.
-	declinedCancel         map[string]string
+	declinedCancel map[string]string
+	// borrowedBranch maps task ID -> the borrowed origin branch/PR it was
+	// dispatched onto by resolveAutopilotFixBranch (cmd/pilot/handlers.go),
+	// recorded via RecordBorrowedBranch — GH-5421. The primary SDK
+	// OnPRCreated hook (poller_github.go's githubOnPRCreatedHandler) has no
+	// other way to tell a fix/revision issue's borrowed-branch dispatch
+	// apart from a plain issue running on its own default branch; without
+	// this record it silently drops the PR via Controller.OnPRCreated's
+	// branch/issue guard (GH-5413 only fixed the rate-limit retry path, not
+	// this primary path). In-memory only — does not survive a daemon
+	// restart, which is out of scope for GH-5421; a restart mid-execution
+	// just falls back to the pre-existing (broken) drop behavior, not a new
+	// regression.
+	//
+	// Lifetime: entries are deliberately NOT cleared by unregisterExecCancel.
+	// The SDK poller's OnPRCreated hook fires after handleGithubIssueEventSDK
+	// returns, which is after this call's unregisterExecCancel has already
+	// run — clearing there would erase the record before its one consumer
+	// ever reads it. Instead an entry simply gets overwritten the next time
+	// the same task ID is dispatched via RecordBorrowedBranch; a stale entry
+	// left behind by a task that never runs again is harmless (looked up by
+	// exact task ID / exact branch match only). Guarded by mu alongside
+	// execCancel/declinedCancel.
+	borrowedBranch map[string]borrowedBranchRecord
+	// borrowedBranchByBranch is the reverse index (branch -> task ID) kept in
+	// lockstep with borrowedBranch, used by FixIssueForBranch so the
+	// autopilot reconciler (internal/autopilot Controller.reconcileOrphanPRs)
+	// can find which fix issue, if any, is driving a given borrowed branch.
+	borrowedBranchByBranch map[string]string
 	log                    *slog.Logger
 	recordingsPath         string                                                          // Path to recordings directory (empty = default)
 	enableRecording        bool                                                            // Whether to record executions
@@ -6950,6 +6978,74 @@ func (r *Runner) takeDeclinedCancelReason(taskID string) (string, bool) {
 		delete(r.declinedCancel, taskID)
 	}
 	return reason, ok
+}
+
+// borrowedBranchRecord captures the branch/origin-PR pair a task was
+// dispatched with when resolveAutopilotFixBranch (cmd/pilot/handlers.go) put
+// it on another issue's branch instead of its own default
+// "pilot/<taskID>" branch — GH-5421.
+type borrowedBranchRecord struct {
+	branch string
+	fromPR int
+}
+
+// RecordBorrowedBranch records that taskID's dispatch put it on branch
+// (named after a different, origin issue), continuing origin PR fromPR —
+// GH-5421. Callers should only record when fromPR > 0 and branch differs
+// from taskID's own default branch; see the borrowedBranch field doc for the
+// in-memory-only lifetime and why entries are not cleared on unregister.
+func (r *Runner) RecordBorrowedBranch(taskID, branch string, fromPR int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.borrowedBranch == nil {
+		r.borrowedBranch = make(map[string]borrowedBranchRecord)
+	}
+	if r.borrowedBranchByBranch == nil {
+		r.borrowedBranchByBranch = make(map[string]string)
+	}
+	// A task ID borrows at most one branch at a time — drop any stale
+	// reverse-index entry for its previously recorded branch first, so
+	// FixIssueForBranch never returns this task ID for a branch it no
+	// longer runs on.
+	if prev, ok := r.borrowedBranch[taskID]; ok && prev.branch != branch {
+		if r.borrowedBranchByBranch[prev.branch] == taskID {
+			delete(r.borrowedBranchByBranch, prev.branch)
+		}
+	}
+	r.borrowedBranch[taskID] = borrowedBranchRecord{branch: branch, fromPR: fromPR}
+	r.borrowedBranchByBranch[branch] = taskID
+}
+
+// BorrowedBranch returns the borrowed branch/origin-PR recorded for taskID by
+// RecordBorrowedBranch, if any — GH-5421.
+func (r *Runner) BorrowedBranch(taskID string) (branch string, fromPR int, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	rec, ok := r.borrowedBranch[taskID]
+	if !ok {
+		return "", 0, false
+	}
+	return rec.branch, rec.fromPR, true
+}
+
+// FixIssueForBranch returns the fix-issue number of the task currently
+// recorded (via RecordBorrowedBranch) as running on branch, if any —
+// GH-5421. Used by the autopilot reconciler (Controller.reconcileOrphanPRs)
+// to avoid re-homing an untracked PR under a closed origin issue when a fix
+// issue actually drove that branch. Task IDs are expected in "GH-<N>" form
+// (cmd/pilot's GitHub task ID convention); any other form yields ok=false
+// since there is no issue number to report.
+func (r *Runner) FixIssueForBranch(branch string) (fixIssue int, ok bool) {
+	r.mu.Lock()
+	taskID, found := r.borrowedBranchByBranch[branch]
+	r.mu.Unlock()
+	if !found {
+		return 0, false
+	}
+	if _, err := fmt.Sscanf(taskID, "GH-%d", &fixIssue); err != nil {
+		return 0, false
+	}
+	return fixIssue, true
 }
 
 // recordLearning records the execution outcome for pattern learning.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5421.

Closes #5421

## Changes

GitHub Issue GH-5421: fix(poller): borrowed-branch fix-issue PRs still dropped on the primary SDK OnPRCreated path; reconciler re-homes new PR under closed origin issue (PR #5416 follow-up)

## Problem

PR #5416 (GH-5413) added `OnPRCreatedForFixIssue` on the autopilot controller and routed borrowed-branch PRs to it, but only on the rate-limit retry path in `cmd/pilot/poller_github.go` (the `QueueRetryIfRateLimited` / `githubRetryCallback` pair). The primary path is untouched: the SDK poller calls its `OnPRCreated` hook after every handled issue, that hook is `githubOnPRCreatedHandler` in `cmd/pilot/poller_github.go` (around line 75), and it calls the plain guarded `OnPRCreated` in `internal/autopilot/controller.go`. The SDK's PRCreatedEvent struct carries only PR number, URL, issue id, head SHA, branch name and node id; there is no borrowed marker, and `FromPR` is not persisted anywhere the handler could read.

So for a fix or revision issue F whose task runs on the origin branch named after issue O (set by `resolveAutopilotFixBranch` in `cmd/pilot/handlers.go`), the branch/issue guard still drops the registration on every non-rate-limited run. GH-5413's acceptance criterion is not met on the path that fires in production. The earlier issue pointed at the retry callback line by mistake; this issue corrects the target.

Second gap: `reconcileOrphanPRs` in `internal/autopilot/controller.go` (around lines 8585-8600) asks `HasSpawnedFixForPR` keyed by the ORIGIN PR number. The normal CI-fix spawn closes the origin PR P, so the fix run opens a new PR N on the borrowed branch. The lookup for N finds nothing and N is registered under O. Live scenario: P on branch for #100 fails CI → fix #200 spawned, P closed → run opens N on that branch → SDK path drops it → reconciler registers N under #100 → N merges, closed #100 gets the merge comment, #200 stays `pilot-in-progress`.

## Fix (network-free, no SDK bump)

1. **Record the borrowed branch at dispatch.** In `cmd/pilot/handlers.go` where the Task is built (the block that sets `FromPR` and `FixFromSHA`, around line 1117): when `FromPR > 0` and the resolved branch does not equal the task's own default branch name, record (task id → branch, fromPR) in a small process-local registry. Put the registry on the Runner in `internal/executor/runner.go` next to the per-task cancel stack (same mutex), with `RecordBorrowedBranch(taskID, branch string, fromPR int)` and `BorrowedBranch(taskID string) (branch string, fromPR int, ok bool)`. Clear the entry when the execution unregisters, the same way `declinedCancel` is cleared in `unregisterExecCancel` (PR #5418), but only AFTER the poller has had its chance to read it: simplest is to keep the entry until the next execution of the same task id overwrites it, or expire on a short TTL. State the choice in the PR.
2. **Consult it in the primary hook.** `githubOnPRCreatedHandler` gets the Runner (or a narrow interface with just `BorrowedBranch`). If the event's issue id maps to a task with a recorded borrowed branch equal to the event's branch name, call `OnPRCreatedForFixIssue` with fixIssue = event issue, originIssue = parsed from the branch; otherwise call `OnPRCreated` as today. Keep `githubRetryCallback` working; it can use the same registry instead of the `FromPR` it currently threads through, or keep both.
3. **Reconciler.** In `reconcileOrphanPRs`, before registering an untracked `pilot/GH-<O>` PR under O: if the registry (or the state store) shows an open pilot issue F that ran on this branch, register under F via `OnPRCreatedForFixIssue`. If no such record exists AND issue O is closed, log a warning naming O and the PR and skip registration rather than registering under a closed issue. The existing `HasSpawnedFixForPR` check can stay as a first attempt.
4. Persisting across daemon restarts is out of scope for this issue; note it in the PR if the registry is in-memory only.

## Tests

- `cmd/pilot`: a test that builds the real `githubOnPRCreatedHandler` with a Runner that has a borrowed-branch record for task GH-200 on branch pilot/GH-100, feeds a PRCreatedEvent with IssueID "200" and that branch, and asserts the controller tracks the PR with IssueNumber 200 and the branch preserved (the GH-4211 lesson: drive the production hook, not the controller method).
- Negative: same event without a registry record → zero registrations (guard still holds).
- `internal/autopilot`: reconciler test where the origin issue is closed and no fix record exists → warning, no registration; and where a fix record exists → registered under the fix issue.
- Removing the `FromPR` assignment in `cmd/pilot/handlers.go` must fail at least one test.

## Acceptance

- A fix issue whose run pushes to a borrowed origin branch is tracked under the fix issue on the normal poll path, and merging closes the fix issue.
- An untracked PR on a branch whose origin issue is closed is never silently registered under that closed issue.
- Test command, must be green:

```
go test ./cmd/pilot/ ./internal/autopilot/
```