### PR TITLE
GH-5432: test(executor): pin touchBorrowedBranchStart wiring in executeWithOptions; fix TTL comment and fromPR doc contract (PR #5431 follow-up)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2362,6 +2362,19 @@ func (c *Controller) evictPersistFailedPR(prNumber int) {
 
 	if prState != nil && prState.RegisteredViaFixIssue && c.borrowedBranchLookup != nil {
 		taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
+		// GH-5432: fromPR is passed as 0 here, not the real origin PR number
+		// — PRState doesn't carry it (OnPRCreatedForFixIssue's originIssue
+		// param is an *issue* number, kept for logging only, and is never
+		// stored on PRState). That's safe for this call specifically: the
+		// re-recorded entry's only intended consumer is
+		// reconcileOrphanPRs -> FixIssueForBranch(BranchName) (see the
+		// doc comment above), whose destructive-read implementation
+		// (runner.go) never inspects fromPR — only RecordBorrowedBranch's
+		// *other* caller (handlers.go, at original dispatch time) needs
+		// fromPR > 0, to satisfy githubOnPRCreatedHandler's BorrowedBranch
+		// gate for a brand-new PR-created webhook event. This PR's
+		// PR-created event already fired once before eviction, so that gate
+		// will not see this entry again.
 		c.borrowedBranchLookup.RecordBorrowedBranch(taskID, prState.BranchName, 0)
 		c.log.Info("evictPersistFailedPR: re-recorded borrowed-branch registry entry so a later reconciler tick can re-adopt this fix-issue PR",
 			"pr", prNumber, "fix_issue", prState.IssueNumber, "branch", prState.BranchName)

--- a/internal/executor/gh5430_borrowed_branch_ttl_test.go
+++ b/internal/executor/gh5430_borrowed_branch_ttl_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -52,5 +53,63 @@ func TestTouchBorrowedBranchStart_NoEntry(t *testing.T) {
 
 	if _, _, ok := r.BorrowedBranch("GH-999"); ok {
 		t.Error("BorrowedBranch(\"GH-999\") = found after touching an unrecorded task ID, want not-found")
+	}
+}
+
+// TestExecuteWithOptions_TouchesBorrowedBranchStart is the GH-5432 wiring
+// pin: TestTouchBorrowedBranchStart_RearmsExpiredEntry above exercises
+// touchBorrowedBranchStart directly, so it would keep passing even if the
+// r.touchBorrowedBranchStart(task.ID) call were deleted from
+// executeWithOptions (runner.go) — the exact PR #5431 mutation-testing gap
+// this test closes. This one drives the real Runner.Execute -> executeWithOptions
+// path (mirroring the setupPRGuardRepo/mockFixedBackend pattern used by the
+// GH-5359 tests) for a task whose borrowed-branch entry was recorded more
+// than borrowedBranchTTL ago, then asserts the entry still resolves once
+// execution has started — which is only true if executeWithOptions actually
+// calls touchBorrowedBranchStart at the queued→running transition.
+func TestExecuteWithOptions_TouchesBorrowedBranchStart(t *testing.T) {
+	const taskID = "GH-5432"
+	const branch = "pilot/GH-5432-branch"
+	// No additional commit: the PR guard's fast confirmed-empty no_op path
+	// resolves without shelling out to gh, keeping this test hermetic while
+	// still exercising the real executeWithOptions entry sequence.
+	dir := setupPRGuardRepo(t, branch, false)
+
+	backend := &mockFixedBackend{
+		result: &BackendResult{Success: true, Output: "analysis complete"},
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	runner.RecordBorrowedBranch(taskID, "pilot/GH-100", 5364)
+	// Backdate recordedAt past borrowedBranchTTL, as if this task's own
+	// dispatch-time record sat unrefreshed for longer than the TTL window.
+	runner.mu.Lock()
+	rec := runner.borrowedBranch[taskID]
+	rec.recordedAt = time.Now().Add(-borrowedBranchTTL - time.Hour)
+	runner.borrowedBranch[taskID] = rec
+	runner.mu.Unlock()
+
+	task := &Task{
+		ID:          taskID,
+		Title:       "test: pin touchBorrowedBranchStart wiring in executeWithOptions",
+		Description: "GH-5432 regression: deleting the touch call must fail this test",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    true,
+	}
+
+	if _, err := runner.Execute(context.Background(), task); err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+
+	gotBranch, fromPR, ok := runner.BorrowedBranch(taskID)
+	if !ok {
+		t.Fatal("BorrowedBranch(taskID) = not found after Execute() ran a pre-expired entry through it — executeWithOptions did not re-stamp recordedAt via touchBorrowedBranchStart")
+	}
+	if gotBranch != "pilot/GH-100" || fromPR != 5364 {
+		t.Errorf("BorrowedBranch(taskID) = (%q, %d), want (%q, %d)", gotBranch, fromPR, "pilot/GH-100", 5364)
 	}
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1061,8 +1061,11 @@ type Runner struct {
 	// GH-5430: recordedAt starts at dispatch time (RecordBorrowedBranch,
 	// before the task is even admitted into the queue), but
 	// touchBorrowedBranchStart re-stamps it to the queued→running transition
-	// (executeWithOptions) — so borrowedBranchTTL bounds queue-wait once plus
-	// run time, not queue-wait plus run time added together from dispatch.
+	// (executeWithOptions) — so once execution actually starts, the original
+	// dispatch-time stamp is overwritten and borrowedBranchTTL bounds run
+	// time only, not queue-wait time at all (GH-5432 follow-up: this comment
+	// previously said the TTL bounds queue-wait plus run time, which was the
+	// pre-re-stamp behavior this very change replaced).
 	// Guarded by mu alongside execCancel/declinedCancel.
 	borrowedBranch map[string]borrowedBranchRecord
 	// borrowedBranchByBranch is the reverse index (branch -> task ID) kept in
@@ -7036,10 +7039,18 @@ const borrowedBranchTTL = 6 * time.Hour
 
 // RecordBorrowedBranch records that taskID's dispatch put it on branch
 // (named after a different, origin issue), continuing origin PR fromPR —
-// GH-5421. Callers should only record when fromPR > 0 and branch differs
-// from taskID's own default branch; see the borrowedBranch field doc for the
-// in-memory-only lifetime, the TTL fallback, and why entries are not cleared
-// on unregister.
+// GH-5421. The primary caller (handlers.go, at dispatch time) should only
+// record when fromPR > 0 and branch differs from taskID's own default
+// branch, since fromPR > 0 is what githubOnPRCreatedHandler's BorrowedBranch
+// gate (poller_github.go) requires to route a brand-new PR-created event
+// through OnPRCreatedForFixIssue. GH-5432: evictPersistFailedPR
+// (internal/autopilot/controller.go) is a second caller that re-records an
+// entry consumed only by FixIssueForBranch's destructive read (the
+// reconciler's orphan-PR sweep) — that path never inspects fromPR, so it
+// deliberately passes 0 when the origin PR number isn't available at
+// eviction time; see the call site for why that is still correct there. See
+// the borrowedBranch field doc for the in-memory-only lifetime, the TTL
+// fallback, and why entries are not cleared on unregister.
 func (r *Runner) RecordBorrowedBranch(taskID, branch string, fromPR int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5432.

Closes #5432

## Changes

GitHub Issue GH-5432: test(executor): pin touchBorrowedBranchStart wiring in executeWithOptions; fix TTL comment and fromPR doc contract (PR #5431 follow-up)

## Problem

PR #5431 (GH-5430) re-stamps the borrowed-branch registry TTL at run start by calling touchBorrowedBranchStart from executeWithOptions in `internal/executor/runner.go`. Post-merge mutation check: deleting that call fails no test. `internal/executor/gh5430_borrowed_branch_ttl_test.go` exercises the method directly, so the wiring that makes the TTL start at run time is unpinned, and a refactor that drops the call would silently reintroduce the GH-5430 shape (fix task queued more than 6 hours reaches the hook with an expired entry).

Two small doc inaccuracies from the same review:
- The comment near the TTL constant in `internal/executor/runner.go` (around line 1064) still says the TTL bounds queue wait plus run time; after the re-stamp it bounds run time only.
- evictPersistFailedPR in `internal/autopilot/controller.go` re-records with fromPR equal to zero, contradicting the RecordBorrowedBranch doc contract that says callers record only when fromPR is positive. Either relax the doc or carry the origin PR number through PRState so the re-record passes the real value.

## Fix

- Add a test that drives executeWithOptions (a mock backend that returns quickly is enough) for a task whose registry entry was recorded more than 6 hours ago, then asserts BorrowedBranch still resolves after the run started. Removing the touch call must fail this test.
- Correct the TTL comment.
- Resolve the fromPR contract one way or the other and state which in the PR.

## Acceptance

- [ ] Deleting the touchBorrowedBranchStart call in executeWithOptions fails a test
- [ ] Comments match behaviour
- [ ] Test command, must be green:

```
go test ./internal/executor/ -run 'Borrowed|TTL' && go test ./internal/autopilot/
```