### PR TITLE
GH-5425: fix(autopilot): memoize closed-origin skip in reconcileOrphanPRs (GetIssue + Warn every tick) and prune borrowed-branch registry on terminal state (PR #5423 follow-up)

### DIFF
--- a/.agent/tasks/gh-5425.md
+++ b/.agent/tasks/gh-5425.md
@@ -1,0 +1,38 @@
+# GH-5425
+
+**Created:** 2026-09-10
+
+## Problem
+
+GitHub Issue GH-5425: fix(autopilot): memoize closed-origin skip in reconcileOrphanPRs (GetIssue + Warn every tick) and prune borrowed-branch registry on terminal state (PR #5423 follow-up)
+
+## Problem
+
+PR #5423 (GH-5421) made `reconcileOrphanPRs` in `internal/autopilot/controller.go` consult the borrowed-branch registry and, when no record exists and the origin issue is closed, warn and skip instead of registering the PR under the closed issue. Two small costs remain:
+
+1. **Repeated work on the skip path.** A skipped PR stays untracked, so on every 60 s tick the reconciler calls GetIssue for the origin issue again and logs the same warning again, until that PR is closed. One stale PR means roughly 1,440 API calls and warnings per day.
+2. **Reverse index never pruned.** The registry's branch → fix-issue mapping in `internal/executor/runner.go` is only replaced when the same task id is re-recorded. When fix issue F reaches a terminal state, a later untracked PR on the same borrowed branch (manual push, or a re-run of the origin issue) would be re-homed under closed F.
+
+## Fix
+
+- Memoize closed-origin skip decisions per PR number in the controller (a small map with the PR number, the origin issue, and the time decided). On later ticks, skip the GetIssue call and log at Debug, not Warn, for a memoized PR. Drop the entry when the PR leaves the untracked set (tracked or closed) so a later legitimate registration is not blocked. Bound the map to open PRs only.
+- Remove the registry's reverse-index entry (and the forward entry) when the recording task's execution reaches a terminal state. The natural hook is the lifecycle Finish path, or the same defer that already clears `declinedCancel` in `unregisterExecCancel`, but only if the PR-created hook has already fired for that task; if that ordering cannot be guaranteed, expire entries on a generous TTL instead and state the choice in the PR.
+
+## Tests
+
+- Reconciler: two consecutive ticks over the same skipped PR make exactly one GetIssue call and one Warn; the second tick logs at Debug.
+- Reconciler: a memoized PR that becomes tracked, then a new untracked PR with the same number is impossible, but a memoized PR that is closed must be evicted so the map does not grow.
+- Registry: after the recording task finishes and the hook has fired, `FixIssueForBranch` for that branch returns not-found.
+
+## Acceptance
+
+- One GetIssue and one Warn per skipped PR for its lifetime, not per tick.
+- Registry entries do not outlive the fix issue's execution beyond the PR-created hook.
+- Test command, must be green:
+
+```
+go test ./internal/autopilot/ ./internal/executor/ -run 'Orphan|Borrowed|Reconcile'
+```
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -662,6 +662,20 @@ type Controller struct {
 	// adopt-fail-evict cycle forever (GH-4053).
 	persistFailedPRs map[int]time.Time
 
+	// closedOriginSkip memoizes reconcileOrphanPRs's decision to skip
+	// registering an orphan PR under a closed origin issue, keyed by PR
+	// number. Guarded by mu. Without this, a stale untracked PR (branch
+	// origin issue closed, no fix-issue record found) triggers a fresh
+	// GetIssue call and a Warn log on every 60s reconciler tick until the PR
+	// itself closes — roughly 1,440 API calls and log lines per day for one
+	// wedged PR (GH-5425, PR #5423 follow-up). Entries are removed the
+	// instant the PR leaves the untracked set — becomes tracked (a later
+	// borrowed-branch registration succeeds) or closes (no longer present in
+	// the open-PR list reconcileOrphanPRs fetches each tick) — so a later
+	// legitimate registration is never blocked by a stale memo, and the map
+	// never grows past the current count of open pilot/ PRs.
+	closedOriginSkip map[int]closedOriginSkipRecord
+
 	// alertedApprovalFailures deduplicates approval-submit-failure alerts and
 	// PR-comment fallbacks per PR number, guarded by mu — same rationale as
 	// alertedPersistFailures: handleAwaitApproval retries submitAsyncApprovalRequest
@@ -865,6 +879,7 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 		scopeDeferLogAt:         make(map[string]time.Time),
 		alertedPersistFailures:  make(map[int]bool),
 		persistFailedPRs:        make(map[int]time.Time),
+		closedOriginSkip:        make(map[int]closedOriginSkipRecord),
 		alertedApprovalFailures: make(map[int]bool),
 		epicVeto:                make(map[int]*epicCloseVetoTracking),
 		epicResolvedParents:     make(map[int]bool),
@@ -2334,6 +2349,62 @@ func (c *Controller) recentlyEvictedForPersistFailure(prNumber int) bool {
 		return false
 	}
 	return time.Since(evictedAt) < persistFailureReadoptCooldown
+}
+
+// closedOriginSkipRecord is the memoized value for Controller.closedOriginSkip
+// — see that field's doc for the GetIssue/Warn cost it exists to avoid
+// (GH-5425).
+type closedOriginSkipRecord struct {
+	originIssue int
+	decidedAt   time.Time
+}
+
+// closedOriginSkipDecision reports whether prNumber's closed-origin skip was
+// already memoized by a prior reconcileOrphanPRs tick, so the caller can log
+// at Debug and skip the GetIssue call instead of repeating the Warn every
+// tick (GH-5425).
+func (c *Controller) closedOriginSkipDecision(prNumber int) (rec closedOriginSkipRecord, ok bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	rec, ok = c.closedOriginSkip[prNumber]
+	return rec, ok
+}
+
+// recordClosedOriginSkip memoizes prNumber's closed-origin skip decision so
+// later reconcileOrphanPRs ticks don't re-issue the GetIssue call or the Warn
+// log for the same PR (GH-5425).
+func (c *Controller) recordClosedOriginSkip(prNumber, originIssue int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closedOriginSkip == nil {
+		c.closedOriginSkip = make(map[int]closedOriginSkipRecord)
+	}
+	c.closedOriginSkip[prNumber] = closedOriginSkipRecord{originIssue: originIssue, decidedAt: time.Now()}
+}
+
+// clearClosedOriginSkip drops prNumber's memoized skip decision, if any. It
+// is called the moment a PR leaves the untracked set the memo applies to —
+// either a later tick registers it (e.g. under a fix issue found via the
+// borrowed-branch registry) or the PR itself closes — so a stale memo can
+// never block a legitimate registration (GH-5425).
+func (c *Controller) clearClosedOriginSkip(prNumber int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.closedOriginSkip, prNumber)
+}
+
+// pruneClosedOriginSkip drops every memoized skip decision whose PR is not
+// in openPRs, the set of currently open pilot/ PR numbers reconcileOrphanPRs
+// just fetched. A PR absent from that set has closed since it was memoized,
+// so the entry is stale — bounds closedOriginSkip to open PRs only (GH-5425).
+func (c *Controller) pruneClosedOriginSkip(openPRs map[int]struct{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for prNumber := range c.closedOriginSkip {
+		if _, ok := openPRs[prNumber]; !ok {
+			delete(c.closedOriginSkip, prNumber)
+		}
+	}
 }
 
 // persistRemovePR removes a PR state from the store if available.
@@ -8568,6 +8639,15 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 		return
 	}
 
+	// GH-5425: openPRs is the set of currently open PR numbers, used below to
+	// prune closedOriginSkip entries for PRs that have since closed — without
+	// this the memo map would grow forever instead of staying bounded to
+	// open PRs.
+	openPRs := make(map[int]struct{}, len(prs))
+	for _, pr := range prs {
+		openPRs[pr.Number] = struct{}{}
+	}
+
 	for _, pr := range prs {
 		if !strings.HasPrefix(pr.Head.Ref, "pilot/GH-") {
 			continue
@@ -8577,6 +8657,10 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 		_, tracked := c.activePRs[pr.Number]
 		c.mu.RUnlock()
 		if tracked {
+			// GH-5425: the PR left the untracked set this memo applies to —
+			// drop it so a future untracked PR reusing this number is never
+			// blocked by a stale skip decision.
+			c.clearClosedOriginSkip(pr.Number)
 			continue
 		}
 		if c.recentlyEvictedForPersistFailure(pr.Number) {
@@ -8640,6 +8724,22 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 				c.seedAdoptedCIWaitClock(pr.Number, updatedAt)
 			}
 			c.metrics.RecordOrphanPRRegistered("reconciler")
+			// GH-5425: this PR just became tracked — drop any stale skip
+			// memo from an earlier tick so a future untracked reuse of this
+			// PR number isn't blocked by it.
+			c.clearClosedOriginSkip(pr.Number)
+			continue
+		}
+
+		// GH-5425: a prior tick already confirmed the branch-derived origin
+		// issue is closed and no fix-issue record exists for this PR — skip
+		// the GetIssue call and the Warn log this tick, logging at Debug
+		// instead, so a wedged PR costs one GetIssue call and one Warn for
+		// its entire lifetime rather than one of each every 60s.
+		if rec, ok := c.closedOriginSkipDecision(pr.Number); ok {
+			c.log.Debug("reconciler: origin issue is closed and no fix-issue record exists — skip decision already memoized, not re-querying GitHub",
+				"pr", pr.Number, "branch", pr.Head.Ref, "origin_issue", rec.originIssue, "decided_at", rec.decidedAt,
+			)
 			continue
 		}
 
@@ -8659,6 +8759,9 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 			c.log.Warn("reconciler: origin issue is closed and no fix-issue record exists — skipping registration rather than attaching this PR to a closed issue",
 				"pr", pr.Number, "branch", pr.Head.Ref, "origin_issue", issueNum,
 			)
+			// GH-5425: memoize the decision so later ticks skip straight to
+			// the Debug log above instead of repeating this GetIssue+Warn.
+			c.recordClosedOriginSkip(pr.Number, issueNum)
 			continue
 		}
 
@@ -8667,7 +8770,13 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 			c.seedAdoptedCIWaitClock(pr.Number, updatedAt)
 		}
 		c.metrics.RecordOrphanPRRegistered("reconciler")
+		c.clearClosedOriginSkip(pr.Number)
 	}
+
+	// GH-5425: bound closedOriginSkip to currently open PRs — a memoized PR
+	// that has since closed is no longer in openPRs, so its entry would
+	// otherwise linger forever.
+	c.pruneClosedOriginSkip(openPRs)
 }
 
 // backstopCheckReleaseMissing is the scanner-side counterpart to afterTagCreated's

--- a/internal/autopilot/gh5425_closed_origin_skip_memo_test.go
+++ b/internal/autopilot/gh5425_closed_origin_skip_memo_test.go
@@ -1,0 +1,148 @@
+package autopilot
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestController_ReconcileOrphanPRs_ClosedOriginSkip_MemoizedAcrossTicks is
+// the GH-5425 regression test for reconciler cost #1 (PR #5423 follow-up): a
+// PR whose origin issue is closed with no fix-issue record stays untracked
+// forever, so before this fix every 60s reconciler tick repeated the same
+// GetIssue call and the same Warn log for it — roughly 1,440 of each per day
+// for one wedged PR. The first tick must still call GetIssue and Warn once;
+// every later tick must skip the GetIssue call entirely and log at Debug.
+func TestController_ReconcileOrphanPRs_ClosedOriginSkip_MemoizedAcrossTicks(t *testing.T) {
+	var issueRequests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls":
+			prs := []*github.PullRequest{
+				{
+					Number:  42,
+					HTMLURL: "https://github.com/owner/repo/pull/42",
+					Head:    github.PRRef{Ref: "pilot/GH-100", SHA: "abc1234"},
+					Base:    github.PRRef{Ref: "main"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		case "/repos/owner/repo/issues/100":
+			atomic.AddInt32(&issueRequests, 1)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(&github.Issue{Number: 100, State: github.StateClosed})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	var logBuf bytes.Buffer
+	c.log = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Tick 1: no memo yet — must call GetIssue and Warn.
+	c.reconcileOrphanPRs(context.Background())
+	if n := atomic.LoadInt32(&issueRequests); n != 1 {
+		t.Fatalf("GetIssue calls after tick 1 = %d, want 1", n)
+	}
+	if _, ok := c.GetPRState(42); ok {
+		t.Fatal("PR 42 must not be registered — origin issue is closed with no fix-issue record")
+	}
+	warnCount := strings.Count(logBuf.String(), "level=WARN")
+	if warnCount != 1 {
+		t.Fatalf("Warn log lines after tick 1 = %d, want 1; log:\n%s", warnCount, logBuf.String())
+	}
+
+	// Tick 2 (and a 3rd, for good measure): the skip decision is memoized —
+	// no additional GetIssue call, no additional Warn, only a Debug log.
+	c.reconcileOrphanPRs(context.Background())
+	c.reconcileOrphanPRs(context.Background())
+	if n := atomic.LoadInt32(&issueRequests); n != 1 {
+		t.Errorf("GetIssue calls after 3 ticks = %d, want 1 (memoized on ticks 2-3)", n)
+	}
+	if warnCount := strings.Count(logBuf.String(), "level=WARN"); warnCount != 1 {
+		t.Errorf("Warn log lines after 3 ticks = %d, want 1 (still just tick 1's)", warnCount)
+	}
+	if debugCount := strings.Count(logBuf.String(), "level=DEBUG"); debugCount != 2 {
+		t.Errorf("Debug log lines after 3 ticks = %d, want 2 (ticks 2 and 3)", debugCount)
+	}
+	if _, ok := c.GetPRState(42); ok {
+		t.Error("PR 42 must still not be registered after memoized ticks")
+	}
+}
+
+// TestController_ReconcileOrphanPRs_ClosedOriginSkip_EvictedWhenPRCloses is
+// the GH-5425 regression test for reconciler cost #1's bound: a memoized skip
+// decision must not survive the PR itself closing, or the map backing it
+// would grow forever across the life of the repo. Once the PR no longer
+// appears in the open-PR list, its memo entry must be pruned.
+func TestController_ReconcileOrphanPRs_ClosedOriginSkip_EvictedWhenPRCloses(t *testing.T) {
+	var prOpen atomic.Bool
+	prOpen.Store(true)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls":
+			var prs []*github.PullRequest
+			if prOpen.Load() {
+				prs = []*github.PullRequest{
+					{
+						Number:  42,
+						HTMLURL: "https://github.com/owner/repo/pull/42",
+						Head:    github.PRRef{Ref: "pilot/GH-100", SHA: "abc1234"},
+						Base:    github.PRRef{Ref: "main"},
+					},
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		case "/repos/owner/repo/issues/100":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(&github.Issue{Number: 100, State: github.StateClosed})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Tick 1: PR open, origin closed, no fix record — memoized skip.
+	c.reconcileOrphanPRs(context.Background())
+	c.mu.RLock()
+	_, memoized := c.closedOriginSkip[42]
+	c.mu.RUnlock()
+	if !memoized {
+		t.Fatal("expected PR 42's closed-origin skip to be memoized after tick 1")
+	}
+
+	// PR 42 closes (no longer in the open-PR list).
+	prOpen.Store(false)
+	c.reconcileOrphanPRs(context.Background())
+
+	c.mu.RLock()
+	_, stillMemoized := c.closedOriginSkip[42]
+	mapLen := len(c.closedOriginSkip)
+	c.mu.RUnlock()
+	if stillMemoized {
+		t.Error("PR 42's skip memo must be evicted once the PR is no longer open, so the map does not grow forever")
+	}
+	if mapLen != 0 {
+		t.Errorf("closedOriginSkip has %d entries after the only memoized PR closed, want 0", mapLen)
+	}
+}

--- a/internal/executor/gh5425_borrowed_branch_prune_test.go
+++ b/internal/executor/gh5425_borrowed_branch_prune_test.go
@@ -1,0 +1,92 @@
+package executor
+
+import (
+	"testing"
+	"time"
+)
+
+// TestFixIssueForBranch_ConsumesEntryOnMatch is the GH-5425 regression test
+// for the registry's reverse-index pruning: FixIssueForBranch's own
+// successful lookup is treated as "the recording task's PR-created hook has
+// fired" (see that method's doc for why the alternative — clearing on the
+// task's own terminal-state signal — can't work, since that signal always
+// fires before the hook does). The entry must therefore be gone immediately
+// after one successful match, so a later, unrelated PR pushed to the same
+// borrowed branch is never mis-attributed to the now-consumed fix issue.
+func TestFixIssueForBorrowedBranch_ConsumesEntryOnMatch(t *testing.T) {
+	r := NewRunner()
+	r.RecordBorrowedBranch("GH-200", "pilot/GH-100", 5361)
+
+	fixIssue, ok := r.FixIssueForBranch("pilot/GH-100")
+	if !ok {
+		t.Fatal("FixIssueForBranch(\"pilot/GH-100\") = not found on first (hook-fired) lookup, want fix issue 200")
+	}
+	if fixIssue != 200 {
+		t.Errorf("fixIssue = %d, want 200", fixIssue)
+	}
+
+	// The recording task's execution has, from this consumer's perspective,
+	// now finished and the hook has fired — a second lookup for the same
+	// branch must report not-found rather than repeating the same match.
+	if fixIssue, ok := r.FixIssueForBranch("pilot/GH-100"); ok {
+		t.Errorf("FixIssueForBranch(\"pilot/GH-100\") = (%d, true) on second lookup, want not-found (entry must be consumed after first match)", fixIssue)
+	}
+
+	// The forward record must be gone too, not just the reverse index.
+	if branch, fromPR, ok := r.BorrowedBranch("GH-200"); ok {
+		t.Errorf("BorrowedBranch(\"GH-200\") = (%q, %d, true) after FixIssueForBranch consumed the entry, want not-found", branch, fromPR)
+	}
+}
+
+// TestFixIssueForBranch_ExpiresUnconsumedEntryAfterTTL is the GH-5425
+// regression test for the registry's TTL fallback: a task that borrows a
+// branch but never gets a PR-created hook to consume the record (declined,
+// failed, or the hook simply never fires) must not leave the mapping around
+// forever — that staleness is exactly what let a later, unrelated PR on the
+// same branch get mis-attributed to a long-dead fix issue (GH-5425).
+func TestFixIssueForBorrowedBranch_ExpiresUnconsumedEntryAfterTTL(t *testing.T) {
+	r := NewRunner()
+	r.RecordBorrowedBranch("GH-201", "pilot/GH-101", 5362)
+
+	// Backdate the entry past borrowedBranchTTL without ever consuming it,
+	// simulating a task that ended without its PR-created hook ever firing.
+	r.mu.Lock()
+	rec := r.borrowedBranch["GH-201"]
+	rec.recordedAt = time.Now().Add(-borrowedBranchTTL - time.Minute)
+	r.borrowedBranch["GH-201"] = rec
+	r.mu.Unlock()
+
+	if fixIssue, ok := r.FixIssueForBranch("pilot/GH-101"); ok {
+		t.Errorf("FixIssueForBranch(\"pilot/GH-101\") = (%d, true) for an entry older than borrowedBranchTTL, want not-found", fixIssue)
+	}
+
+	r.mu.Lock()
+	_, stillPresent := r.borrowedBranch["GH-201"]
+	_, reverseStillPresent := r.borrowedBranchByBranch["pilot/GH-101"]
+	r.mu.Unlock()
+	if stillPresent || reverseStillPresent {
+		t.Error("expired entry was reported not-found but not pruned from the registry")
+	}
+}
+
+// TestBorrowedBranch_NonDestructivePeek pins that BorrowedBranch — the
+// primary SDK-hook consumer, unlike the reconciler's FixIssueForBranch — does
+// NOT delete the entry on a successful read. The SDK poller can redeliver
+// the same PRCreatedEvent, and a destructive read here would break that
+// retry by silently falling through to the plain OnPRCreated path on
+// redelivery (GH-5425).
+func TestBorrowedBranch_NonDestructivePeek(t *testing.T) {
+	r := NewRunner()
+	r.RecordBorrowedBranch("GH-202", "pilot/GH-102", 5363)
+
+	if _, _, ok := r.BorrowedBranch("GH-202"); !ok {
+		t.Fatal("BorrowedBranch(\"GH-202\") = not found on first read, want a match")
+	}
+	branch, fromPR, ok := r.BorrowedBranch("GH-202")
+	if !ok {
+		t.Fatal("BorrowedBranch(\"GH-202\") = not found on second (redelivery) read, want the entry to survive a non-destructive peek")
+	}
+	if branch != "pilot/GH-102" || fromPR != 5363 {
+		t.Errorf("BorrowedBranch(\"GH-202\") = (%q, %d), want (%q, %d)", branch, fromPR, "pilot/GH-102", 5363)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1034,15 +1034,30 @@ type Runner struct {
 	// just falls back to the pre-existing (broken) drop behavior, not a new
 	// regression.
 	//
-	// Lifetime: entries are deliberately NOT cleared by unregisterExecCancel.
-	// The SDK poller's OnPRCreated hook fires after handleGithubIssueEventSDK
-	// returns, which is after this call's unregisterExecCancel has already
-	// run — clearing there would erase the record before its one consumer
-	// ever reads it. Instead an entry simply gets overwritten the next time
-	// the same task ID is dispatched via RecordBorrowedBranch; a stale entry
-	// left behind by a task that never runs again is harmless (looked up by
-	// exact task ID / exact branch match only). Guarded by mu alongside
-	// execCancel/declinedCancel.
+	// Lifetime (GH-5425 revises the original GH-5421 "never cleared" design):
+	// entries are deliberately NOT cleared by unregisterExecCancel/the task's
+	// own terminal-state defer — the SDK poller's OnPRCreated hook fires
+	// after handleGithubIssueEventSDK returns, which is always after this
+	// call's unregisterExecCancel has already run, so a terminal-state
+	// delete there would erase the record before its consumer ever reads it
+	// (that ordering can't be changed, so a Finish-path hook gated on "has
+	// the PR-created hook already fired" would never actually fire). Instead:
+	//   - FixIssueForBranch (the reconciler's fallback consumer) deletes the
+	//     entry the moment it returns a match — from the reconciler's
+	//     perspective that read IS the PR-created hook firing for this task,
+	//     and the resulting PR becomes tracked immediately after, so the
+	//     entry is never needed again.
+	//   - BorrowedBranch (the primary SDK-hook consumer) stays a
+	//     non-destructive peek, since the SDK poller can redeliver the same
+	//     PRCreatedEvent and a destructive read there would break the retry.
+	//   - Both consumers additionally expire (and prune) entries older than
+	//     borrowedBranchTTL, so a task that ends without ever creating a PR
+	//     (declined, failed, or the hook simply never fires) doesn't leave
+	//     the mapping around indefinitely — that staleness is exactly what
+	//     let a later, unrelated PR on the same branch (a manual push, or a
+	//     fresh re-run of the origin issue) get mis-attributed to a
+	//     long-closed fix issue.
+	// Guarded by mu alongside execCancel/declinedCancel.
 	borrowedBranch map[string]borrowedBranchRecord
 	// borrowedBranchByBranch is the reverse index (branch -> task ID) kept in
 	// lockstep with borrowedBranch, used by FixIssueForBranch so the
@@ -6985,15 +7000,30 @@ func (r *Runner) takeDeclinedCancelReason(taskID string) (string, bool) {
 // it on another issue's branch instead of its own default
 // "pilot/<taskID>" branch — GH-5421.
 type borrowedBranchRecord struct {
-	branch string
-	fromPR int
+	branch     string
+	fromPR     int
+	recordedAt time.Time
 }
+
+// borrowedBranchTTL bounds how long an unconsumed borrowedBranch entry can
+// survive — GH-5425. FixIssueForBranch deletes an entry the instant it
+// consumes it (see that method's doc), so this TTL only matters for entries
+// that are never consumed at all: the recording task declined, failed, or
+// otherwise ended without ever opening a PR on the borrowed branch. Without
+// it such an entry would linger forever (the pre-GH-5425 behavior), and a
+// later, unrelated PR pushed to the same branch (a manual push, or a fresh
+// re-run of the origin issue) would be mis-attributed to that long-dead fix
+// issue by a subsequent reconciler sweep. Six hours is generous relative to
+// a normal task's runtime (minutes) plus the 60s reconciler tick, while still
+// bounding the mis-attribution window to hours instead of indefinitely.
+const borrowedBranchTTL = 6 * time.Hour
 
 // RecordBorrowedBranch records that taskID's dispatch put it on branch
 // (named after a different, origin issue), continuing origin PR fromPR —
 // GH-5421. Callers should only record when fromPR > 0 and branch differs
 // from taskID's own default branch; see the borrowedBranch field doc for the
-// in-memory-only lifetime and why entries are not cleared on unregister.
+// in-memory-only lifetime, the TTL fallback, and why entries are not cleared
+// on unregister.
 func (r *Runner) RecordBorrowedBranch(taskID, branch string, fromPR int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -7012,17 +7042,29 @@ func (r *Runner) RecordBorrowedBranch(taskID, branch string, fromPR int) {
 			delete(r.borrowedBranchByBranch, prev.branch)
 		}
 	}
-	r.borrowedBranch[taskID] = borrowedBranchRecord{branch: branch, fromPR: fromPR}
+	r.borrowedBranch[taskID] = borrowedBranchRecord{branch: branch, fromPR: fromPR, recordedAt: time.Now()}
 	r.borrowedBranchByBranch[branch] = taskID
 }
 
 // BorrowedBranch returns the borrowed branch/origin-PR recorded for taskID by
-// RecordBorrowedBranch, if any — GH-5421.
+// RecordBorrowedBranch, if any — GH-5421. Deliberately a non-destructive peek
+// (unlike FixIssueForBranch): the SDK poller can redeliver the same
+// PRCreatedEvent, and a destructive read here would break that retry by
+// silently falling through to the plain OnPRCreated path on redelivery. An
+// entry older than borrowedBranchTTL is treated as expired and pruned —
+// GH-5425.
 func (r *Runner) BorrowedBranch(taskID string) (branch string, fromPR int, ok bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	rec, ok := r.borrowedBranch[taskID]
 	if !ok {
+		return "", 0, false
+	}
+	if time.Since(rec.recordedAt) > borrowedBranchTTL {
+		delete(r.borrowedBranch, taskID)
+		if r.borrowedBranchByBranch[rec.branch] == taskID {
+			delete(r.borrowedBranchByBranch, rec.branch)
+		}
 		return "", 0, false
 	}
 	return rec.branch, rec.fromPR, true
@@ -7035,16 +7077,47 @@ func (r *Runner) BorrowedBranch(taskID string) (branch string, fromPR int, ok bo
 // issue actually drove that branch. Task IDs are expected in "GH-<N>" form
 // (cmd/pilot's GitHub task ID convention); any other form yields ok=false
 // since there is no issue number to report.
+//
+// GH-5425: unlike BorrowedBranch, a successful match here is destructive —
+// the entry is deleted before returning. From this method's caller's
+// perspective (the reconciler), this lookup IS the PR-created hook firing
+// for the task: the caller is about to register the orphan PR under
+// fixIssue, which makes that PR number tracked from then on, so no later
+// reconciler tick will consult this branch/task pairing again. Deleting here
+// — rather than waiting on the recording task's own terminal-state signal —
+// sidesteps the ordering problem documented on the borrowedBranch field: that
+// signal unavoidably fires before any PR-created hook has run, so a
+// terminal-state delete would erase the record before this lookup, the one
+// hook that actually needs it, ever ran. A match older than borrowedBranchTTL
+// is instead treated as an expired, never-consumed entry: also deleted, but
+// reported as not found.
 func (r *Runner) FixIssueForBranch(branch string) (fixIssue int, ok bool) {
 	r.mu.Lock()
+	defer r.mu.Unlock()
 	taskID, found := r.borrowedBranchByBranch[branch]
-	r.mu.Unlock()
 	if !found {
 		return 0, false
 	}
-	if _, err := fmt.Sscanf(taskID, "GH-%d", &fixIssue); err != nil {
+	rec, recOK := r.borrowedBranch[taskID]
+	if !recOK {
+		// Reverse index pointed at a taskID with no forward record. Should
+		// not happen — RecordBorrowedBranch keeps both in lockstep — but
+		// clean up the dangling reverse entry defensively.
+		delete(r.borrowedBranchByBranch, branch)
 		return 0, false
 	}
+	expired := time.Since(rec.recordedAt) > borrowedBranchTTL
+	if _, err := fmt.Sscanf(taskID, "GH-%d", &fixIssue); err != nil || expired {
+		// Either the task ID can't name an issue (nothing to report), or the
+		// entry is stale and was never consumed within the TTL — in both
+		// cases delete it so it stops accumulating (GH-5425) and report not
+		// found.
+		delete(r.borrowedBranch, taskID)
+		delete(r.borrowedBranchByBranch, branch)
+		return 0, false
+	}
+	delete(r.borrowedBranch, taskID)
+	delete(r.borrowedBranchByBranch, branch)
 	return fixIssue, true
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5425.

Closes #5425

## Changes

GitHub Issue GH-5425: fix(autopilot): memoize closed-origin skip in reconcileOrphanPRs (GetIssue + Warn every tick) and prune borrowed-branch registry on terminal state (PR #5423 follow-up)

## Problem

PR #5423 (GH-5421) made `reconcileOrphanPRs` in `internal/autopilot/controller.go` consult the borrowed-branch registry and, when no record exists and the origin issue is closed, warn and skip instead of registering the PR under the closed issue. Two small costs remain:

1. **Repeated work on the skip path.** A skipped PR stays untracked, so on every 60 s tick the reconciler calls GetIssue for the origin issue again and logs the same warning again, until that PR is closed. One stale PR means roughly 1,440 API calls and warnings per day.
2. **Reverse index never pruned.** The registry's branch → fix-issue mapping in `internal/executor/runner.go` is only replaced when the same task id is re-recorded. When fix issue F reaches a terminal state, a later untracked PR on the same borrowed branch (manual push, or a re-run of the origin issue) would be re-homed under closed F.

## Fix

- Memoize closed-origin skip decisions per PR number in the controller (a small map with the PR number, the origin issue, and the time decided). On later ticks, skip the GetIssue call and log at Debug, not Warn, for a memoized PR. Drop the entry when the PR leaves the untracked set (tracked or closed) so a later legitimate registration is not blocked. Bound the map to open PRs only.
- Remove the registry's reverse-index entry (and the forward entry) when the recording task's execution reaches a terminal state. The natural hook is the lifecycle Finish path, or the same defer that already clears `declinedCancel` in `unregisterExecCancel`, but only if the PR-created hook has already fired for that task; if that ordering cannot be guaranteed, expire entries on a generous TTL instead and state the choice in the PR.

## Tests

- Reconciler: two consecutive ticks over the same skipped PR make exactly one GetIssue call and one Warn; the second tick logs at Debug.
- Reconciler: a memoized PR that becomes tracked, then a new untracked PR with the same number is impossible, but a memoized PR that is closed must be evicted so the map does not grow.
- Registry: after the recording task finishes and the hook has fired, `FixIssueForBranch` for that branch returns not-found.

## Acceptance

- One GetIssue and one Warn per skipped PR for its lifetime, not per tick.
- Registry entries do not outlive the fix issue's execution beyond the PR-created hook.
- Test command, must be green:

```
go test ./internal/autopilot/ ./internal/executor/ -run 'Orphan|Borrowed|Reconcile'
```