### PR TITLE
GH-5424: docs: per-page titles and meta descriptions; docs CTR is 1% on 7.5K impressions

### DIFF
--- a/.agent/tasks/gh-5424.md
+++ b/.agent/tasks/gh-5424.md
@@ -1,0 +1,85 @@
+# GH-5424
+
+**Created:** 2026-09-10
+
+## Problem
+
+GitHub Issue GH-5424: docs: per-page titles and meta descriptions; docs CTR is 1% on 7.5K impressions
+
+## Problem
+
+Search Console for `pilot.quantflow.studio`, 2026-06-08 → 09-07: the docs get ~7.5K impressions but ~1% CTR. The pages with the most impressions get almost no clicks:
+
+| Page | Impressions | Clicks | Avg position |
+|---|---|---|---|
+| /getting-started/configuration | 1,500 | 0 | 21.4 |
+| /concepts/execution-backends | 820 | 1 | 17.4 |
+| /features/dashboard | 813 | 17 | 7.5 |
+| /concepts/why-pilot | 486 | 1 | 18.8 |
+| /guides/tunnel-setup | 449 | 0 | 13.8 |
+| /integrations/plane | 381 | 2 | 7.0 |
+| /integrations/telegram | 363 | 1 | 11.0 |
+| /guides/custom-providers | 326 | 1 | 14.8 |
+| /deployment/desktop-app | 305 | 2 | 10.4 |
+| /getting-started/prerequisites | 301 | 0 | 17.8 |
+| /getting-started/quickstart | 297 | 1 | 9.9 |
+| /integrations/linear | 296 | 0 | 8.7 |
+
+Queries that produce these impressions (all zero clicks): `bot_token config.yaml`, `bot_token settings.yaml`, `glm_api_key config.yml`, `telegram_bot_token config.yml`, `linear api priority 1 urgent 2 high 3 medium 4 low` (and ~8 variants), `plane webhooks`, `plane api key`, `cloudflare tunnel webhook gateway`, `webhook tunnel`, `zcode custom provider`, `openrouter anthropic base url`, `quality gates`, `asana workspace id`. The one page that does click is `/features/dashboard` on `tui dashboard` (6 clicks, 3.1% CTR).
+
+## Root cause
+
+Live HTML today (`curl https://pilot.quantflow.studio/getting-started/configuration`):
+
+```
+<title>Configuration</title>
+<meta name="description" content="Autonomous AI development pipeline that turns tickets into pull requests">
+<meta property="og:title" content="Pilot — AI That Ships Your Tickets">
+```
+
+Two defects, both in `docs/`:
+
+1. **Bare `<title>`**: no product name, no context. A result titled "Configuration" or "Prerequisites" next to nine other results loses every time. Nextra 4 takes the title from the H1 when no frontmatter `title` is set, and `docs/app/layout.tsx` has no `title.template`.
+2. **One shared meta description on all pages**: no `.mdx` under `docs/content/` has frontmatter, so every page falls back to the layout's `description` from `docs/app/layout.tsx`. Google then shows the same generic sentence for the configuration guide, the Linear integration, and the tunnel guide.
+
+## Fix
+
+**A. Title template** in `docs/app/layout.tsx`:
+
+```ts
+title: { default: 'Pilot — AI That Ships Your Tickets', template: '%s | Pilot' },
+```
+
+Keep the root page's title as is. Confirm the template applies to Nextra-generated page metadata (Nextra 4 merges frontmatter into Next `metadata`; check `nextra` version in `docs/package.json` and its docs for the exact key).
+
+**B. Per-page frontmatter** with `title` and `description` on every page in every .mdx page under docs/content. Descriptions are 120–155 characters, written for the query the page already ranks on, and name the concrete thing the searcher typed. Required minimum, the twelve pages above:
+
+| Page | `title` | `description` |
+|---|---|---|
+| getting-started/configuration | Configuration: config.yaml reference | Every key in config.yaml in the pilot home directory: bot_token, api keys, backends, tracker and chat settings, with `${VAR}` env expansion and the setup wizard. |
+| concepts/execution-backends | Execution backends: Claude Code, OpenCode, custom | How Pilot runs tasks on Claude Code, OpenCode or other backends, what each supports, and how to switch per repo or per task. |
+| features/dashboard | Dashboard TUI: real-time terminal monitor | Terminal dashboard for Pilot: live task board, logs, queue, worker status and keyboard controls. Same panels as the desktop app. |
+| concepts/why-pilot | Why Pilot: autonomous tickets-to-PR pipeline | What separates Pilot from AI coding assistants: label a ticket, get a reviewed pull request, self-hosted, on your own repos. |
+| guides/tunnel-setup | Webhook tunnel setup: Cloudflare, ngrok, custom | Expose a local Pilot daemon for GitHub, Linear or Jira webhooks with a Cloudflare quick tunnel, ngrok or your own gateway. |
+| integrations/plane | Plane integration: API key, webhooks, polling | Connect Pilot to Plane Cloud or self-hosted: create the API key, configure webhooks or polling, and map labels to task states. |
+| integrations/telegram | Telegram bot: setup and telegram_bot_token | Run Pilot from Telegram: create the bot, set telegram_bot_token in config.yaml, and use task, question, research, plan and chat modes. |
+| guides/custom-providers | Custom model providers: GLM, OpenRouter, LiteLLM | Point Pilot at any Anthropic-compatible endpoint with one config block: glm_api_key for Z.AI, OpenRouter base URL, LiteLLM or a proxy. |
+| deployment/desktop-app | Desktop app for macOS, Windows, Linux | Native Pilot desktop app built with Wails: install, connect to the daemon over the gateway API, and mirror the dashboard TUI. |
+| getting-started/prerequisites | Prerequisites: Claude Code and a Git host | What you need before installing Pilot: Claude Code authenticated and a GitHub, GitLab or Azure DevOps token with the right scopes. |
+| getting-started/quickstart | Quick start: first PR in 10 minutes | Install Pilot, connect a repo, label one issue and get your first AI-generated pull request, step by step. |
+| integrations/linear | Linear integration: labels, priorities, webhooks | Connect Pilot to Linear: API key, label-based pickup, priority mapping (0 none, 1 urgent, 2 high, 3 medium, 4 low) and webhook setup. |
+
+Then the rest of `docs/content/` in the same style, one frontmatter block per page. Do not change H1s or body copy in this issue.
+
+**C. Priority mapping content** on `integrations/linear`: ~10 distinct queries ask for Linear's numeric priority values. Add a short table (0 none, 1 urgent, 2 high, 3 medium, 4 low) with an H2 "Priority mapping" so the page matches the query, not only the description.
+
+## Acceptance
+
+- `curl -s https://pilot.quantflow.studio/<page>` for each of the twelve pages shows a `<title>` ending in `| Pilot` and a unique `<meta name="description">` matching the table.
+- No two pages in `docs/content/` share a description (`grep -h '^description:' docs/content -r | sort | uniq -d` is empty).
+- `og:title` follows the page title, not the site default.
+- Docs build passes (`bun run build` in `docs/`).
+- Follow-up, not in this issue: re-check Search Console CTR on these pages after 4–6 weeks.
+
+## Acceptance Criteria
+

--- a/docs/app/[[...mdxPath]]/page.tsx
+++ b/docs/app/[[...mdxPath]]/page.tsx
@@ -6,6 +6,15 @@ export const generateStaticParams = generateStaticParamsFor('mdxPath')
 export async function generateMetadata(props: PageProps) {
   const params = await props.params
   const { metadata } = await importPage(params.mdxPath)
+
+  // The root page has no frontmatter `title` and no H1, so Nextra falls back
+  // to a filename-derived title ("Index") that would otherwise clobber the
+  // site default from app/layout.tsx once a title.template is in play.
+  // `absolute` bypasses the template so it renders exactly as the default.
+  if (!params.mdxPath || params.mdxPath.length === 0) {
+    return { ...metadata, title: { absolute: 'Pilot — AI That Ships Your Tickets' } }
+  }
+
   return metadata
 }
 

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -8,12 +8,14 @@ import './globals.css'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://pilot.quantflow.studio'),
-  title: 'Pilot — AI That Ships Your Tickets',
+  title: { default: 'Pilot — AI That Ships Your Tickets', template: '%s | Pilot' },
   description: 'Autonomous AI development pipeline that turns tickets into pull requests',
   openGraph: {
+    // title/description intentionally omitted: Next.js auto-fills them from
+    // the resolved per-page `title`/`description` above (see
+    // postProcessMetadata's inheritFromMetadata in next/dist/lib/metadata),
+    // so every docs page gets its own og:title instead of this site default.
     type: 'website',
-    title: 'Pilot — AI That Ships Your Tickets',
-    description: 'Autonomous AI development pipeline. Label a ticket, get a PR. Self-hosted, source-available.',
     url: 'https://pilot.quantflow.studio',
     images: [
       {
@@ -26,8 +28,6 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Pilot — AI That Ships Your Tickets',
-    description: 'Autonomous AI development pipeline. Label a ticket, get a PR. Self-hosted, source-available.',
     images: ['https://pilot.quantflow.studio/pilot-preview.png'],
   },
 }

--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -1,3 +1,8 @@
+---
+title: "CLI commands: pilot start, task, config"
+description: "Full pilot CLI reference: start, task, github, telegram, doctor and other subcommands with every flag and example usage."
+---
+
 # CLI Commands
 
 ## pilot start

--- a/docs/content/cli/doctor.mdx
+++ b/docs/content/cli/doctor.mdx
@@ -1,3 +1,8 @@
+---
+title: "pilot doctor: health check command"
+description: "Run pilot doctor to validate config.yaml, check dependencies and credentials, and diagnose setup problems before they block execution."
+---
+
 # pilot doctor
 
 Run health checks on system dependencies, configuration, and features.

--- a/docs/content/community.mdx
+++ b/docs/content/community.mdx
@@ -1,3 +1,8 @@
+---
+title: "Community, license and support"
+description: "Where to get help with Pilot: Discord server, GitHub Discussions, issue tracker, contributing guide, and the BSL 1.1 source-available license."
+---
+
 # Community
 
 Pilot is source-available under [BSL 1.1](https://github.com/qf-studio/pilot/blob/main/LICENSE). Free for internal use and self-hosting.

--- a/docs/content/concepts/adapters.mdx
+++ b/docs/content/concepts/adapters.mdx
@@ -1,3 +1,8 @@
+---
+title: "Adapters: the issue tracker interface"
+description: "How Pilot's adapter interface normalizes GitHub, GitLab, Linear, Jira, Azure DevOps and chat platforms into one execution and reporting model."
+---
+
 import { Callout } from 'nextra/components'
 
 # Adapters

--- a/docs/content/concepts/architecture.mdx
+++ b/docs/content/concepts/architecture.mdx
@@ -1,3 +1,8 @@
+---
+title: "Architecture: components and execution flow"
+description: "Pilot's system architecture end to end: CLI, gateway, adapters, executor and autopilot, plus the state machine from issue to merged PR."
+---
+
 import { Callout } from 'nextra/components'
 
 # Architecture & Execution Flow

--- a/docs/content/concepts/execution-backends.mdx
+++ b/docs/content/concepts/execution-backends.mdx
@@ -1,3 +1,8 @@
+---
+title: "Execution backends: Claude Code, OpenCode, custom"
+description: "How Pilot runs tasks on Claude Code, OpenCode or other backends, what each supports, and how to switch per repo or per task."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Execution Backends

--- a/docs/content/concepts/execution-pipeline.mdx
+++ b/docs/content/concepts/execution-pipeline.mdx
@@ -1,3 +1,8 @@
+---
+title: "Execution pipeline: issue to merged PR"
+description: "The full runtime path Pilot follows for every task, from adapter pickup through prompt assembly, quality gates, self-review and release."
+---
+
 import { Callout } from 'nextra/components'
 
 # Execution Pipeline

--- a/docs/content/concepts/model-routing.mdx
+++ b/docs/content/concepts/model-routing.mdx
@@ -1,3 +1,8 @@
+---
+title: "Model routing: complexity detection tiers"
+description: "How Pilot classifies task complexity and routes each one to a Claude model tier, timeout and reasoning effort automatically."
+---
+
 import { Callout } from 'nextra/components'
 
 # Complexity Detection & Model Routing

--- a/docs/content/concepts/signal-parser.mdx
+++ b/docs/content/concepts/signal-parser.mdx
@@ -1,3 +1,8 @@
+---
+title: "Signal parser: pilot-signal JSON blocks"
+description: "How Pilot parses structured pilot-signal JSON blocks from Claude Code output to drive dashboard progress and detect stagnation."
+---
+
 import { Callout } from 'nextra/components'
 
 # Signal Parser

--- a/docs/content/concepts/why-pilot.mdx
+++ b/docs/content/concepts/why-pilot.mdx
@@ -1,3 +1,8 @@
+---
+title: "Why Pilot: autonomous tickets-to-PR pipeline"
+description: "What separates Pilot from AI coding assistants: label a ticket, get a reviewed pull request, self-hosted, on your own repos."
+---
+
 import { Callout } from 'nextra/components'
 
 # Why Pilot

--- a/docs/content/concepts/worktree-isolation.mdx
+++ b/docs/content/concepts/worktree-isolation.mdx
@@ -1,3 +1,8 @@
+---
+title: "Worktree isolation: safe concurrent execution"
+description: "How Pilot runs tasks in isolated git worktrees so autonomous execution never conflicts with your local uncommitted changes."
+---
+
 # Worktree Isolation
 
 Worktree isolation allows Pilot to execute tasks in a separate git worktree, preventing conflicts with your local uncommitted changes. This feature enables autonomous execution even when your repository has pending work.

--- a/docs/content/deployment/aws.mdx
+++ b/docs/content/deployment/aws.mdx
@@ -1,3 +1,8 @@
+---
+title: "Deploy on AWS: EC2, ECS, Fargate"
+description: "Run Pilot on AWS with EC2, ECS or Fargate: instance sizing, IAM, container images and systemd service configuration."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # AWS Deployment

--- a/docs/content/deployment/azure.mdx
+++ b/docs/content/deployment/azure.mdx
@@ -1,3 +1,8 @@
+---
+title: "Deploy on Azure: Container Apps, VMs"
+description: "Run Pilot on Azure using Container Apps or a Virtual Machine, including container build steps and environment configuration."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Azure Deployment

--- a/docs/content/deployment/desktop-app.mdx
+++ b/docs/content/deployment/desktop-app.mdx
@@ -1,3 +1,8 @@
+---
+title: "Desktop app for macOS, Windows, Linux"
+description: "Native Pilot desktop app built with Wails: install, connect to the daemon over the gateway API, and mirror the dashboard TUI."
+---
+
 import { Callout, Steps } from 'nextra/components'
 
 # Desktop App

--- a/docs/content/deployment/docker-helm.mdx
+++ b/docs/content/deployment/docker-helm.mdx
@@ -1,3 +1,8 @@
+---
+title: "Docker and Helm: production deployment"
+description: "Production Pilot deployment with Docker Compose or Helm on Kubernetes: the official image, persistence, ingress and monitoring."
+---
+
 import { Callout, Tabs, Steps } from 'nextra/components'
 
 # Docker & Helm Deployment

--- a/docs/content/deployment/docker.mdx
+++ b/docs/content/deployment/docker.mdx
@@ -1,3 +1,8 @@
+---
+title: "Docker deployment guide"
+description: "Run Pilot in Docker: the official Dockerfile, image build, environment variables and container configuration for portable deployments."
+---
+
 import { Callout } from 'nextra/components'
 
 # Docker Deployment

--- a/docs/content/deployment/google-cloud.mdx
+++ b/docs/content/deployment/google-cloud.mdx
@@ -1,3 +1,8 @@
+---
+title: "Deploy on Google Cloud: GCE, Cloud Run"
+description: "Run Pilot on Google Cloud using Compute Engine or Cloud Run, with gcloud commands for instance creation and configuration."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Google Cloud Deployment

--- a/docs/content/deployment/index.mdx
+++ b/docs/content/deployment/index.mdx
@@ -1,3 +1,8 @@
+---
+title: "Deployment overview and requirements"
+description: "What Pilot needs to run in production: the binary, Git, a backend CLI, API keys and adapter tokens, across every deployment target."
+---
+
 # Deployment Overview
 
 Pilot is a single Go binary with minimal runtime dependencies. This section covers deployment options from local development to production cloud environments.

--- a/docs/content/deployment/kubernetes.mdx
+++ b/docs/content/deployment/kubernetes.mdx
@@ -1,3 +1,8 @@
+---
+title: "Kubernetes deployment: probes and secrets"
+description: "Deploy Pilot on Kubernetes with liveness and readiness probes, secrets management, and persistent storage for the SQLite database."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Kubernetes Deployment

--- a/docs/content/deployment/local.mdx
+++ b/docs/content/deployment/local.mdx
@@ -1,3 +1,8 @@
+---
+title: "Local deployment: systemd and launchd"
+description: "Run Pilot as a background service on bare metal with systemd on Linux or launchd on macOS, including binary install steps."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Local / Bare Metal Deployment

--- a/docs/content/deployment/monitoring.mdx
+++ b/docs/content/deployment/monitoring.mdx
@@ -1,3 +1,8 @@
+---
+title: "Monitoring: Prometheus metrics and logs"
+description: "Observe Pilot in production with Prometheus metrics at /metrics and structured JSON logging for counters, histograms and gauges."
+---
+
 import { Callout } from 'nextra/components'
 
 # Monitoring

--- a/docs/content/deployment/networking.mdx
+++ b/docs/content/deployment/networking.mdx
@@ -1,3 +1,8 @@
+---
+title: "Networking: gateway, tunnels, reverse proxies"
+description: "Configure Pilot's gateway for webhooks, set up tunnels for local development, and integrate with reverse proxies in production."
+---
+
 import { Callout } from 'nextra/components'
 
 # Networking & Tunnels

--- a/docs/content/features/alerts.mdx
+++ b/docs/content/features/alerts.mdx
@@ -1,3 +1,8 @@
+---
+title: "Alerts: Slack, Telegram, email, PagerDuty"
+description: "Pilot's alert engine: event-driven rules, cooldowns and severity filtering routed to Slack, Telegram, email, webhooks and PagerDuty."
+---
+
 import { Callout } from 'nextra/components'
 
 # Alerts & Notifications

--- a/docs/content/features/approval-workflows.mdx
+++ b/docs/content/features/approval-workflows.mdx
@@ -1,3 +1,8 @@
+---
+title: "Approval workflows: human gates for autopilot"
+description: "Add human approval checkpoints before task execution, PR merge or failure recovery in Pilot's autonomous prod environment."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Approval Workflows

--- a/docs/content/features/autopilot-environments.mdx
+++ b/docs/content/features/autopilot-environments.mdx
@@ -1,3 +1,8 @@
+---
+title: "Autopilot environments: dev, stage, prod"
+description: "Compare Pilot's dev, stage and prod autopilot environments: auto-merge rules, CI requirements, approval and self-review differences."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Autopilot Environments

--- a/docs/content/features/autopilot.mdx
+++ b/docs/content/features/autopilot.mdx
@@ -1,3 +1,8 @@
+---
+title: "Autopilot: automatic PR merging"
+description: "Fully autonomous CI monitoring, conflict resolution and auto-merge that picks up once Pilot opens a pull request."
+---
+
 import { Callout } from 'nextra/components'
 
 # Autopilot Mode

--- a/docs/content/features/budget.mdx
+++ b/docs/content/features/budget.mdx
@@ -1,3 +1,8 @@
+---
+title: "Budget and cost controls"
+description: "Track API spend and enforce daily, monthly and per-task cost limits in Pilot to prevent runaway AI usage bills."
+---
+
 import { Callout } from 'nextra/components'
 
 # Budget & Cost Controls

--- a/docs/content/features/conversational-bot.mdx
+++ b/docs/content/features/conversational-bot.mdx
@@ -1,3 +1,8 @@
+---
+title: "Conversational bot: fast chat responses"
+description: "Pilot's fast-response chat path for Slack and Telegram: answer questions, file issues from a sentence, and skip executor latency."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Conversational Bot

--- a/docs/content/features/dashboard.mdx
+++ b/docs/content/features/dashboard.mdx
@@ -1,3 +1,8 @@
+---
+title: "Dashboard TUI: real-time terminal monitor"
+description: "Terminal dashboard for Pilot: live task board, logs, queue, worker status and keyboard controls. Same panels as the desktop app."
+---
+
 import { Callout } from 'nextra/components'
 
 # Dashboard TUI

--- a/docs/content/features/effort-routing.mdx
+++ b/docs/content/features/effort-routing.mdx
@@ -1,3 +1,8 @@
+---
+title: "Effort-based model routing"
+description: "How Pilot's 3-tier model mapping selects Claude model and API effort level per task complexity to cut cost without losing quality."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Effort-Based Model Routing

--- a/docs/content/features/epic-decomposition.mdx
+++ b/docs/content/features/epic-decomposition.mdx
@@ -1,3 +1,8 @@
+---
+title: "Epic decomposition: splitting large tasks"
+description: "How Pilot automatically breaks a large ticket into 3-5 sequential subtasks using Claude Code planning before execution begins."
+---
+
 import { Callout } from 'nextra/components'
 
 # Epic Decomposition

--- a/docs/content/features/evaluation-system.mdx
+++ b/docs/content/features/evaluation-system.mdx
@@ -1,3 +1,8 @@
+---
+title: "Evaluation system: regression detection"
+description: "How Pilot extracts benchmark tasks from merged PRs and tracks pass rates over time to catch quality regressions across models."
+---
+
 import { Callout } from 'nextra/components'
 
 # Evaluation System

--- a/docs/content/features/execution-modes.mdx
+++ b/docs/content/features/execution-modes.mdx
@@ -1,3 +1,8 @@
+---
+title: "Execution modes: sequential, parallel, auto"
+description: "Control how Pilot processes multiple tasks at once: sequential, parallel with max_concurrent, or auto scope-overlap guarding."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Execution Modes

--- a/docs/content/features/executor-mode-signal.mdx
+++ b/docs/content/features/executor-mode-signal.mdx
@@ -1,3 +1,8 @@
+---
+title: "Executor-mode signal for CLAUDE.md rules"
+description: "How Pilot signals a Claude Code subprocess that it is the autonomous executor so CLAUDE.md 'do not write code' rules can be skipped safely."
+---
+
 import { Callout } from 'nextra/components'
 
 # Executor-Mode Signal

--- a/docs/content/features/github.mdx
+++ b/docs/content/features/github.mdx
@@ -1,3 +1,8 @@
+---
+title: "GitHub setup: personal access token"
+description: "Create a GitHub personal access token or GitHub App, set the required repo and workflow scopes, and connect Pilot to your repository."
+---
+
 # GitHub Integration
 
 Pilot monitors GitHub issues and automatically implements tasks.

--- a/docs/content/features/hooks.mdx
+++ b/docs/content/features/hooks.mdx
@@ -1,3 +1,8 @@
+---
+title: "Claude Code hooks: inline quality gates"
+description: "Run tests, block destructive commands or auto-format files inline during Claude Code execution with Pilot's hook system."
+---
+
 import { Callout } from 'nextra/components'
 
 # Claude Code Hooks

--- a/docs/content/features/hot-upgrade.mdx
+++ b/docs/content/features/hot-upgrade.mdx
@@ -1,3 +1,8 @@
+---
+title: "Hot upgrade: zero-downtime self-update"
+description: "How Pilot checks for new versions, downloads and replaces its own binary, and restarts without downtime in daemon mode."
+---
+
 import { Callout } from 'nextra/components'
 
 # Hot Upgrade

--- a/docs/content/features/memory.mdx
+++ b/docs/content/features/memory.mdx
@@ -1,3 +1,8 @@
+---
+title: "Memory and learning: execution history"
+description: "How Pilot's SQLite-backed memory subsystem records every task execution, extracts patterns, and applies them to future work."
+---
+
 import { Callout } from 'nextra/components'
 
 # Memory & Learning

--- a/docs/content/features/quality-gates.mdx
+++ b/docs/content/features/quality-gates.mdx
@@ -1,3 +1,8 @@
+---
+title: "Quality gates: pre-PR code checks"
+description: "Enforce lint, test and build checks between implementation and PR creation, with automatic retry feedback when gates fail."
+---
+
 import { Callout } from 'nextra/components'
 
 # Quality Gates

--- a/docs/content/features/replay.mdx
+++ b/docs/content/features/replay.mdx
@@ -1,3 +1,8 @@
+---
+title: "Replay and debug: execution recordings"
+description: "Every Pilot task is recorded automatically: tool calls, responses, token usage and file changes, replayable for debugging."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Replay & Debug

--- a/docs/content/features/self-healing.mdx
+++ b/docs/content/features/self-healing.mdx
@@ -1,3 +1,8 @@
+---
+title: "Self-healing: CI error pattern learning"
+description: "How Pilot learns from CI failures, retries with decomposition, and avoids duplicate work in a closed-loop fix pipeline."
+---
+
 import { Callout } from 'nextra/components'
 
 # Self-Healing

--- a/docs/content/features/self-improvement.mdx
+++ b/docs/content/features/self-improvement.mdx
@@ -1,3 +1,8 @@
+---
+title: "Self-improvement: 20+ learning mechanisms"
+description: "How Pilot learns from every execution, PR review and CI failure through pattern extraction, anti-pattern injection and routing."
+---
+
 import { Callout } from 'nextra/components'
 
 # Self-Improvement System

--- a/docs/content/features/teams.mdx
+++ b/docs/content/features/teams.mdx
@@ -1,3 +1,8 @@
+---
+title: "Teams and permissions: RBAC"
+description: "Role-based access control for Pilot: Owner, Admin, Developer and Viewer roles mapped to GitHub, Telegram and Slack identities."
+---
+
 import { Callout } from 'nextra/components'
 
 # Teams & Permissions

--- a/docs/content/features/telegram.mdx
+++ b/docs/content/features/telegram.mdx
@@ -1,3 +1,8 @@
+---
+title: "Telegram bot: control and notifications"
+description: "Control Pilot and receive execution notifications through a Telegram bot: create it with BotFather and connect the bot token."
+---
+
 # Telegram Bot
 
 Control Pilot and receive notifications via Telegram.

--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -1,3 +1,8 @@
+---
+title: "Configuration: config.yaml reference"
+description: "Every key in config.yaml in the pilot home directory: bot_token, api keys, backends, tracker and chat settings, with ${VAR} env expansion and the setup wizard."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Configuration

--- a/docs/content/getting-started/index.mdx
+++ b/docs/content/getting-started/index.mdx
@@ -1,3 +1,8 @@
+---
+title: "Getting started: overview and requirements"
+description: "What you need before installing Pilot and the path from zero to your first AI-generated pull request, start to finish."
+---
+
 import { Callout } from 'nextra/components'
 
 # Getting Started

--- a/docs/content/getting-started/installation.mdx
+++ b/docs/content/getting-started/installation.mdx
@@ -1,3 +1,8 @@
+---
+title: "Installation: install script and binaries"
+description: "Install the Pilot binary with the quick install script, Homebrew, or from source, then verify the install with pilot doctor."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Installation

--- a/docs/content/getting-started/prerequisites.mdx
+++ b/docs/content/getting-started/prerequisites.mdx
@@ -1,3 +1,8 @@
+---
+title: "Prerequisites: Claude Code and a Git host"
+description: "What you need before installing Pilot: Claude Code authenticated and a GitHub, GitLab or Azure DevOps token with the right scopes."
+---
+
 import { Callout, Tabs } from 'nextra/components'
 
 # Prerequisites

--- a/docs/content/getting-started/quickstart.mdx
+++ b/docs/content/getting-started/quickstart.mdx
@@ -1,3 +1,8 @@
+---
+title: "Quick start: first PR in 10 minutes"
+description: "Install Pilot, connect a repo, label one issue and get your first AI-generated pull request, step by step."
+---
+
 import { Callout, Steps, Tabs } from 'nextra/components'
 
 # Quick Start: First PR in 10 Minutes

--- a/docs/content/guides/custom-providers.mdx
+++ b/docs/content/guides/custom-providers.mdx
@@ -1,3 +1,8 @@
+---
+title: "Custom model providers: GLM, OpenRouter, LiteLLM"
+description: "Point Pilot at any Anthropic-compatible endpoint with one config block: glm_api_key for Z.AI, OpenRouter base URL, LiteLLM or a proxy."
+---
+
 import { Callout, Steps, Tabs } from 'nextra/components'
 
 # Custom Model Providers

--- a/docs/content/guides/multi-repo.mdx
+++ b/docs/content/guides/multi-repo.mdx
@@ -1,3 +1,8 @@
+---
+title: "Multi-repo polling: monitor multiple projects"
+description: "Run one Pilot instance across multiple GitHub repositories with per-project pollers and independent autopilot controllers."
+---
+
 import { Callout } from 'nextra/components'
 
 # Multi-Repo Polling

--- a/docs/content/guides/troubleshooting.mdx
+++ b/docs/content/guides/troubleshooting.mdx
@@ -1,3 +1,8 @@
+---
+title: "Troubleshooting: common errors and fixes"
+description: "Fix common Pilot problems: command not found, installation issues, config errors and execution failures, starting with pilot doctor."
+---
+
 import { Callout } from 'nextra/components'
 
 # Troubleshooting

--- a/docs/content/guides/tunnel-setup.mdx
+++ b/docs/content/guides/tunnel-setup.mdx
@@ -1,3 +1,8 @@
+---
+title: "Webhook tunnel setup: Cloudflare, ngrok, custom"
+description: "Expose a local Pilot daemon for GitHub, Linear or Jira webhooks with a Cloudflare quick tunnel, ngrok or your own gateway."
+---
+
 import { Callout, Steps, Tabs } from 'nextra/components'
 
 # Tunnel Setup Guide

--- a/docs/content/integrations/asana.mdx
+++ b/docs/content/integrations/asana.mdx
@@ -1,3 +1,8 @@
+---
+title: "Asana integration: workspace ID and API token"
+description: "Connect Pilot to Asana: personal access token, workspace ID, and the pilot tag that triggers task pickup and status updates."
+---
+
 import { Callout } from 'nextra/components'
 
 # Asana Integration

--- a/docs/content/integrations/azure-devops.mdx
+++ b/docs/content/integrations/azure-devops.mdx
@@ -1,3 +1,8 @@
+---
+title: "Azure DevOps integration: PAT and work items"
+description: "Connect Pilot to Azure DevOps Services or Server: create a personal access token and map work items and tags to Pilot tasks."
+---
+
 import { Callout } from 'nextra/components'
 
 # Azure DevOps Integration

--- a/docs/content/integrations/discord.mdx
+++ b/docs/content/integrations/discord.mdx
@@ -1,3 +1,8 @@
+---
+title: "Discord integration: bot setup"
+description: "Connect a Discord bot to Pilot so team members can submit tasks from channels with interactive confirmation buttons."
+---
+
 import { Callout } from 'nextra/components'
 
 # Discord Integration

--- a/docs/content/integrations/github.mdx
+++ b/docs/content/integrations/github.mdx
@@ -1,3 +1,8 @@
+---
+title: "GitHub integration: webhooks and PR automation"
+description: "Connect Pilot to GitHub for label-based issue intake, automatic pull requests, CI status tracking and Autopilot auto-merge."
+---
+
 import { Callout } from 'nextra/components'
 
 # GitHub Integration

--- a/docs/content/integrations/gitlab.mdx
+++ b/docs/content/integrations/gitlab.mdx
@@ -1,3 +1,8 @@
+---
+title: "GitLab integration: token and merge requests"
+description: "Connect Pilot to GitLab.com or self-hosted GitLab: create an access token and get automatic merge requests from issues."
+---
+
 import { Callout } from 'nextra/components'
 
 # GitLab Integration

--- a/docs/content/integrations/jira.mdx
+++ b/docs/content/integrations/jira.mdx
@@ -1,3 +1,8 @@
+---
+title: "Jira integration: API token and webhooks"
+description: "Connect Pilot to Jira Cloud or Server: create an API token, configure webhooks or polling, and link PRs back to Jira issues."
+---
+
 import { Callout } from 'nextra/components'
 
 # Jira Integration

--- a/docs/content/integrations/linear.mdx
+++ b/docs/content/integrations/linear.mdx
@@ -1,3 +1,8 @@
+---
+title: "Linear integration: labels, priorities, webhooks"
+description: "Connect Pilot to Linear: API key, label-based pickup, priority mapping (0 none, 1 urgent, 2 high, 3 medium, 4 low) and webhook setup."
+---
+
 import { Callout } from 'nextra/components'
 
 # Linear Integration
@@ -165,6 +170,18 @@ Pilot also supports real-time issue detection via Linear webhooks.
 
 When using multiple workspaces, Pilot routes incoming webhooks to the correct workspace handler based on the `team.id` field in the payload. If the team ID is missing, Pilot falls back to trying each workspace handler in sequence.
 
+## Priority mapping
+
+Linear's numeric issue priority maps directly to Pilot's priority system:
+
+| Value | Linear Priority | Pilot Priority |
+|-------|-----------------|-----------------|
+| 0 | No Priority | None |
+| 1 | Urgent | Urgent |
+| 2 | High | High |
+| 3 | Medium | Medium |
+| 4 | Low | Low |
+
 ## Issue States and Priority
 
 ### State Types
@@ -178,18 +195,6 @@ Pilot filters issues by state type during polling:
 | `started` | In progress | Yes |
 | `completed` | Done | No |
 | `canceled` | Canceled | No |
-
-### Priority Levels
-
-Linear priorities map directly to Pilot's priority system:
-
-| Linear Priority | Value | Pilot Priority |
-|----------------|-------|---------------|
-| Urgent | 1 | Urgent |
-| High | 2 | High |
-| Medium | 3 | Medium |
-| Low | 4 | Low |
-| No Priority | 0 | None |
 
 ## Status Notifications
 

--- a/docs/content/integrations/plane.mdx
+++ b/docs/content/integrations/plane.mdx
@@ -1,3 +1,8 @@
+---
+title: "Plane integration: API key, webhooks, polling"
+description: "Connect Pilot to Plane Cloud or self-hosted: create the API key, configure webhooks or polling, and map labels to task states."
+---
+
 import { Callout } from 'nextra/components'
 
 # Plane Integration

--- a/docs/content/integrations/slack.mdx
+++ b/docs/content/integrations/slack.mdx
@@ -1,3 +1,8 @@
+---
+title: "Slack integration: notifications and bot"
+description: "Send real-time Pilot notifications to Slack and enable two-way chat: progress updates, PR alerts, and approval workflows."
+---
+
 import { Callout } from 'nextra/components'
 
 # Slack Integration

--- a/docs/content/integrations/telegram.mdx
+++ b/docs/content/integrations/telegram.mdx
@@ -1,3 +1,8 @@
+---
+title: "Telegram bot: setup and telegram_bot_token"
+description: "Run Pilot from Telegram: create the bot, set telegram_bot_token in config.yaml, and use task, question, research, plan and chat modes."
+---
+
 import { Callout } from 'nextra/components'
 
 # Telegram Integration

--- a/docs/content/navigator/best-practices.mdx
+++ b/docs/content/navigator/best-practices.mdx
@@ -1,3 +1,8 @@
+---
+title: "Navigator best practices"
+description: "Proven patterns for Pilot's context intelligence layer from 500+ autonomous executions: index document design and token budgets."
+---
+
 import { Callout } from 'nextra/components'
 
 # Best Practices

--- a/docs/content/navigator/how-it-works.mdx
+++ b/docs/content/navigator/how-it-works.mdx
@@ -1,3 +1,8 @@
+---
+title: "Navigator architecture: how it works"
+description: "How Pilot's context intelligence layer structures loading, persistent memory and workflow enforcement across executions."
+---
+
 import { Callout } from 'nextra/components'
 
 # Architecture

--- a/docs/content/navigator/index.mdx
+++ b/docs/content/navigator/index.mdx
@@ -1,3 +1,8 @@
+---
+title: "Context intelligence: Navigator overview"
+description: "How Pilot's .agent/ directory and Navigator plugin reduce token waste while keeping full project awareness during execution."
+---
+
 import { Callout } from 'nextra/components'
 
 # Context Intelligence

--- a/docs/content/navigator/setup.mdx
+++ b/docs/content/navigator/setup.mdx
@@ -1,3 +1,8 @@
+---
+title: "Navigator setup: the .agent/ directory"
+description: "How Pilot auto-initializes the .agent/ directory on first task execution, and how to customize the documentation structure manually."
+---
+
 import { Callout, Steps } from 'nextra/components'
 
 # Setup


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5424.

Closes #5424

## Changes

GitHub Issue GH-5424: docs: per-page titles and meta descriptions; docs CTR is 1% on 7.5K impressions

## Problem

Search Console for `pilot.quantflow.studio`, 2026-06-08 → 09-07: the docs get ~7.5K impressions but ~1% CTR. The pages with the most impressions get almost no clicks:

| Page | Impressions | Clicks | Avg position |
|---|---|---|---|
| /getting-started/configuration | 1,500 | 0 | 21.4 |
| /concepts/execution-backends | 820 | 1 | 17.4 |
| /features/dashboard | 813 | 17 | 7.5 |
| /concepts/why-pilot | 486 | 1 | 18.8 |
| /guides/tunnel-setup | 449 | 0 | 13.8 |
| /integrations/plane | 381 | 2 | 7.0 |
| /integrations/telegram | 363 | 1 | 11.0 |
| /guides/custom-providers | 326 | 1 | 14.8 |
| /deployment/desktop-app | 305 | 2 | 10.4 |
| /getting-started/prerequisites | 301 | 0 | 17.8 |
| /getting-started/quickstart | 297 | 1 | 9.9 |
| /integrations/linear | 296 | 0 | 8.7 |

Queries that produce these impressions (all zero clicks): `bot_token config.yaml`, `bot_token settings.yaml`, `glm_api_key config.yml`, `telegram_bot_token config.yml`, `linear api priority 1 urgent 2 high 3 medium 4 low` (and ~8 variants), `plane webhooks`, `plane api key`, `cloudflare tunnel webhook gateway`, `webhook tunnel`, `zcode custom provider`, `openrouter anthropic base url`, `quality gates`, `asana workspace id`. The one page that does click is `/features/dashboard` on `tui dashboard` (6 clicks, 3.1% CTR).

## Root cause

Live HTML today (`curl https://pilot.quantflow.studio/getting-started/configuration`):

```
<title>Configuration</title>
<meta name="description" content="Autonomous AI development pipeline that turns tickets into pull requests">
<meta property="og:title" content="Pilot — AI That Ships Your Tickets">
```

Two defects, both in `docs/`:

1. **Bare `<title>`**: no product name, no context. A result titled "Configuration" or "Prerequisites" next to nine other results loses every time. Nextra 4 takes the title from the H1 when no frontmatter `title` is set, and `docs/app/layout.tsx` has no `title.template`.
2. **One shared meta description on all pages**: no `.mdx` under `docs/content/` has frontmatter, so every page falls back to the layout's `description` from `docs/app/layout.tsx`. Google then shows the same generic sentence for the configuration guide, the Linear integration, and the tunnel guide.

## Fix

**A. Title template** in `docs/app/layout.tsx`:

```ts
title: { default: 'Pilot — AI That Ships Your Tickets', template: '%s | Pilot' },
```

Keep the root page's title as is. Confirm the template applies to Nextra-generated page metadata (Nextra 4 merges frontmatter into Next `metadata`; check `nextra` version in `docs/package.json` and its docs for the exact key).

**B. Per-page frontmatter** with `title` and `description` on every page in every .mdx page under docs/content. Descriptions are 120–155 characters, written for the query the page already ranks on, and name the concrete thing the searcher typed. Required minimum, the twelve pages above:

| Page | `title` | `description` |
|---|---|---|
| getting-started/configuration | Configuration: config.yaml reference | Every key in config.yaml in the pilot home directory: bot_token, api keys, backends, tracker and chat settings, with `${VAR}` env expansion and the setup wizard. |
| concepts/execution-backends | Execution backends: Claude Code, OpenCode, custom | How Pilot runs tasks on Claude Code, OpenCode or other backends, what each supports, and how to switch per repo or per task. |
| features/dashboard | Dashboard TUI: real-time terminal monitor | Terminal dashboard for Pilot: live task board, logs, queue, worker status and keyboard controls. Same panels as the desktop app. |
| concepts/why-pilot | Why Pilot: autonomous tickets-to-PR pipeline | What separates Pilot from AI coding assistants: label a ticket, get a reviewed pull request, self-hosted, on your own repos. |
| guides/tunnel-setup | Webhook tunnel setup: Cloudflare, ngrok, custom | Expose a local Pilot daemon for GitHub, Linear or Jira webhooks with a Cloudflare quick tunnel, ngrok or your own gateway. |
| integrations/plane | Plane integration: API key, webhooks, polling | Connect Pilot to Plane Cloud or self-hosted: create the API key, configure webhooks or polling, and map labels to task states. |
| integrations/telegram | Telegram bot: setup and telegram_bot_token | Run Pilot from Telegram: create the bot, set telegram_bot_token in config.yaml, and use task, question, research, plan and chat modes. |
| guides/custom-providers | Custom model providers: GLM, OpenRouter, LiteLLM | Point Pilot at any Anthropic-compatible endpoint with one config block: glm_api_key for Z.AI, OpenRouter base URL, LiteLLM or a proxy. |
| deployment/desktop-app | Desktop app for macOS, Windows, Linux | Native Pilot desktop app built with Wails: install, connect to the daemon over the gateway API, and mirror the dashboard TUI. |
| getting-started/prerequisites | Prerequisites: Claude Code and a Git host | What you need before installing Pilot: Claude Code authenticated and a GitHub, GitLab or Azure DevOps token with the right scopes. |
| getting-started/quickstart | Quick start: first PR in 10 minutes | Install Pilot, connect a repo, label one issue and get your first AI-generated pull request, step by step. |
| integrations/linear | Linear integration: labels, priorities, webhooks | Connect Pilot to Linear: API key, label-based pickup, priority mapping (0 none, 1 urgent, 2 high, 3 medium, 4 low) and webhook setup. |

Then the rest of `docs/content/` in the same style, one frontmatter block per page. Do not change H1s or body copy in this issue.

**C. Priority mapping content** on `integrations/linear`: ~10 distinct queries ask for Linear's numeric priority values. Add a short table (0 none, 1 urgent, 2 high, 3 medium, 4 low) with an H2 "Priority mapping" so the page matches the query, not only the description.

## Acceptance

- `curl -s https://pilot.quantflow.studio/<page>` for each of the twelve pages shows a `<title>` ending in `| Pilot` and a unique `<meta name="description">` matching the table.
- No two pages in `docs/content/` share a description (`grep -h '^description:' docs/content -r | sort | uniq -d` is empty).
- `og:title` follows the page title, not the site default.
- Docs build passes (`bun run build` in `docs/`).
- Follow-up, not in this issue: re-check Search Console CTR on these pages after 4–6 weeks.