### PR TITLE
fix(autopilot): borrowed-branch registry: re-record on persist-failure eviction, TTL from run start, closed-origin memo revalidation

### DIFF
--- a/.agent/tasks/gh-5430.md
+++ b/.agent/tasks/gh-5430.md
@@ -1,0 +1,42 @@
+# GH-5430
+
+**Created:** 2026-09-10
+
+## Problem
+
+GitHub Issue GH-5430: fix(autopilot): borrowed-branch registry consumed before registration commits; TTL starts at dispatch; closed-origin memo never revalidated (PR #5427 follow-up)
+
+## Problem
+
+PR #5427 (GH-5425) made the borrowed-branch registry self-cleaning and memoized the reconciler's closed-origin skip. Post-merge review found three narrow gaps in `internal/executor/runner.go` and `internal/autopilot/controller.go`.
+
+1. **Consume before commit.** FixIssueForBranch deletes the registry entry on match, then the reconciler calls OnPRCreatedForFixIssue, which persists the PR state. If that persist fails and the PR is evicted after the cooldown, the next reconcile finds no registry entry, sees the closed origin issue, warns, memoizes the skip, and the PR is orphaned for good. Before #5427 the entry survived and the next tick re-adopted the PR.
+2. **TTL measured from dispatch.** The 6 hour clock starts in RecordBorrowedBranch, which runs before the task is dispatched. A fix task that waits in the queue or runs for more than 6 hours reaches the PR-created hook with an expired entry and falls into the guarded OnPRCreated path, which drops the registration (the GH-5421 shape, now for long tasks only).
+3. **Memo never invalidated on origin reopen.** A PR memoized as closed-origin stays skipped until the PR itself closes, even if the origin issue is reopened.
+
+## Fix
+
+- Make the consume conditional on success: either have FixIssueForBranch return the entry without deleting and add an explicit ConsumeBorrowedBranch(branch) that the reconciler calls only after OnPRCreatedForFixIssue returns and the PR is present in the active set, or re-record the entry when evictPersistFailedPR drops a PR that was registered through the fix-issue path. State the choice in the PR body, not only in comments.
+- Start the TTL from the execution's start, not from record time: stamp recordedAt when the task transitions to running (the runner has that moment), or extend the TTL to cover the maximum queue wait plus run time and document the bound. Add a test with a recordedAt older than 6 hours but a running-start within the window that still resolves.
+- Invalidate the memo entry when the reconciler observes the origin issue open again: the cheapest signal is the existing GetIssue call the memo avoids, so instead re-check memoized entries on a slow cadence (for example every 30 ticks) and drop the memo if the issue is open. State the cadence in the PR.
+
+## Tests
+
+- Registry: match then simulated persist failure keeps the entry (or re-records it), and the following tick registers the PR under the fix issue.
+- Registry: TTL test as above.
+- Reconciler: memoized PR whose origin issue is reopened gets re-checked on the slow cadence and registered.
+- Existing GH-5421 and GH-5425 tests stay green.
+
+## Acceptance
+
+- [ ] A persist failure at registration time never orphans a fix-issue PR permanently
+- [ ] A fix task older than 6 hours at hook time still registers under the fix issue
+- [ ] A reopened origin issue clears the closed-origin memo within the documented cadence
+- [ ] Test command, must be green:
+
+```
+go test ./internal/autopilot/ ./internal/executor/ ./cmd/pilot/
+```
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -675,6 +675,11 @@ type Controller struct {
 	// legitimate registration is never blocked by a stale memo, and the map
 	// never grows past the current count of open pilot/ PRs.
 	closedOriginSkip map[int]closedOriginSkipRecord
+	// reconcileTick counts reconcileOrphanPRs invocations, guarded by mu.
+	// GH-5430: gates closedOriginRecheckCadence — see that constant's doc for
+	// why closedOriginSkip memos need periodic revalidation against GitHub's
+	// current issue state, not just pruning against the open-PR list.
+	reconcileTick uint64
 
 	// alertedApprovalFailures deduplicates approval-submit-failure alerts and
 	// PR-comment fallbacks per PR number, guarded by mu — same rationale as
@@ -1286,6 +1291,15 @@ func (c *Controller) SetLaneQueueStatus(s LaneQueueStatus) {
 // above.
 type BorrowedBranchLookup interface {
 	FixIssueForBranch(branch string) (fixIssue int, ok bool)
+	// RecordBorrowedBranch (re-)records that taskID's branch/fix-issue
+	// pairing should be reported by a later FixIssueForBranch(branch) call —
+	// satisfied by *executor.Runner's RecordBorrowedBranch. GH-5430:
+	// evictPersistFailedPR calls this to restore an entry that
+	// FixIssueForBranch already consumed destructively at match time, when
+	// the registration that consume enabled later fails to persist and the
+	// PR is evicted — without restoring it, no later reconciler tick could
+	// ever rediscover the fix issue for this branch again.
+	RecordBorrowedBranch(taskID, branch string, fromPR int)
 }
 
 // SetBorrowedBranchLookup wires the in-process borrowed-branch registry
@@ -2319,8 +2333,21 @@ func (c *Controller) alertUnresolvableBaseOnce(prNumber, issueNumber int, readEr
 // expected to succeed even when the upsert path that got the PR into this
 // state cannot — clearing the stuck row is the same one-time reconciliation
 // a human would otherwise run by hand.
+//
+// GH-5430: a PR registered via OnPRCreatedForFixIssue already consumed its
+// runner-side borrowed-branch registry entry destructively the moment
+// FixIssueForBranch matched it (see that method's doc) — well before this
+// eviction, and well before persistence ever had a chance to succeed. If
+// eviction is the only outcome, that entry is gone for good and no later
+// reconciler tick could ever rediscover the fix issue for this branch again,
+// orphaning the PR permanently (PR #5427 follow-up gap #1). Re-recording it
+// here — keyed the same way RecordBorrowedBranch's original caller keyed it,
+// "GH-<fix issue>" -> BranchName — restores exactly what a later
+// FixIssueForBranch(BranchName) needs to re-adopt this PR once
+// persistFailureReadoptCooldown lets reconcileOrphanPRs try again.
 func (c *Controller) evictPersistFailedPR(prNumber int) {
 	c.mu.Lock()
+	prState := c.activePRs[prNumber]
 	delete(c.activePRs, prNumber)
 	delete(c.prFailures, prNumber)
 	delete(c.recordedMerges, prNumber)
@@ -2332,6 +2359,14 @@ func (c *Controller) evictPersistFailedPR(prNumber int) {
 
 	c.persistRemovePR(prNumber)
 	c.removePRFailures(prNumber)
+
+	if prState != nil && prState.RegisteredViaFixIssue && c.borrowedBranchLookup != nil {
+		taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
+		c.borrowedBranchLookup.RecordBorrowedBranch(taskID, prState.BranchName, 0)
+		c.log.Info("evictPersistFailedPR: re-recorded borrowed-branch registry entry so a later reconciler tick can re-adopt this fix-issue PR",
+			"pr", prNumber, "fix_issue", prState.IssueNumber, "branch", prState.BranchName)
+	}
+
 	c.log.Error("evicted PR after repeated persist failures — state store cannot save this PR's row",
 		"pr", prNumber, "repo", c.repoKey(), "threshold", persistFailureEvictThreshold)
 }
@@ -2403,6 +2438,47 @@ func (c *Controller) pruneClosedOriginSkip(openPRs map[int]struct{}) {
 	for prNumber := range c.closedOriginSkip {
 		if _, ok := openPRs[prNumber]; !ok {
 			delete(c.closedOriginSkip, prNumber)
+		}
+	}
+}
+
+// closedOriginRecheckCadence bounds how often reconcileOrphanPRs revalidates
+// each closedOriginSkip memo entry against GitHub's current issue state —
+// GH-5430 (PR #5427 follow-up gap #3). The memo (GH-5425) intentionally never
+// expires on its own — pruneClosedOriginSkip only drops it once the PR itself
+// closes — so a PR memoized while its origin issue was closed stays skipped
+// forever even if a human later reopens that issue to continue the work by
+// hand. Revalidating every tick would defeat the whole point of the memo (the
+// GetIssue call + Warn log it exists to avoid), so instead every 30th tick —
+// about 30 minutes at the reconciler's 60s sweep interval — pays that cost
+// once per memoized PR to check whether it should be dropped.
+const closedOriginRecheckCadence = 30
+
+// revalidateClosedOriginSkip re-fetches the origin issue for every memoized
+// closedOriginSkip entry and drops the memo if that issue is open again —
+// GH-5430. Called by reconcileOrphanPRs every closedOriginRecheckCadence
+// ticks, before it iterates the current open-PR list, so a dropped memo is
+// re-evaluated for registration in the very same tick that revalidated it.
+func (c *Controller) revalidateClosedOriginSkip(ctx context.Context) {
+	c.mu.RLock()
+	origins := make(map[int]int, len(c.closedOriginSkip))
+	for prNumber, rec := range c.closedOriginSkip {
+		origins[prNumber] = rec.originIssue
+	}
+	c.mu.RUnlock()
+
+	for prNumber, originIssue := range origins {
+		issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, originIssue)
+		if err != nil {
+			c.log.Warn("reconciler: closed-origin memo revalidation failed to fetch origin issue, leaving memo in place",
+				"pr", prNumber, "origin_issue", originIssue, "error", err)
+			continue
+		}
+		if issue != nil && issue.State == github.StateOpen {
+			c.log.Info("reconciler: origin issue was reopened — dropping closed-origin skip memo so this PR is re-checked for registration",
+				"pr", prNumber, "origin_issue", originIssue,
+			)
+			c.clearClosedOriginSkip(prNumber)
 		}
 	}
 }
@@ -2705,7 +2781,7 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 		}
 	}
 
-	c.registerPR(prNumber, prURL, issueNumber, headSHA, branchName, issueNodeID)
+	c.registerPR(prNumber, prURL, issueNumber, headSHA, branchName, issueNodeID, false)
 }
 
 // OnPRCreatedForFixIssue registers prNumber under fixIssue even though
@@ -2727,13 +2803,16 @@ func (c *Controller) OnPRCreatedForFixIssue(prNumber int, prURL string, fixIssue
 		"origin_issue", originIssue,
 		"branch", branchName,
 	)
-	c.registerPR(prNumber, prURL, fixIssue, headSHA, branchName, issueNodeID)
+	c.registerPR(prNumber, prURL, fixIssue, headSHA, branchName, issueNodeID, true)
 }
 
 // registerPR holds the shared registration body for OnPRCreated and
 // OnPRCreatedForFixIssue (GH-5413) — every check below applies identically
 // regardless of which caller verified issueNumber is correct for this PR.
-func (c *Controller) registerPR(prNumber int, prURL string, issueNumber int, headSHA string, branchName string, issueNodeID string) {
+// viaFixIssue records whether the caller is OnPRCreatedForFixIssue, so a
+// later persist failure knows whether to re-record the borrowed-branch
+// registry entry on eviction (see PRState.RegisteredViaFixIssue, GH-5430).
+func (c *Controller) registerPR(prNumber int, prURL string, issueNumber int, headSHA string, branchName string, issueNodeID string, viaFixIssue bool) {
 	c.mu.Lock()
 	if _, exists := c.activePRs[prNumber]; exists {
 		c.mu.Unlock()
@@ -2745,16 +2824,17 @@ func (c *Controller) registerPR(prNumber int, prURL string, issueNumber int, hea
 		return
 	}
 	prState := &PRState{
-		PRNumber:        prNumber,
-		PRURL:           prURL,
-		IssueNumber:     issueNumber,
-		BranchName:      branchName,
-		HeadSHA:         headSHA,
-		Stage:           StagePRCreated,
-		CIStatus:        CIPending,
-		CreatedAt:       time.Now(),
-		EnvironmentName: c.config.EnvironmentName(),
-		IssueNodeID:     issueNodeID,
+		PRNumber:              prNumber,
+		PRURL:                 prURL,
+		IssueNumber:           issueNumber,
+		BranchName:            branchName,
+		HeadSHA:               headSHA,
+		Stage:                 StagePRCreated,
+		CIStatus:              CIPending,
+		CreatedAt:             time.Now(),
+		EnvironmentName:       c.config.EnvironmentName(),
+		IssueNodeID:           issueNodeID,
+		RegisteredViaFixIssue: viaFixIssue,
 	}
 	c.activePRs[prNumber] = prState
 	c.mu.Unlock()
@@ -8646,6 +8726,18 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 	openPRs := make(map[int]struct{}, len(prs))
 	for _, pr := range prs {
 		openPRs[pr.Number] = struct{}{}
+	}
+
+	// GH-5430: revalidate closedOriginSkip memos every closedOriginRecheckCadence
+	// ticks, before the main loop below, so a memo dropped here (origin issue
+	// reopened) is re-evaluated for registration in this same tick rather than
+	// waiting for the next one.
+	c.mu.Lock()
+	c.reconcileTick++
+	tick := c.reconcileTick
+	c.mu.Unlock()
+	if tick%closedOriginRecheckCadence == 0 {
+		c.revalidateClosedOriginSkip(ctx)
 	}
 
 	for _, pr := range prs {

--- a/internal/autopilot/gh5421_reconciler_borrowed_branch_test.go
+++ b/internal/autopilot/gh5421_reconciler_borrowed_branch_test.go
@@ -3,26 +3,55 @@ package autopilot
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/qf-studio/pilot/internal/testutil"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
+// recordedBorrowedBranch captures one RecordBorrowedBranch call observed by
+// fakeBorrowedBranchLookup — GH-5430.
+type recordedBorrowedBranch struct {
+	taskID string
+	branch string
+	fromPR int
+}
+
 // fakeBorrowedBranchLookup is a minimal BorrowedBranchLookup fake for
-// reconcileOrphanPRs tests — GH-5421.
+// reconcileOrphanPRs tests — GH-5421. GH-5430 extends it with
+// RecordBorrowedBranch so it can also stand in for evictPersistFailedPR's
+// re-record path: a RecordBorrowedBranch call updates branch/fixIssue the
+// same way the real registry would, so a later FixIssueForBranch call on the
+// same branch reflects it — and every call is recorded for assertions.
 type fakeBorrowedBranchLookup struct {
+	mu       sync.Mutex
 	branch   string
 	fixIssue int
+	recorded []recordedBorrowedBranch
 }
 
 func (f *fakeBorrowedBranchLookup) FixIssueForBranch(branch string) (int, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if branch == f.branch && f.fixIssue > 0 {
 		return f.fixIssue, true
 	}
 	return 0, false
+}
+
+func (f *fakeBorrowedBranchLookup) RecordBorrowedBranch(taskID, branch string, fromPR int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recorded = append(f.recorded, recordedBorrowedBranch{taskID: taskID, branch: branch, fromPR: fromPR})
+	var fixIssue int
+	if _, err := fmt.Sscanf(taskID, "GH-%d", &fixIssue); err == nil {
+		f.branch = branch
+		f.fixIssue = fixIssue
+	}
 }
 
 // TestController_ReconcileOrphanPRs_ClosedOriginIssueNoFixRecord_SkipsRegistration

--- a/internal/autopilot/gh5430_borrowed_branch_persist_failure_test.go
+++ b/internal/autopilot/gh5430_borrowed_branch_persist_failure_test.go
@@ -1,0 +1,125 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestEvictPersistFailedPR_ReRecordsBorrowedBranchForFixIssuePR is the
+// GH-5430 regression test for reconciler fix #1 (PR #5427 follow-up gap #1):
+// FixIssueForBranch consumes the runner's borrowed-branch registry entry
+// destructively the instant it matches, well before OnPRCreatedForFixIssue
+// (called right after) has any chance to persist the resulting PR state. If
+// that persistence keeps failing until evictPersistFailedPR drops the PR,
+// the registry entry is already gone — before this fix, no later reconciler
+// tick could ever rediscover the fix issue for this branch again, orphaning
+// the PR permanently. evictPersistFailedPR must re-record the entry (chosen
+// fix, stated in the PR body per the issue: option B — "re-record the entry
+// when evictPersistFailedPR drops a PR that was registered through the
+// fix-issue path" — rather than option A's deferred-consume redesign) so a
+// later tick, once persistFailureReadoptCooldown elapses, can re-adopt it.
+func TestEvictPersistFailedPR_ReRecordsBorrowedBranchForFixIssuePR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls":
+			prs := []*github.PullRequest{
+				{
+					Number:  42,
+					HTMLURL: "https://github.com/owner/repo/pull/42",
+					Head:    github.PRRef{Ref: "pilot/GH-100", SHA: "abc1234"},
+					Base:    github.PRRef{Ref: "main"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		default:
+			t.Errorf("unexpected request to %s — the borrowed-branch registry re-record should let the reconciler skip straight to registration", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	fake := &fakeBorrowedBranchLookup{}
+	c.SetBorrowedBranchLookup(fake)
+
+	// Simulate the reconciler's normal fix-issue registration: a match on
+	// FixIssueForBranch already consumed the runner-side entry (out of scope
+	// for this test — see gh5425_borrowed_branch_prune_test.go), and the
+	// reconciler now calls OnPRCreatedForFixIssue with the result.
+	c.OnPRCreatedForFixIssue(42, "https://github.com/owner/repo/pull/42", 200, 100, "abc1234", "pilot/GH-100", "")
+
+	prState, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("PR 42 was not registered by OnPRCreatedForFixIssue")
+	}
+	if !prState.RegisteredViaFixIssue {
+		t.Fatal("RegisteredViaFixIssue = false after OnPRCreatedForFixIssue, want true")
+	}
+
+	// Persistence for PR 42 keeps failing until it is evicted.
+	c.evictPersistFailedPR(42)
+
+	if _, ok := c.GetPRState(42); ok {
+		t.Fatal("PR 42 is still tracked after evictPersistFailedPR, want it evicted")
+	}
+
+	fake.mu.Lock()
+	recorded := append([]recordedBorrowedBranch(nil), fake.recorded...)
+	fake.mu.Unlock()
+	if len(recorded) != 1 {
+		t.Fatalf("RecordBorrowedBranch was called %d times, want exactly 1 (the re-record on eviction)", len(recorded))
+	}
+	if recorded[0].taskID != "GH-200" || recorded[0].branch != "pilot/GH-100" {
+		t.Errorf("re-recorded entry = (taskID=%q, branch=%q), want (taskID=%q, branch=%q)",
+			recorded[0].taskID, recorded[0].branch, "GH-200", "pilot/GH-100")
+	}
+
+	// "The following tick": backdate the persist-failure cooldown so
+	// reconcileOrphanPRs is willing to re-adopt PR 42 instead of skipping it
+	// via recentlyEvictedForPersistFailure.
+	c.mu.Lock()
+	c.persistFailedPRs[42] = time.Now().Add(-persistFailureReadoptCooldown - time.Minute)
+	c.mu.Unlock()
+
+	c.reconcileOrphanPRs(context.Background())
+
+	pr, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("reconciler did not re-adopt PR 42 under the fix issue using the re-recorded borrowed-branch entry")
+	}
+	if pr.IssueNumber != 200 {
+		t.Errorf("IssueNumber = %d, want 200 (fix issue restored via the re-recorded borrowed-branch entry)", pr.IssueNumber)
+	}
+}
+
+// TestEvictPersistFailedPR_PlainOnPRCreatedDoesNotReRecord pins that eviction
+// of a PR registered via the plain OnPRCreated path (branch matches its own
+// issue, not borrowed) never touches the borrowed-branch registry — the
+// re-record in evictPersistFailedPR is scoped to fix-issue registrations only
+// (GH-5430).
+func TestEvictPersistFailedPR_PlainOnPRCreatedDoesNotReRecord(t *testing.T) {
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+	fake := &fakeBorrowedBranchLookup{}
+	c.SetBorrowedBranchLookup(fake)
+
+	c.OnPRCreated(43, "https://github.com/owner/repo/pull/43", 43, "def5678", "pilot/GH-43", "")
+	c.evictPersistFailedPR(43)
+
+	fake.mu.Lock()
+	recorded := len(fake.recorded)
+	fake.mu.Unlock()
+	if recorded != 0 {
+		t.Errorf("RecordBorrowedBranch was called %d times for a plain OnPRCreated eviction, want 0", recorded)
+	}
+}

--- a/internal/autopilot/gh5430_closed_origin_recheck_test.go
+++ b/internal/autopilot/gh5430_closed_origin_recheck_test.go
@@ -1,0 +1,142 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestReconcileOrphanPRs_ClosedOriginSkipRevalidatedOnCadence_ReopenedIssueRegistered
+// is the GH-5430 regression test for reconciler fix #3 (PR #5427 follow-up
+// gap #3): closedOriginSkip (GH-5425) memoizes a skip decision forever —
+// pruneClosedOriginSkip only drops it once the PR itself closes — so a PR
+// memoized while its origin issue was closed stayed skipped even after a
+// human reopened that issue to continue the work by hand. Every
+// closedOriginRecheckCadence ticks, reconcileOrphanPRs must re-fetch the
+// origin issue for each memoized PR and drop the memo (and register the PR,
+// in the same tick) if the issue is open again.
+func TestReconcileOrphanPRs_ClosedOriginSkipRevalidatedOnCadence_ReopenedIssueRegistered(t *testing.T) {
+	var issueCalls int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls":
+			prs := []*github.PullRequest{
+				{
+					Number:  42,
+					HTMLURL: "https://github.com/owner/repo/pull/42",
+					Head:    github.PRRef{Ref: "pilot/GH-100", SHA: "abc1234"},
+					Base:    github.PRRef{Ref: "main"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		case "/repos/owner/repo/issues/100":
+			n := atomic.AddInt64(&issueCalls, 1)
+			state := github.StateOpen
+			if n == 1 {
+				// First check (the memoizing tick): origin issue is closed.
+				state = github.StateClosed
+			}
+			// Every subsequent check (the cadence revalidation, and the
+			// same-tick registration check that follows it): reopened.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(&github.Issue{Number: 100, State: state})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Tick 1: origin issue 100 is closed, no fix-issue record exists —
+	// reconciler memoizes the skip and does not register PR 42.
+	c.reconcileOrphanPRs(context.Background())
+
+	if _, ok := c.GetPRState(42); ok {
+		t.Fatal("PR 42 was registered on the memoizing tick, want it skipped (origin issue closed)")
+	}
+	if _, ok := c.closedOriginSkipDecision(42); !ok {
+		t.Fatal("closedOriginSkip has no memo for PR 42 after the memoizing tick")
+	}
+
+	// Fast-forward to just before the next cadence boundary without actually
+	// running closedOriginRecheckCadence-1 ticks (white-box: same package).
+	c.mu.Lock()
+	c.reconcileTick = closedOriginRecheckCadence - 1
+	c.mu.Unlock()
+
+	// Tick 30: crosses the cadence boundary. revalidateClosedOriginSkip
+	// re-fetches issue 100 (now open), drops the memo, and the main loop —
+	// running in this same call — finds no memo, re-checks GitHub directly,
+	// and registers PR 42 under the now-open origin issue.
+	c.reconcileOrphanPRs(context.Background())
+
+	pr, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("reconciler did not register PR 42 after its origin issue was reopened on the cadence tick")
+	}
+	if pr.IssueNumber != 100 {
+		t.Errorf("IssueNumber = %d, want 100", pr.IssueNumber)
+	}
+	if _, ok := c.closedOriginSkipDecision(42); ok {
+		t.Error("closedOriginSkip still has a memo for PR 42 after it was registered, want it cleared")
+	}
+}
+
+// TestReconcileOrphanPRs_ClosedOriginSkipNotRevalidatedOffCadence pins that
+// the memo survives ticks that don't land on closedOriginRecheckCadence — the
+// whole point of memoizing in the first place (GH-5425) is to avoid the
+// GetIssue+Warn cost on every tick, and GH-5430's periodic revalidation must
+// not silently turn back into a per-tick check.
+func TestReconcileOrphanPRs_ClosedOriginSkipNotRevalidatedOffCadence(t *testing.T) {
+	var issueCalls int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls":
+			prs := []*github.PullRequest{
+				{
+					Number:  42,
+					HTMLURL: "https://github.com/owner/repo/pull/42",
+					Head:    github.PRRef{Ref: "pilot/GH-100", SHA: "abc1234"},
+					Base:    github.PRRef{Ref: "main"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		case "/repos/owner/repo/issues/100":
+			atomic.AddInt64(&issueCalls, 1)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(&github.Issue{Number: 100, State: github.StateClosed})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Tick 1: memoizes the skip (1 GetIssue call).
+	c.reconcileOrphanPRs(context.Background())
+	// Tick 2: off-cadence — must be served entirely from the memo.
+	c.reconcileOrphanPRs(context.Background())
+
+	if calls := atomic.LoadInt64(&issueCalls); calls != 1 {
+		t.Errorf("GetIssue was called %d times across 2 off-cadence ticks, want 1 (second tick must be served from the memo)", calls)
+	}
+	if _, ok := c.GetPRState(42); ok {
+		t.Fatal("PR 42 was registered on an off-cadence tick, want it to stay skipped")
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1392,6 +1392,19 @@ type PRState struct {
 	// between the close and the next poll, via the same SavePRState/
 	// LoadAllPRStates round-trip every other persisted field uses.
 	SelfClosedFixIssue int
+	// RegisteredViaFixIssue is true when this PR was registered through
+	// OnPRCreatedForFixIssue — i.e. BranchName encodes a different, origin
+	// issue than IssueNumber (the fix issue) — rather than the plain
+	// OnPRCreated path. In-memory only, set once at registration and never
+	// mutated after. GH-5430: evictPersistFailedPR reads this to decide
+	// whether a persist failure that evicts this PR must also re-record the
+	// runner's borrowed-branch registry entry (BranchName -> IssueNumber).
+	// Without that re-record, the entry is already gone — FixIssueForBranch
+	// consumes it destructively at match time, before this field's PR was
+	// even registered — so a later reconciler tick could never rediscover
+	// the fix issue for this branch again, orphaning the PR permanently
+	// (PR #5427 follow-up).
+	RegisteredViaFixIssue bool
 }
 
 // snapshot returns a detached, field-by-field copy of the PRState with a fresh
@@ -1455,6 +1468,7 @@ func (ps *PRState) snapshot() *PRState {
 		PostMergeInfraRerunSHA:       ps.PostMergeInfraRerunSHA,
 		ReleaseBackfillAbandoned:     ps.ReleaseBackfillAbandoned,
 		SelfClosedFixIssue:           ps.SelfClosedFixIssue,
+		RegisteredViaFixIssue:        ps.RegisteredViaFixIssue,
 	}
 	// DiscoveredChecks and ScopeMemberPRs are slices — copy the backing arrays
 	// so consumers can't mutate the live PR's slice through the snapshot.

--- a/internal/executor/gh5430_borrowed_branch_ttl_test.go
+++ b/internal/executor/gh5430_borrowed_branch_ttl_test.go
@@ -1,0 +1,56 @@
+package executor
+
+import (
+	"testing"
+	"time"
+)
+
+// TestTouchBorrowedBranchStart_RearmsExpiredEntry is the GH-5430 regression
+// test for reconciler fix #2 (PR #5427 follow-up): RecordBorrowedBranch runs
+// at dispatch time, before the task is admitted into the queue, so a fix task
+// that waits in the queue — or itself runs — for more than borrowedBranchTTL
+// would reach the PR-created hook with an entry the TTL already treats as
+// expired. executeWithOptions calls touchBorrowedBranchStart at the
+// queued→running transition to re-stamp recordedAt to that moment instead,
+// so a recordedAt older than the TTL at dispatch time still resolves as long
+// as the running-start touch itself is within the window.
+func TestTouchBorrowedBranchStart_RearmsExpiredEntry(t *testing.T) {
+	r := NewRunner()
+	r.RecordBorrowedBranch("GH-300", "pilot/GH-103", 5364)
+
+	// Backdate recordedAt past borrowedBranchTTL, simulating a task that sat
+	// in the queue (or ran) long enough that the TTL clock, if left running
+	// from dispatch time, would already consider the entry expired.
+	r.mu.Lock()
+	rec := r.borrowedBranch["GH-300"]
+	rec.recordedAt = time.Now().Add(-borrowedBranchTTL - time.Hour)
+	r.borrowedBranch["GH-300"] = rec
+	r.mu.Unlock()
+
+	// The queued→running transition re-arms the TTL from this moment.
+	r.touchBorrowedBranchStart("GH-300")
+
+	branch, fromPR, ok := r.BorrowedBranch("GH-300")
+	if !ok {
+		t.Fatal("BorrowedBranch(\"GH-300\") = not found after touchBorrowedBranchStart re-armed a pre-expired entry, want it to still resolve")
+	}
+	if branch != "pilot/GH-103" || fromPR != 5364 {
+		t.Errorf("BorrowedBranch(\"GH-300\") = (%q, %d), want (%q, %d)", branch, fromPR, "pilot/GH-103", 5364)
+	}
+
+	if fixIssue, ok := r.FixIssueForBranch("pilot/GH-103"); !ok || fixIssue != 300 {
+		t.Errorf("FixIssueForBranch(\"pilot/GH-103\") = (%d, %v), want (300, true) after the running-start touch re-armed the TTL", fixIssue, ok)
+	}
+}
+
+// TestTouchBorrowedBranchStart_NoEntry pins that touching an unrecorded task
+// ID is a harmless no-op — the common case for tasks that never borrowed a
+// branch (GH-5430).
+func TestTouchBorrowedBranchStart_NoEntry(t *testing.T) {
+	r := NewRunner()
+	r.touchBorrowedBranchStart("GH-999")
+
+	if _, _, ok := r.BorrowedBranch("GH-999"); ok {
+		t.Error("BorrowedBranch(\"GH-999\") = found after touching an unrecorded task ID, want not-found")
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1057,6 +1057,12 @@ type Runner struct {
 	//     let a later, unrelated PR on the same branch (a manual push, or a
 	//     fresh re-run of the origin issue) get mis-attributed to a
 	//     long-closed fix issue.
+	//
+	// GH-5430: recordedAt starts at dispatch time (RecordBorrowedBranch,
+	// before the task is even admitted into the queue), but
+	// touchBorrowedBranchStart re-stamps it to the queued→running transition
+	// (executeWithOptions) — so borrowedBranchTTL bounds queue-wait once plus
+	// run time, not queue-wait plus run time added together from dispatch.
 	// Guarded by mu alongside execCancel/declinedCancel.
 	borrowedBranch map[string]borrowedBranchRecord
 	// borrowedBranchByBranch is the reverse index (branch -> task ID) kept in
@@ -3367,6 +3373,16 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	if r.monitor != nil {
 		r.monitor.Start(task.ID)
 	}
+
+	// GH-5430: re-stamp any borrowed-branch entry's recordedAt to this
+	// queued→running transition, the one moment the runner reliably observes
+	// execution actually starting. RecordBorrowedBranch (cmd/pilot/handlers.go)
+	// runs at dispatch time, before the task is admitted into the queue — a
+	// task that then waits in the queue, or itself runs, for more than
+	// borrowedBranchTTL reaches the PR-created hook with an entry the TTL
+	// already considers expired, dropping the registration (the GH-5421 shape,
+	// now for long-queued/long-running tasks only — PR #5427 follow-up gap #2).
+	r.touchBorrowedBranchStart(task.ID)
 
 	// GH-1599: Log task started milestone
 	r.saveLogEntry(task.LogExecutionID(), "info", "Task started: "+task.Title)
@@ -7044,6 +7060,30 @@ func (r *Runner) RecordBorrowedBranch(taskID, branch string, fromPR int) {
 	}
 	r.borrowedBranch[taskID] = borrowedBranchRecord{branch: branch, fromPR: fromPR, recordedAt: time.Now()}
 	r.borrowedBranchByBranch[branch] = taskID
+}
+
+// touchBorrowedBranchStart re-stamps taskID's borrowed-branch entry (if any)
+// with recordedAt = now — GH-5430. RecordBorrowedBranch is called at dispatch
+// time (cmd/pilot/handlers.go), before the task is admitted into the queue,
+// so borrowedBranchTTL's clock previously started counting down queue wait
+// time as well as run time. A fix task that waits in the queue, or itself
+// runs, for more than six hours would then reach the PR-created hook with an
+// entry the TTL already treats as expired, falling back to the guarded
+// OnPRCreated path and dropping the registration — the same GH-5421 shape
+// this whole registry exists to fix, now specifically for long-queued or
+// long-running tasks (PR #5427 follow-up gap #2). Called once execution
+// transitions from queued to running (executeWithOptions), the one moment the
+// runner reliably observes that boundary. A no-op if taskID never recorded a
+// borrowed branch.
+func (r *Runner) touchBorrowedBranchStart(taskID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	rec, ok := r.borrowedBranch[taskID]
+	if !ok {
+		return
+	}
+	rec.recordedAt = time.Now()
+	r.borrowedBranch[taskID] = rec
 }
 
 // BorrowedBranch returns the borrowed branch/origin-PR recorded for taskID by


### PR DESCRIPTION
## Summary

PR #5427 follow-up (GH-5430). Post-merge review found three narrow gaps in the borrowed-branch registry (`internal/executor/runner.go`) and the reconciler (`internal/autopilot/controller.go`).

### 1. Consume before commit

`FixIssueForBranch` deletes the registry entry destructively the instant it matches — before `OnPRCreatedForFixIssue` (called right after) has any chance to persist the resulting PR state. If persistence keeps failing until `evictPersistFailedPR` drops the PR, the entry is already gone: no later reconciler tick can ever rediscover the fix issue for that branch again, orphaning the PR permanently.

**Chosen fix: option B** ("re-record the entry when `evictPersistFailedPR` drops a PR that was registered through the fix-issue path"), not option A's deferred-consume/explicit-`ConsumeBorrowedBranch` redesign. Rationale: option A's proposed gate ("PR present in the active set" right after `OnPRCreatedForFixIssue` returns) is true unconditionally in the golden path — `registerPR` always publishes to `activePRs` before persistence is even attempted — so it would not actually protect against the eviction-after-repeated-persist-failures scenario the issue describes. Option B closes that gap directly: a new `PRState.RegisteredViaFixIssue` flag (set by `registerPR`) lets `evictPersistFailedPR` recognize a fix-issue registration and call the (extended) `BorrowedBranchLookup.RecordBorrowedBranch(taskID, branch, 0)` to restore the entry, so a later reconciler tick — once `persistFailureReadoptCooldown` elapses — re-adopts the PR via the ordinary `FixIssueForBranch` path.

### 2. TTL measured from dispatch

`borrowedBranchTTL`'s 6-hour clock started in `RecordBorrowedBranch`, which runs before the task is admitted into the queue (`cmd/pilot/handlers.go`). A fix task that waits in the queue, or itself runs, for more than 6 hours reached the PR-created hook with an already-expired entry, falling into the guarded `OnPRCreated` path and dropping the registration.

**Fix:** `touchBorrowedBranchStart` re-stamps `recordedAt` to `time.Now()` at the queued→running transition inside `executeWithOptions` — the one moment the runner reliably observes that boundary. The TTL now bounds queue-wait-once-plus-run-time from that point, not queue-wait-plus-run-time measured from dispatch.

### 3. Memo never invalidated on origin reopen

`closedOriginSkip` (GH-5425) memoizes a skip decision forever — only pruned when the PR itself closes — so a PR skipped for a closed origin issue stayed skipped even after a human reopened that issue.

**Fix:** `reconcileOrphanPRs` now revalidates every memoized entry every `closedOriginRecheckCadence` (30) ticks — about 30 minutes at the reconciler's 60s sweep interval — re-fetching the origin issue and dropping the memo if it's open again, before the per-PR loop runs (so a dropped memo is re-evaluated for registration in the same tick).

## Test plan

- [x] `go test ./internal/autopilot/ ./internal/executor/ ./cmd/pilot/` — green
- [x] New tests: registry TTL re-arm (`internal/executor/gh5430_borrowed_branch_ttl_test.go`), persist-failure re-record + re-adoption (`internal/autopilot/gh5430_borrowed_branch_persist_failure_test.go`), closed-origin memo cadence revalidation (`internal/autopilot/gh5430_closed_origin_recheck_test.go`)
- [x] Existing GH-5421/GH-5425 regression tests stay green
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues