### PR TITLE
GH-5426: feat(gateway): active-only filter on the dashboard queue endpoint so consumers can see running work older than the 50 newest rows

### DIFF
--- a/.agent/tasks/gh-5426.md
+++ b/.agent/tasks/gh-5426.md
@@ -1,0 +1,40 @@
+# GH-5426
+
+**Created:** 2026-09-10
+
+## Problem
+
+GitHub Issue GH-5426: feat(gateway): active-only filter on the dashboard queue endpoint so consumers can see running work older than the 50 newest rows
+
+## Problem
+
+The dashboard queue endpoint served by `internal/gateway/dashboard.go` (handleDashboardQueue) returns `GetRecentExecutions(50, projectPath)` from `internal/memory/store.go`: the 50 newest rows by created_at with no status filter. Consumers that need to know "is anything still running or queued" (the pilot-console idle-sleep reader, which can stop a tenant machine when it reads idle) get a window, not an answer. A running execution older than 50 newer terminal rows is invisible. With the daemon started with dashboard scope all, rows from every project share the 50, so the window fills faster.
+
+Stop-a-live-box scenario on the console side: a multi-hour execution on a repo with no open pilot-labelled board card, followed by 50 short no_op or skipped executions on any repo. The reader sees only terminal rows, both predicates read idle, and after the idle window the instance is stopped mid-execution.
+
+## Fix
+
+Add an optional query parameter to the queue endpoint, active only (name at implementer's choice, for example active=1). When set, the handler returns only rows whose status is NOT in the terminal set (use the canonical set in `internal/executor/dispatcher.go`, not a hand-copied list; there is already an AST-drift test for mirrors of that set in `internal/executor/terminal_status_inventory_test.go`, so prefer calling a shared helper over adding another mirror) with no LIMIT, or a high LIMIT with a truncated flag in the response. Without the parameter the response is byte-identical to today, so older consumers are unaffected.
+
+Also expose the same filter on the store: a method that returns non-terminal executions for a project path (empty path meaning all projects), honouring the existing canary exclusion.
+
+## Tests
+
+- Handler test: 60 terminal rows plus one running row older than all of them; without the parameter the running row is absent, with it the running row is returned and no terminal rows are.
+- Store test for the new method including the canary exclusion and the empty-project-path case.
+- Existing dashboard queue tests unchanged and green.
+
+## Acceptance
+
+- [ ] Queue endpoint with the active-only parameter returns every non-terminal execution regardless of age
+- [ ] Response without the parameter is unchanged
+- [ ] Test command, must be green:
+
+```
+go test ./internal/gateway/ ./internal/memory/
+```
+
+Consumer leg: pilot-console exec-activity reader switches to the active-only query (separate issue in that repo; safe to land before this one because an older daemon ignores the unknown parameter and returns today's response).
+
+## Acceptance Criteria
+

--- a/internal/gateway/dashboard.go
+++ b/internal/gateway/dashboard.go
@@ -23,6 +23,11 @@ type DashboardStore interface {
 	GetWindowedStats(projectPath string, since time.Time) (memory.WindowedStats, error)
 	GetDailyMetrics(query memory.MetricsQuery) ([]*memory.DailyMetrics, error)
 	GetRecentExecutions(limit int, projectPath string) ([]*memory.Execution, error)
+	// GetNonTerminalExecutions backs the queue endpoint's active-only filter
+	// (GH-5426): every execution whose status is not terminal, regardless of
+	// age, so a long-running execution older than the 50-newest window isn't
+	// invisible to an idle-detection consumer.
+	GetNonTerminalExecutions(projectPath string) ([]*memory.Execution, error)
 	GetQueuedTasks(limit int) ([]*memory.Execution, error)
 	GetActiveExecutions() ([]*memory.Execution, error)
 	GetRecentLogs(limit int) ([]*memory.LogEntry, error)
@@ -236,7 +241,21 @@ func (s *Server) handleDashboardQueue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	execs, err := store.GetRecentExecutions(50, projectPath)
+	// GH-5426: the "active" query parameter switches the queue endpoint from
+	// the default 50-newest-by-created_at window (which can hide a
+	// long-running execution behind 50 newer terminal rows) to every
+	// non-terminal execution regardless of age. Absent (or falsy), the
+	// response is byte-identical to before this parameter existed, so older
+	// consumers are unaffected.
+	active, _ := strconv.ParseBool(r.URL.Query().Get("active"))
+
+	var execs []*memory.Execution
+	var err error
+	if active {
+		execs, err = store.GetNonTerminalExecutions(projectPath)
+	} else {
+		execs, err = store.GetRecentExecutions(50, projectPath)
+	}
 	if err != nil {
 		http.Error(w, "failed to fetch queue", http.StatusInternalServerError)
 		return

--- a/internal/gateway/dashboard_test.go
+++ b/internal/gateway/dashboard_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,12 +23,18 @@ type mockDashboardStore struct {
 	activeExecs    []*memory.Execution
 	logEntries     []*memory.LogEntry
 
+	// nonTerminalExecs backs GetNonTerminalExecutions (GH-5426 active-only
+	// queue filter) — kept separate from executions/GetRecentExecutions so
+	// tests can assert the handler routes to the right store method.
+	nonTerminalExecs []*memory.Execution
+
 	// Capture last projectPath arg passed to each scoped method.
 	gotTokensPath         string
 	gotTaskCountsPath     string
 	gotWindowedStatsPath  string
 	gotWindowedStatsSince time.Time
 	gotExecsPaths         []string // appended on each GetRecentExecutions call
+	gotNonTerminalPaths   []string // appended on each GetNonTerminalExecutions call
 
 	// Approvals API test hooks (GH-4748).
 	pendingApprovals         []*memory.PendingApproval
@@ -70,6 +77,11 @@ func (m *mockDashboardStore) GetDailyMetrics(_ memory.MetricsQuery) ([]*memory.D
 func (m *mockDashboardStore) GetRecentExecutions(_ int, projectPath string) ([]*memory.Execution, error) {
 	m.gotExecsPaths = append(m.gotExecsPaths, projectPath)
 	return m.executions, nil
+}
+
+func (m *mockDashboardStore) GetNonTerminalExecutions(projectPath string) ([]*memory.Execution, error) {
+	m.gotNonTerminalPaths = append(m.gotNonTerminalPaths, projectPath)
+	return m.nonTerminalExecs, nil
 }
 
 func (m *mockDashboardStore) GetQueuedTasks(_ int) ([]*memory.Execution, error) {
@@ -347,6 +359,80 @@ func TestHandleDashboardQueue(t *testing.T) {
 				tt.checkBody(t, w.Body.Bytes())
 			}
 		})
+	}
+}
+
+// TestHandleDashboardQueue_ActiveOnly is the GH-5426 handler test: 60
+// terminal rows plus one running row older than all of them. Without the
+// "active" parameter the response is unchanged (routes to GetRecentExecutions,
+// the running row absent). With active=1 the response routes to
+// GetNonTerminalExecutions instead, returning only the running row and no
+// terminal rows — regardless of age.
+func TestHandleDashboardQueue_ActiveOnly(t *testing.T) {
+	now := time.Now()
+
+	terminalExecs := make([]*memory.Execution, 60)
+	for i := range terminalExecs {
+		terminalExecs[i] = &memory.Execution{
+			ID:        fmt.Sprintf("term-%d", i),
+			TaskID:    fmt.Sprintf("GH-%d", i),
+			Status:    "completed",
+			CreatedAt: now.Add(-time.Duration(i) * time.Minute),
+		}
+	}
+	runningExec := &memory.Execution{
+		ID:        "running-old",
+		TaskID:    "GH-999",
+		Status:    "running",
+		CreatedAt: now.Add(-24 * time.Hour), // older than all 60 terminal rows
+	}
+
+	store := &mockDashboardStore{
+		executions:       terminalExecs,                    // what GetRecentExecutions returns (non-active path)
+		nonTerminalExecs: []*memory.Execution{runningExec}, // what GetNonTerminalExecutions returns (active path)
+	}
+
+	s := newTestServerWithDashboard(store)
+
+	// Without the parameter: unchanged from today, running row absent.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/queue", nil)
+	w := httptest.NewRecorder()
+	s.handleDashboardQueue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var tasks []queueTaskResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &tasks); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(tasks) != 60 {
+		t.Fatalf("expected 60 tasks without active param, got %d", len(tasks))
+	}
+	for _, task := range tasks {
+		if task.ID == runningExec.ID {
+			t.Fatalf("running row must be absent without the active parameter")
+		}
+	}
+
+	// With active=1: only the running row, no terminal rows.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/queue?active=1", nil)
+	w = httptest.NewRecorder()
+	s.handleDashboardQueue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	tasks = nil
+	if err := json.Unmarshal(w.Body.Bytes(), &tasks); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task with active param, got %d", len(tasks))
+	}
+	if tasks[0].ID != runningExec.ID {
+		t.Errorf("expected running row %q, got %q", runningExec.ID, tasks[0].ID)
+	}
+	if tasks[0].Status != "running" {
+		t.Errorf("expected status 'running', got %q", tasks[0].Status)
 	}
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2004,6 +2004,59 @@ func (s *Store) GetRecentExecutions(limit int, projectPath string) ([]*Execution
 	return executions, rows.Err()
 }
 
+// GetNonTerminalExecutions returns every execution whose status is not in
+// terminalExecutionStatuses (i.e. still queued/pending/running), with no
+// LIMIT and regardless of age — the active-only counterpart to
+// GetRecentExecutions's most-recent-N window (GH-5426). A long-running
+// execution can otherwise be hidden behind 50 newer terminal rows, which is
+// invisible to a consumer (e.g. an idle-sleep reader) that needs to know
+// "is anything still running or queued" rather than "what happened recently".
+// If projectPath is non-empty, only executions for that project are
+// returned; empty scopes across all projects, matching GetRecentExecutions.
+// Canary sandbox executions are excluded (GH-4240), also matching
+// GetRecentExecutions.
+func (s *Store) GetNonTerminalExecutions(projectPath string) ([]*Execution, error) {
+	notTerminal, notTerminalArgs := notTerminalClause()
+
+	base := `
+		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at,
+			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
+			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
+			COALESCE(peak_rss_mb, 0), COALESCE(final_rss_mb, 0)
+		FROM executions
+		WHERE COALESCE(is_canary, 0) = 0 AND status NOT IN (` + notTerminal + `)`
+
+	var rows *sql.Rows
+	var err error
+	if projectPath != "" {
+		args := append(append([]interface{}{}, notTerminalArgs...), projectPath)
+		rows, err = s.db.Query(base+` AND project_path = ? ORDER BY created_at DESC`, args...)
+	} else {
+		rows, err = s.db.Query(base+` ORDER BY created_at DESC`, notTerminalArgs...)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var executions []*Execution
+	for rows.Next() {
+		var exec Execution
+		var completedAt sql.NullTime
+		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt,
+			&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
+			&exec.PeakRSSMB, &exec.FinalRSSMB); err != nil {
+			return nil, err
+		}
+		if completedAt.Valid {
+			exec.CompletedAt = &completedAt.Time
+		}
+		executions = append(executions, &exec)
+	}
+
+	return executions, rows.Err()
+}
+
 // Pattern represents a learned pattern from project executions.
 // Patterns capture recurring code structures, workflows, or solutions
 // that can be applied to future similar tasks.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -138,6 +138,92 @@ func TestGetRecentExecutions_ExcludesCanary(t *testing.T) {
 	}
 }
 
+// TestGetNonTerminalExecutions covers GH-5426: the active-only counterpart
+// to GetRecentExecutions. It must return every non-terminal row (queued,
+// pending, running) regardless of age, exclude terminal rows regardless of
+// age, honour the is_canary exclusion (GH-4240, matching GetRecentExecutions),
+// and support the empty-project-path "all projects" case.
+func TestGetNonTerminalExecutions(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	old := time.Now().Add(-72 * time.Hour)
+
+	// A running row older than every terminal row below — must still surface
+	// with no LIMIT truncating it out.
+	if err := store.SaveExecution(&Execution{
+		ID: "nte-running-old", TaskID: "TASK-RUNNING", ProjectPath: "/path",
+		Status: "running", CreatedAt: old,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	// A queued row (also non-terminal).
+	if err := store.SaveExecution(&Execution{
+		ID: "nte-queued", TaskID: "TASK-QUEUED", ProjectPath: "/path",
+		Status: "queued",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	// Terminal rows of various statuses — none should appear.
+	for _, st := range []string{"completed", "failed", "no_op", "skipped"} {
+		if err := store.SaveExecution(&Execution{
+			ID: "nte-" + st, TaskID: "TASK-" + st, ProjectPath: "/path", Status: st,
+		}); err != nil {
+			t.Fatalf("SaveExecution(%s): %v", st, err)
+		}
+	}
+	// A canary running row — must be excluded like GetRecentExecutions.
+	if err := store.SaveExecution(&Execution{
+		ID: "nte-canary-running", TaskID: "TASK-CANARY", ProjectPath: "/canary-sandbox",
+		Status: "running", IsCanary: true,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	got, err := store.GetNonTerminalExecutions("")
+	if err != nil {
+		t.Fatalf("GetNonTerminalExecutions: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("GetNonTerminalExecutions(\"\") = %d rows, want 2 (running+queued): %v", len(got), got)
+	}
+	gotIDs := map[string]bool{}
+	for _, e := range got {
+		gotIDs[e.ID] = true
+		if e.ID == "nte-canary-running" {
+			t.Error("canary running row must be excluded")
+		}
+	}
+	if !gotIDs["nte-running-old"] {
+		t.Error("expected old running row to be present regardless of age")
+	}
+	if !gotIDs["nte-queued"] {
+		t.Error("expected queued row to be present")
+	}
+
+	// Empty project path scopes across all projects — already exercised
+	// above; now confirm project-path scoping narrows the result.
+	scoped, err := store.GetNonTerminalExecutions("/path")
+	if err != nil {
+		t.Fatalf("GetNonTerminalExecutions(/path): %v", err)
+	}
+	if len(scoped) != 2 {
+		t.Errorf("GetNonTerminalExecutions(/path) = %d rows, want 2", len(scoped))
+	}
+
+	noneForOtherProject, err := store.GetNonTerminalExecutions("/other-project")
+	if err != nil {
+		t.Fatalf("GetNonTerminalExecutions(/other-project): %v", err)
+	}
+	if len(noneForOtherProject) != 0 {
+		t.Errorf("GetNonTerminalExecutions(/other-project) = %d rows, want 0", len(noneForOtherProject))
+	}
+}
+
 func TestGetLatestExecutionByTaskID(t *testing.T) {
 	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
 	defer func() { _ = os.RemoveAll(tmpDir) }()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5426.

Closes #5426

## Changes

GitHub Issue GH-5426: feat(gateway): active-only filter on the dashboard queue endpoint so consumers can see running work older than the 50 newest rows

## Problem

The dashboard queue endpoint served by `internal/gateway/dashboard.go` (handleDashboardQueue) returns `GetRecentExecutions(50, projectPath)` from `internal/memory/store.go`: the 50 newest rows by created_at with no status filter. Consumers that need to know "is anything still running or queued" (the pilot-console idle-sleep reader, which can stop a tenant machine when it reads idle) get a window, not an answer. A running execution older than 50 newer terminal rows is invisible. With the daemon started with dashboard scope all, rows from every project share the 50, so the window fills faster.

Stop-a-live-box scenario on the console side: a multi-hour execution on a repo with no open pilot-labelled board card, followed by 50 short no_op or skipped executions on any repo. The reader sees only terminal rows, both predicates read idle, and after the idle window the instance is stopped mid-execution.

## Fix

Add an optional query parameter to the queue endpoint, active only (name at implementer's choice, for example active=1). When set, the handler returns only rows whose status is NOT in the terminal set (use the canonical set in `internal/executor/dispatcher.go`, not a hand-copied list; there is already an AST-drift test for mirrors of that set in `internal/executor/terminal_status_inventory_test.go`, so prefer calling a shared helper over adding another mirror) with no LIMIT, or a high LIMIT with a truncated flag in the response. Without the parameter the response is byte-identical to today, so older consumers are unaffected.

Also expose the same filter on the store: a method that returns non-terminal executions for a project path (empty path meaning all projects), honouring the existing canary exclusion.

## Tests

- Handler test: 60 terminal rows plus one running row older than all of them; without the parameter the running row is absent, with it the running row is returned and no terminal rows are.
- Store test for the new method including the canary exclusion and the empty-project-path case.
- Existing dashboard queue tests unchanged and green.

## Acceptance

- [ ] Queue endpoint with the active-only parameter returns every non-terminal execution regardless of age
- [ ] Response without the parameter is unchanged
- [ ] Test command, must be green:

```
go test ./internal/gateway/ ./internal/memory/
```

Consumer leg: pilot-console exec-activity reader switches to the active-only query (separate issue in that repo; safe to land before this one because an older daemon ignores the unknown parameter and returns today's response).